### PR TITLE
Options of envs should overried the config item in the file

### DIFF
--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -146,12 +146,12 @@ func (opt *Options) Parse() (string, error) {
 		}
 	}
 
-	opt.readEnv()
 
 	opt.viper.Unmarshal(opt, func(c *mapstructure.DecoderConfig) {
 		c.TagName = "yaml"
 	})
 
+	opt.readEnv()
 	err = opt.validate()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
EG_CLUSTER_PERR_URL&EG_CLUSTER_CLIENT_URL should override config item  `cluster-client-url&client-peer-url` in the config file