### PR TITLE
allow full url in client

### DIFF
--- a/cmd/client/command/common.go
+++ b/cmd/client/command/common.go
@@ -32,7 +32,7 @@ import (
 type (
 	// GlobalFlags is the global flags for the whole client.
 	GlobalFlags struct {
-		Server       string
+		URL          string
 		OutputFormat string
 	}
 
@@ -105,7 +105,7 @@ const (
 )
 
 func makeURL(urlTemplate string, a ...interface{}) string {
-	return "http://" + CommandlineGlobalFlags.Server + fmt.Sprintf(urlTemplate, a...)
+	return CommandlineGlobalFlags.URL + fmt.Sprintf(urlTemplate, a...)
 }
 
 func successfulStatusCode(code int) bool {

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -113,8 +113,8 @@ func main() {
 		completionCmd,
 	)
 
-	rootCmd.PersistentFlags().StringVar(&command.CommandlineGlobalFlags.Server,
-		"server", "localhost:2381", "The address of the Easegress endpoint")
+	rootCmd.PersistentFlags().StringVar(&command.CommandlineGlobalFlags.URL,
+		"url", "https://localhost:2381", "The address of the Easegress endpoint")
 	rootCmd.PersistentFlags().StringVarP(&command.CommandlineGlobalFlags.OutputFormat,
 		"output", "o", "yaml", "Output format(json, yaml)")
 


### PR DESCRIPTION
This references issue #60 and is simply changing the `server` flag with a `URL` flag. Like as is shown in the updated help text, the user can put in a http or https fqdn

This pr is lower risk due to it only being referenced here
https://github.com/megaease/easegress/blob/7bae03f5f33be47a9bf8836275b6c71e9f405712/cmd/client/command/common.go#L108
and here
https://github.com/megaease/easegress/blob/7bae03f5f33be47a9bf8836275b6c71e9f405712/cmd/client/main.go#L116

Lastly, here is the output from the local test
```
A command line admin tool for Easegress.

Usage:
  egctl [command]

Examples:
  # List APIs.
  egctl api list

  # Probe health.
  egctl health

  # List member information.
  egctl member list

  # Purge a easegress member
  egctl member purge <member name>

  # List object kinds.
  egctl object kinds

  # Create an object from a yaml file.
  egctl object create -f <object_spec.yaml>

  # Create an object from stdout.
  cat <object_spec.yaml> | egctl object create

  # Delete an object.
  egctl object delete <object_name>

  # Get an object.
  egctl object get <object_name>

  # List objects.
  egctl object list

  # Update an object from a yaml file.
  egctl object update -f <new_object_spec.yaml>

  # Update an object from stdout.
  cat <new_object_spec.yaml> | egctl object update

  # list objects status
  egctl object status list

  # Get object status
  egctl object status get <object_name>


Available Commands:
  api         View Easegress APIs
  completion  Output shell completion code for the specified shell (bash or zsh)
  health      Probe Easegress health
  help        Help about any command
  member      View Easegress members
  mesh        deploy and manager mesh components
  object      View and change objects

Flags:
  -h, --help            help for egctl
  -o, --output string   Output format(json, yaml) (default "yaml")
      --url string      The address of the Easegress endpoint (default "https://localhost:2381")

Use "egctl [command] --help" for more information about a command.
```