### PR TITLE
support windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,3 +44,22 @@ jobs:
         uses: codecov/codecov-action@v1.5.2
         with:
           file: ./coverage.txt
+  test-win:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Set up Go 1.x.y
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.16.5
+
+      - name: Checkout codebase
+        uses: actions/checkout@v2
+
+      - name: Test
+        run: |
+          go mod verify
+          go mod download
+          go test -v ./...
+

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ member
 dist/
 
 easegress.pid
+
+*.exe

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -115,7 +115,10 @@ func main() {
 		cls.StartServer()
 		apiServer = api.MustNewServer(opt, cls, super)
 	}
-	graceupdate.NotifySigUsr2(closeCls, restartCls)
+	if err := graceupdate.NotifySigUsr2(closeCls, restartCls); err != nil {
+		log.Printf("failed to notify signal: %v", err)
+		os.Exit(1)
+	}
 
 	sigChan := make(chan common.Signal, 1)
 	if err := common.NotifySignal(sigChan, common.SignalInt, common.SignalTerm); err != nil {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -64,7 +64,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		if err := common.SignalRaise(pid, common.SingalUsr2); err != nil {
+		if err := common.RaiseSignal(pid, common.SingalUsr2); err != nil {
 			logger.Errorf("failed to send signal: %v", err)
 			os.Exit(1)
 		}
@@ -118,7 +118,7 @@ func main() {
 	graceupdate.NotifySigUsr2(closeCls, restartCls)
 
 	sigChan := make(chan common.Signal, 1)
-	if err := common.SignalNotify(sigChan, common.SignalInt, common.SignalTerm); err != nil {
+	if err := common.NotifySignal(sigChan, common.SignalInt, common.SignalTerm); err != nil {
 		log.Printf("failed to register signal: %v", err)
 		os.Exit(1)
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -69,7 +69,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		logger.Infof("graceful uprade signal sent")
+		logger.Infof("graceful upgrade signal sent")
 
 		return
 	}

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	go.etcd.io/etcd/server/v3 v3.5.0
 	go.uber.org/zap v1.17.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.20.7
 	k8s.io/apimachinery v0.20.7

--- a/pkg/cluster/config.go
+++ b/pkg/cluster/config.go
@@ -101,7 +101,7 @@ func (c *cluster) prepareEtcdConfig() (*embed.Config, error) {
 	ec.MaxTxnOps = maxTxnOps
 	ec.MaxRequestBytes = maxRequestBytes
 	ec.Logger = "zap"
-	ec.LogOutputs = []string{filepath.Join(opt.AbsLogDir, logFilename)}
+	ec.LogOutputs = []string{common.NormalizeZapLogPath(filepath.Join(opt.AbsLogDir, logFilename))}
 
 	ec.ClusterState = embed.ClusterStateFlagExisting
 	if c.opt.ForceNewCluster {

--- a/pkg/common/signal.go
+++ b/pkg/common/signal.go
@@ -17,10 +17,15 @@
 
 package common
 
+// Signal is cross platform abstract type of os.Signal
 type Signal string
 
 const (
+	// SignalInt represents quit in Easegress
 	SignalInt  Signal = "int"
+	// SignalTerm represents force quit in Easegress
 	SignalTerm Signal = "term"
+
+	// SingalUsr2 represents reload signal in Easegress
 	SingalUsr2 Signal = "usr2"
 )

--- a/pkg/common/signal.go
+++ b/pkg/common/signal.go
@@ -22,7 +22,7 @@ type Signal string
 
 const (
 	// SignalInt represents quit in Easegress
-	SignalInt  Signal = "int"
+	SignalInt Signal = "int"
 	// SignalTerm represents force quit in Easegress
 	SignalTerm Signal = "term"
 

--- a/pkg/common/signal.go
+++ b/pkg/common/signal.go
@@ -17,11 +17,10 @@
 
 package common
 
-import (
-	"time"
-)
+type Signal string
 
-// Since returns the elapsed time.
-func Since(t time.Time) time.Duration {
-	return Now().Sub(t)
-}
+const (
+	SignalInt  Signal = "int"
+	SignalTerm Signal = "term"
+	SingalUsr2 Signal = "usr2"
+)

--- a/pkg/common/signal_unix.go
+++ b/pkg/common/signal_unix.go
@@ -38,7 +38,7 @@ var signalFromOsMap = map[os.Signal]Signal{
 	syscall.SIGUSR2: SingalUsr2,
 }
 
-func SignalNotify(c chan<- Signal, sig ...Signal) error {
+func NotifySignal(c chan<- Signal, sig ...Signal) error {
 	if c == nil {
 		return fmt.Errorf("SignalNotify using nil channel")
 	}
@@ -69,7 +69,7 @@ func SignalNotify(c chan<- Signal, sig ...Signal) error {
 	return nil
 }
 
-func SignalRaise(pid int, sig Signal) error {
+func RaiseSignal(pid int, sig Signal) error {
 	oss, ok := signalToOsMap[sig]
 
 	if !ok {

--- a/pkg/common/signal_unix.go
+++ b/pkg/common/signal_unix.go
@@ -38,13 +38,15 @@ var signalFromOsMap = map[os.Signal]Signal{
 	syscall.SIGUSR2: SingalUsr2,
 }
 
+// NotifySignal is identical to os/signal.Notify on Linux
+// param is mapped to abstract Signal and nil is not allowed
 func NotifySignal(c chan<- Signal, sig ...Signal) error {
 	if c == nil {
-		return fmt.Errorf("SignalNotify using nil channel")
+		return fmt.Errorf("NotifySignal using nil channel")
 	}
 
 	if len(sig) == 0 {
-		return fmt.Errorf("SignalNotify must notify at least 1 signal")
+		return fmt.Errorf("NotifySignal must notify at least 1 signal")
 	}
 
 	ch := make(chan os.Signal, cap(c))
@@ -53,7 +55,7 @@ func NotifySignal(c chan<- Signal, sig ...Signal) error {
 	for _, s := range sig {
 		oss, ok := signalToOsMap[s]
 		if !ok {
-			return fmt.Errorf("SignalNotify unsupported signal %v", s)
+			return fmt.Errorf("NotifySignal unsupported signal %v", s)
 		}
 		sigs = append(sigs, oss)
 	}
@@ -69,6 +71,10 @@ func NotifySignal(c chan<- Signal, sig ...Signal) error {
 	return nil
 }
 
+// RaiseSignal is identical to syscall.Kill on Linux
+// param is mapped to abstract Signal
+//
+// any chan passed to NotifySignal will receive the sig
 func RaiseSignal(pid int, sig Signal) error {
 	oss, ok := signalToOsMap[sig]
 

--- a/pkg/common/signal_unix.go
+++ b/pkg/common/signal_unix.go
@@ -1,0 +1,80 @@
+// +build !windows
+
+/*
+ * Copyright (c) 2017, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+var signalToOsMap = map[Signal]syscall.Signal{
+	SignalInt:  syscall.SIGINT,
+	SignalTerm: syscall.SIGTERM,
+	SingalUsr2: syscall.SIGUSR2,
+}
+
+var signalFromOsMap = map[os.Signal]Signal{
+	syscall.SIGINT:  SignalInt,
+	syscall.SIGTERM: SignalTerm,
+	syscall.SIGUSR2: SingalUsr2,
+}
+
+func SignalNotify(c chan<- Signal, sig ...Signal) error {
+	if c == nil {
+		return fmt.Errorf("SignalNotify using nil channel")
+	}
+
+	if len(sig) == 0 {
+		return fmt.Errorf("SignalNotify must notify at least 1 signal")
+	}
+
+	ch := make(chan os.Signal, cap(c))
+
+	sigs := make([]os.Signal, 0, len(sig))
+	for _, s := range sig {
+		oss, ok := signalToOsMap[s]
+		if !ok {
+			return fmt.Errorf("SignalNotify unsupported signal %v", s)
+		}
+		sigs = append(sigs, oss)
+	}
+
+	signal.Notify(ch, sigs...)
+
+	go func() {
+		for s := range ch {
+			c <- signalFromOsMap[s]
+		}
+	}()
+
+	return nil
+}
+
+func SignalRaise(pid int, sig Signal) error {
+	oss, ok := signalToOsMap[sig]
+
+	if !ok {
+		return fmt.Errorf("unsupported signal %v", sig)
+	}
+
+	return syscall.Kill(pid, oss)
+}

--- a/pkg/common/signal_windows.go
+++ b/pkg/common/signal_windows.go
@@ -31,7 +31,7 @@ func eventName(s Signal, pid int) string {
 	return fmt.Sprintf("Global\\easegress_%v_%v", s, pid)
 }
 
-func SignalNotify(c chan<- Signal, sig ...Signal) error {
+func NotifySignal(c chan<- Signal, sig ...Signal) error {
 	if c == nil {
 		return fmt.Errorf("SignalNotify using nil channel")
 	}
@@ -73,7 +73,7 @@ func SignalNotify(c chan<- Signal, sig ...Signal) error {
 	return nil
 }
 
-func SignalRaise(pid int, sig Signal) error {
+func RaiseSignal(pid int, sig Signal) error {
 	name, err := windows.UTF16PtrFromString(eventName(sig, pid))
 	if err != nil {
 		return err

--- a/pkg/common/signal_windows.go
+++ b/pkg/common/signal_windows.go
@@ -31,9 +31,13 @@ func eventName(s Signal, pid int) string {
 	return fmt.Sprintf("Global\\easegress_%v_%v", s, pid)
 }
 
+// NotifySignal is the windows impl of os/signal.Notify
+// which takes abstract Signal and causes common to relay incoming signals to c
+// 
+// On Windows, the impl is based on https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-createeventw
 func NotifySignal(c chan<- Signal, sig ...Signal) error {
 	if c == nil {
-		return fmt.Errorf("SignalNotify using nil channel")
+		return fmt.Errorf("NotifySignal using nil channel")
 	}
 
 	var pid = os.Getpid()
@@ -73,6 +77,10 @@ func NotifySignal(c chan<- Signal, sig ...Signal) error {
 	return nil
 }
 
+// RaiseSignal is the windows impl of syscall.Kill
+// any chan passed to NotifySignal will receive the sig
+// 
+// On Windows, the impl is based on https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-createeventw
 func RaiseSignal(pid int, sig Signal) error {
 	name, err := windows.UTF16PtrFromString(eventName(sig, pid))
 	if err != nil {

--- a/pkg/common/signal_windows.go
+++ b/pkg/common/signal_windows.go
@@ -33,7 +33,7 @@ func eventName(s Signal, pid int) string {
 
 // NotifySignal is the windows impl of os/signal.Notify
 // which takes abstract Signal and causes common to relay incoming signals to c
-// 
+//
 // On Windows, the impl is based on https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-createeventw
 func NotifySignal(c chan<- Signal, sig ...Signal) error {
 	if c == nil {
@@ -79,7 +79,7 @@ func NotifySignal(c chan<- Signal, sig ...Signal) error {
 
 // RaiseSignal is the windows impl of syscall.Kill
 // any chan passed to NotifySignal will receive the sig
-// 
+//
 // On Windows, the impl is based on https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-createeventw
 func RaiseSignal(pid int, sig Signal) error {
 	name, err := windows.UTF16PtrFromString(eventName(sig, pid))

--- a/pkg/common/time_unix.go
+++ b/pkg/common/time_unix.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 /*
  * Copyright (c) 2017, MegaEase
  * All rights reserved.
@@ -18,10 +20,20 @@
 package common
 
 import (
+	"syscall"
 	"time"
 )
 
-// Since returns the elapsed time.
-func Since(t time.Time) time.Duration {
-	return Now().Sub(t)
+// Now is the current time
+func Now() time.Time {
+	var tv syscall.Timeval
+	syscall.Gettimeofday(&tv)
+	return time.Unix(0, syscall.TimevalToNsec(tv))
+}
+
+// NowUnixNano is the current Unix Nano time
+func NowUnixNano() int64 {
+	var tv syscall.Timeval
+	syscall.Gettimeofday(&tv)
+	return syscall.TimevalToNsec(tv)
 }

--- a/pkg/common/time_windows.go
+++ b/pkg/common/time_windows.go
@@ -1,3 +1,5 @@
+// +build windows
+
 /*
  * Copyright (c) 2017, MegaEase
  * All rights reserved.
@@ -18,10 +20,20 @@
 package common
 
 import (
+	"syscall"
 	"time"
 )
 
-// Since returns the elapsed time.
-func Since(t time.Time) time.Duration {
-	return Now().Sub(t)
+// Now is the current time
+func Now() time.Time {
+	var ft syscall.Filetime
+	syscall.GetSystemTimeAsFileTime(&ft)
+	return time.Unix(0, ft.Nanoseconds())
+}
+
+// NowUnixNano is the current Unix Nano time
+func NowUnixNano() int64 {
+	var ft syscall.Filetime
+	syscall.GetSystemTimeAsFileTime(&ft)
+	return ft.Nanoseconds()
 }

--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 )
@@ -287,4 +288,14 @@ func BackupAndCleanDir(dir string) error {
 	}
 
 	return MkdirAll(dir)
+}
+
+// NormalizeZapLogPath is a workaround for https://github.com/uber-go/zap/issues/621
+// the workaround is from https://github.com/ipfs/go-log/issues/73
+func NormalizeZapLogPath(path string) string {
+	if runtime.GOOS == "windows" {
+		return "file:////%3F/" + filepath.ToSlash(path)
+	}
+
+	return path
 }

--- a/pkg/graceupdate/graceupdate.go
+++ b/pkg/graceupdate/graceupdate.go
@@ -43,7 +43,7 @@ func IsInherit() bool {
 func CallOriProcessTerm(done chan struct{}) bool {
 	if didInherit && ppid != 1 {
 		<-done
-		if err := common.SignalRaise(ppid, common.SignalTerm); err != nil {
+		if err := common.RaiseSignal(ppid, common.SignalTerm); err != nil {
 			logger.Errorf("failed to close parent: %s", err)
 			return false
 		}
@@ -55,7 +55,7 @@ func CallOriProcessTerm(done chan struct{}) bool {
 // NotifySigUsr2 handles signal SIGUSR2 to gracefully update.
 func NotifySigUsr2(closeCls func(), restartCls func()) error {
 	sigUsr2 := make(chan common.Signal, 1)
-	if err := common.SignalNotify(sigUsr2, common.SingalUsr2); err != nil {
+	if err := common.NotifySignal(sigUsr2, common.SingalUsr2); err != nil {
 		return err
 	}
 

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -70,7 +70,7 @@ func EtcdClientLoggerConfig(opt *option.Options, filename string) *zap.Config {
 	level := zap.NewAtomicLevel()
 	level.SetLevel(zapcore.DebugLevel)
 
-	outputPaths := []string{filepath.Join(opt.AbsLogDir, filename)}
+	outputPaths := []string{common.NormalizeZapLogPath(filepath.Join(opt.AbsLogDir, filename))}
 
 	return &zap.Config{
 		Level:            level,

--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -96,7 +96,7 @@ func New() *Options {
 	opt.flags.BoolVarP(&opt.ShowConfig, "print-config", "c", false, "Print the configuration.")
 	opt.flags.StringVarP(&opt.ConfigFile, "config-file", "f", "", "Load server configuration from a file(yaml format), other command line flags will be ignored if specified.")
 	opt.flags.BoolVar(&opt.ForceNewCluster, "force-new-cluster", false, "Force to create a new one-member cluster.")
-	opt.flags.BoolVar(&opt.SignalUpgrade, "signal-upgrade", false, "Send upgrade signal to the pid and exit. The server will start a graceful upgrade after signal received.")
+	opt.flags.BoolVar(&opt.SignalUpgrade, "signal-upgrade", false, "Send an upgrade signal to the server based on the local pid file, then exit. The original server will start a graceful upgrade after signal received.")
 	opt.flags.StringVar(&opt.Name, "name", "eg-default-name", "Human-readable name for this member.")
 	opt.flags.StringToStringVar(&opt.Labels, "labels", nil, "The labels for the instance of Easegress.")
 	opt.flags.StringVar(&opt.ClusterName, "cluster-name", "eg-cluster-default-name", "Human-readable name for the new cluster, ignored while joining an existed cluster.")

--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -47,6 +47,7 @@ type Options struct {
 	ShowConfig      bool   `yaml:"-"`
 	ConfigFile      string `yaml:"-"`
 	ForceNewCluster bool   `yaml:"-"`
+	SignalUpgrade   bool   `yaml:"-"`
 
 	// If a config file is specified, below command line flags will be ignored.
 
@@ -95,6 +96,7 @@ func New() *Options {
 	opt.flags.BoolVarP(&opt.ShowConfig, "print-config", "c", false, "Print the configuration.")
 	opt.flags.StringVarP(&opt.ConfigFile, "config-file", "f", "", "Load server configuration from a file(yaml format), other command line flags will be ignored if specified.")
 	opt.flags.BoolVar(&opt.ForceNewCluster, "force-new-cluster", false, "Force to create a new one-member cluster.")
+	opt.flags.BoolVar(&opt.SignalUpgrade, "signal-upgrade", false, "Send upgrade signal to the pid and exit. The server will start a graceful upgrade after signal received.")
 	opt.flags.StringVar(&opt.Name, "name", "eg-default-name", "Human-readable name for this member.")
 	opt.flags.StringToStringVar(&opt.Labels, "labels", nil, "The labels for the instance of Easegress.")
 	opt.flags.StringVar(&opt.ClusterName, "cluster-name", "eg-cluster-default-name", "Human-readable name for the new cluster, ignored while joining an existed cluster.")

--- a/pkg/pidfile/pidfile.go
+++ b/pkg/pidfile/pidfile.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/megaease/easegress/pkg/logger"
 	"github.com/megaease/easegress/pkg/option"
@@ -44,4 +45,16 @@ func Write(opt *option.Options) error {
 	}
 
 	return nil
+}
+
+func Read(opt *option.Options) (int, error) {
+	pidfilePath = filepath.Join(opt.AbsHomeDir, pidfileName)
+
+	data, err := ioutil.ReadFile(pidfilePath)
+	if err != nil {
+		logger.Errorf("write %s failed: %s", err)
+		return 0, err
+	}
+
+	return strconv.Atoi(string(data))
 }

--- a/pkg/pidfile/pidfile.go
+++ b/pkg/pidfile/pidfile.go
@@ -47,6 +47,7 @@ func Write(opt *option.Options) error {
 	return nil
 }
 
+// Read reads pidfile and return its value.
 func Read(opt *option.Options) (int, error) {
 	pidfilePath = filepath.Join(opt.AbsHomeDir, pidfileName)
 


### PR DESCRIPTION
fix #21 

signal idea copy from nginx <https://github.com/nginx/nginx/blob/a64190933e06758d50eea926e6a55974645096fd/src/os/win32/ngx_process_cycle.c>

`./easegress-server --signal-upgrade` introduced 

- [x] the graceful is not support on windows, will follow the pattern of nginx using Windows service to impl it
- [x] gh test on windows
- [x] signal test 
- [ ] gracenet to support windows 
