### PR TITLE
CI: check unnecessary dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,4 @@ jobs:
       - name: Test
         shell: bash
         run: |
-          go mod verify
-          go mod download
           make test

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,11 @@ build_docker:
 	docker build -t megaease/easegress:${RELEASE} -f ./build/package/Dockerfile .
 
 test:
-	@go list ./... | grep -v -E 'vendor' | xargs -n1 go test
+	cd ${MKFILE_DIR}
+	go mod tidy
+	git diff --exit-code go.mod go.sum
+	go mod verify
+	go test -v ./...
 
 clean:
 	rm -rf ${RELEASE_DIR}


### PR DESCRIPTION
Check unnecessary dependencies by running `go mod tidy && git diff --exit-code go.mod go.sum`

The command `go test ./...` now will not run tests in `vendor` dir by default, it's unnecessary to exclude it explicitly.