### PR TITLE
fix double free etcd

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -583,10 +583,12 @@ func (c *cluster) startServer() (done, timeout chan struct{}, err error) {
 
 	monitorServer := func(s *embed.Etcd) {
 		select {
-		case err := <-s.Err():
-			logger.Errorf("etcd server %s serve failed: %v",
-				c.server.Config().Name, err.Error())
-			closeEtcdServer(s)
+		case err, ok := <-s.Err():
+			if ok {
+				logger.Errorf("etcd server %s serve failed: %v",
+					c.server.Config().Name, err)
+				closeEtcdServer(s)
+			}
 		case <-c.done:
 			return
 		}


### PR DESCRIPTION
kill -USR2 <server pid>

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x101c598]

goroutine 42 [running]:
github.com/megaease/easegress/pkg/cluster.(*cluster).startServer.func1(0xc0000f4600)
        github.com/megaease/easegress/pkg/cluster/cluster.go:591 +0x358
created by github.com/megaease/easegress/pkg/cluster.(*cluster).startServer.func2
        github.com/megaease/easegress/pkg/cluster/cluster.go:613 +0x1ae
```