### PR TITLE
CI: use GitHub Actions to run tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,41 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "**/*.go"
+      - "go.mod"
+      - "go.sum"
+      - ".github/workflows/test.yml"
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - main
+    paths:
+      - "**/*.go"
+      - "go.mod"
+      - "go.sum"
+      - ".github/workflows/test.yml"
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+    steps:
+      - name: Set up Go 1.x.y
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.16.5
+
+      - name: Checkout codebase
+        uses: actions/checkout@v2
+
+      - name: Test
+        shell: bash
+        run: |
+          go test -v ./...


### PR DESCRIPTION
Run tests on macOS, Ubuntu and Windows with latest Go release using GitHub Actions triggered by:

- `push` and `pull request` event
- changes of files `**/*.go`, `go.mod` and `go.sum`