### PR TITLE
[option] fix print helper msg twice bug,  close #37

### DIFF
--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -43,6 +43,7 @@ type Options struct {
 
 	// Flags from command line only.
 	ShowVersion     bool   `yaml:"-"`
+	ShowHelp        bool   `yaml:"-"`
 	ShowConfig      bool   `yaml:"-"`
 	ConfigFile      string `yaml:"-"`
 	ForceNewCluster bool   `yaml:"-"`
@@ -90,6 +91,7 @@ func New() *Options {
 	}
 
 	opt.flags.BoolVarP(&opt.ShowVersion, "version", "v", false, "Print the version and exit.")
+	opt.flags.BoolVarP(&opt.ShowHelp, "help", "h", false, "Print the helper message and exit.")
 	opt.flags.BoolVarP(&opt.ShowConfig, "print-config", "c", false, "Print the configuration.")
 	opt.flags.StringVarP(&opt.ConfigFile, "config-file", "f", "", "Load server configuration from a file(yaml format), other command line flags will be ignored if specified.")
 	opt.flags.BoolVar(&opt.ForceNewCluster, "force-new-cluster", false, "Force to create a new one-member cluster.")
@@ -129,15 +131,15 @@ func (opt *Options) YAML() string {
 func (opt *Options) Parse() (string, error) {
 	err := opt.flags.Parse(os.Args[1:])
 	if err != nil {
-		if err == pflag.ErrHelp {
-			return opt.flags.FlagUsages(), nil
-		} else {
-			return "", nil
-		}
+		return "", err
 	}
 
 	if opt.ShowVersion {
 		return version.Short, nil
+	}
+
+	if opt.ShowHelp {
+		return opt.flags.FlagUsages(), nil
 	}
 
 	opt.viper.AutomaticEnv()


### PR DESCRIPTION
* In pflag pkg, [line 1129](https://github.com/spf13/pflag/blob/master/flag.go#L1129) says `The return value will be ErrHelp if -help was set but not defined.` So in the original implementation, we use this err type as a signal for us to print the usage message. 
* Before pflag.Parse() return `ErrHelp`, it actually prints to the stdout with function `usage` [line 927](https://github.com/spf13/pflag/blob/master/flag.go#L927)
* So this is the reason why it will double-print the usage message.

Here is what the solution has done:
1. Add helper define. So it won't return `ErrHelp`.
2. In our `option.Parse()` function, the function's action change to `if pflag parsing found error, then return this err and print to std, exit at last`. 

**Note** the original implementation treats `pflag`'s other type return error as a normal condition, and allows Easegress to continue processing. I would like to know the former design's consideration. 