### PR TITLE
Use default spec coorectly & fix httppipeline.Validate without recursively checking

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
 	github.com/rs/cors v1.7.0
+	github.com/sanity-io/litter v1.5.1 // indirect
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.8.0
@@ -39,7 +40,8 @@ require (
 	github.com/tidwall/gjson v1.8.0
 	github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce
 	github.com/valyala/fasttemplate v1.2.1
-	github.com/xeipuuv/gojsonschema v1.2.0
+	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
+	github.com/xeipuuv/gojsonschema v1.2.1-0.20201027075954-b076d39a02e5
 	github.com/yl2chen/cidranger v1.0.2
 	go.etcd.io/etcd/api/v3 v3.5.0
 	go.etcd.io/etcd/client/v3 v3.5.0

--- a/go.sum
+++ b/go.sum
@@ -1139,6 +1139,8 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
+github.com/sanity-io/litter v1.5.1 h1:dwnrSypP6q56o3lFxTU+t2fwQ9A+U5qrXVO4Qg9KwVU=
+github.com/sanity-io/litter v1.5.1/go.mod h1:5Z71SvaYy5kcGtyglXOC9rrUi3c1E8CamFWjQsazTh0=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=
@@ -1233,6 +1235,7 @@ github.com/stretchr/objx v0.0.0-20180129172003-8a3f7159479f/go.mod h1:HFkY916IF+
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
+github.com/stretchr/testify v0.0.0-20161117074351-18a02ba4a312/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v0.0.0-20170130113145-4d4bfba8f1d1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v0.0.0-20180303142811-b89eecf5ca5d/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
@@ -1300,11 +1303,15 @@ github.com/xdg/scram v1.0.3/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49
 github.com/xdg/stringprep v1.0.3/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
+github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v0.0.0-20180618132009-1d523034197f/go.mod h1:5yf86TLmAcydyeJq5YvxkGPE2fm/u4myDekKRoLuqhs=
 github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
+github.com/xeipuuv/gojsonschema v1.2.1-0.20201027075954-b076d39a02e5 h1:ImnGIsrcG8vwbovhYvvSY8fagVV6QhCWSWXfzwGDLVs=
+github.com/xeipuuv/gojsonschema v1.2.1-0.20201027075954-b076d39a02e5/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/pkg/api/object.go
+++ b/pkg/api/object.go
@@ -42,45 +42,42 @@ const (
 
 func (s *Server) objectAPIEntries() []*APIEntry {
 	return []*APIEntry{
-		&APIEntry{
+		{
 			Path:    ObjectKindsPrefix,
 			Method:  "GET",
 			Handler: s.listObjectKinds,
 		},
-
-		&APIEntry{
+		{
 			Path:    ObjectPrefix,
 			Method:  "POST",
 			Handler: s.createObject,
 		},
-		&APIEntry{
+		{
 			Path:    ObjectPrefix,
 			Method:  "GET",
 			Handler: s.listObjects,
 		},
-
-		&APIEntry{
+		{
 			Path:    ObjectPrefix + "/{name}",
 			Method:  "GET",
 			Handler: s.getObject,
 		},
-		&APIEntry{
+		{
 			Path:    ObjectPrefix + "/{name}",
 			Method:  "PUT",
 			Handler: s.updateObject,
 		},
-		&APIEntry{
+		{
 			Path:    ObjectPrefix + "/{name}",
 			Method:  "DELETE",
 			Handler: s.deleteObject,
 		},
-
-		&APIEntry{
+		{
 			Path:    StatusObjectPrefix,
 			Method:  "GET",
 			Handler: s.listStatusObjects,
 		},
-		&APIEntry{
+		{
 			Path:    StatusObjectPrefix + "/{name}",
 			Method:  "GET",
 			Handler: s.getStatusObject,

--- a/pkg/object/function/faascontroller.go
+++ b/pkg/object/function/faascontroller.go
@@ -20,12 +20,10 @@ package function
 import (
 	"fmt"
 
-	"github.com/megaease/easegress/pkg/logger"
 	"github.com/megaease/easegress/pkg/object/function/spec"
 	"github.com/megaease/easegress/pkg/object/function/worker"
 	"github.com/megaease/easegress/pkg/supervisor"
 	"github.com/megaease/easegress/pkg/v"
-	"gopkg.in/yaml.v2"
 )
 
 const (
@@ -80,15 +78,7 @@ func (f *FaasController) Validate() error {
 		return fmt.Errorf("unknown faas provider: %s", f.spec.Provider)
 	}
 
-	buff, err := yaml.Marshal(f.spec.HTTPServer)
-	if err != nil {
-		err = fmt.Errorf("BUG: marshal %#v to yaml failed: %v",
-			f.spec.HTTPServer, err)
-		logger.Errorf(err.Error())
-		return err
-	}
-
-	vr := v.Validate(f.spec.HTTPServer, buff)
+	vr := v.Validate(f.spec.HTTPServer)
 	if !vr.Valid() {
 		return fmt.Errorf("%s", vr.Error())
 	}

--- a/pkg/object/function/worker/api.go
+++ b/pkg/object/function/worker/api.go
@@ -127,7 +127,7 @@ func (worker *Worker) readAPISpec(w http.ResponseWriter, r *http.Request, spec i
 		return fmt.Errorf("unmarshal failed: %v", err)
 	}
 
-	vr := v.Validate(spec, body)
+	vr := v.Validate(spec)
 	if !vr.Valid() {
 		return fmt.Errorf("validate failed: \n%s", vr.Error())
 	}

--- a/pkg/object/function/worker/ingress.go
+++ b/pkg/object/function/worker/ingress.go
@@ -242,8 +242,8 @@ func (ings *ingressServer) add(pipeline string) error {
 	index := ings.find(pipeline)
 	// not backend as function's pipeline
 	if index == -1 {
-		rule := httpserver.Rule{
-			Paths: []httpserver.Path{
+		rule := &httpserver.Rule{
+			Paths: []*httpserver.Path{
 				{
 					PathPrefix: "/",
 					Headers: []*httpserver.Header{

--- a/pkg/object/httppipeline/httppipeline.go
+++ b/pkg/object/httppipeline/httppipeline.go
@@ -216,7 +216,6 @@ func (meta *FilterMetaSpec) Validate() error {
 // Validate validates Spec.
 func (s Spec) Validate() (err error) {
 	errPrefix := "filters"
-	_ = errPrefix
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("%s: %s", errPrefix, r)

--- a/pkg/object/httpserver/mux.go
+++ b/pkg/object/httpserver/mux.go
@@ -335,11 +335,11 @@ func (m *mux) reloadRules(superSpec *supervisor.Spec, muxMapper protocol.MuxMapp
 
 		paths := make([]*muxPath, len(specRule.Paths))
 		for j := 0; j < len(paths); j++ {
-			paths[j] = newMuxPath(ruleIPFilterChain, &specRule.Paths[j])
+			paths[j] = newMuxPath(ruleIPFilterChain, specRule.Paths[j])
 		}
 
 		// NOTE: Given the parent ipFilters not its own.
-		rules.rules[i] = newMuxRule(rules.ipFilterChan, &specRule, paths)
+		rules.rules[i] = newMuxRule(rules.ipFilterChan, specRule, paths)
 	}
 
 	m.rules.Store(rules)

--- a/pkg/object/httpserver/spec.go
+++ b/pkg/object/httpserver/spec.go
@@ -51,7 +51,7 @@ type (
 		Keys map[string]string `yaml:"keys" jsonschema:"omitempty"`
 
 		IPFilter *ipfilter.Spec `yaml:"ipFilter,omitempty" jsonschema:"omitempty"`
-		Rules    []Rule         `yaml:"rules" jsonschema:"omitempty"`
+		Rules    []*Rule        `yaml:"rules" jsonschema:"omitempty"`
 	}
 
 	// Rule is first level entry of router.
@@ -66,7 +66,7 @@ type (
 		IPFilter   *ipfilter.Spec `yaml:"ipFilter,omitempty" jsonschema:"omitempty"`
 		Host       string         `yaml:"host" jsonschema:"omitempty"`
 		HostRegexp string         `yaml:"hostRegexp" jsonschema:"omitempty,format=regexp"`
-		Paths      []Path         `yaml:"paths" jsonschema:"omitempty"`
+		Paths      []*Path        `yaml:"paths" jsonschema:"omitempty"`
 	}
 
 	// Path is second level entry of router.

--- a/pkg/object/meshcontroller/api/api.go
+++ b/pkg/object/meshcontroller/api/api.go
@@ -23,9 +23,6 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	yamljsontool "github.com/ghodss/yaml"
-	"gopkg.in/yaml.v2"
-
 	"github.com/megaease/easegress/pkg/api"
 	"github.com/megaease/easegress/pkg/object/meshcontroller/service"
 	"github.com/megaease/easegress/pkg/supervisor"
@@ -162,25 +159,6 @@ func (a *API) registerAPIs() {
 	api.RegisterAPIs(group)
 }
 
-func (a *API) readSpec(w http.ResponseWriter, r *http.Request, spec interface{}) error {
-	body, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		return fmt.Errorf("read body failed: %v", err)
-	}
-
-	err = yaml.Unmarshal(body, spec)
-	if err != nil {
-		return fmt.Errorf("unmarshal %#v to yaml: %v", spec, err)
-	}
-
-	vr := v.Validate(spec, body)
-	if !vr.Valid() {
-		return fmt.Errorf("validate failed: \n%s", vr)
-	}
-
-	return nil
-}
-
 func (a *API) convertSpecToPB(spec interface{}, pbSpec interface{}) error {
 	buf, err := json.Marshal(spec)
 	if err != nil {
@@ -225,14 +203,9 @@ func (a *API) readAPISpec(w http.ResponseWriter, r *http.Request, pbSpec interfa
 		return err
 	}
 
-	yamlBuff, err := yamljsontool.JSONToYAML(body)
-	if err != nil {
-		return err
-	}
-
-	vr := v.Validate(spec, yamlBuff)
+	vr := v.Validate(spec)
 	if !vr.Valid() {
-		return fmt.Errorf("validate failed: \n%s", vr)
+		return fmt.Errorf("validate failed:\n%s", vr)
 	}
 
 	return nil

--- a/pkg/object/meshcontroller/spec/spec.go
+++ b/pkg/object/meshcontroller/spec/spec.go
@@ -85,10 +85,10 @@ type (
 		RegistryType string `yaml:"registryType" jsonschema:"required"`
 
 		// APIPort is the port for worker's API server
-		APIPort int `yaml:"apiPort" jsonschema:"omitempty"`
+		APIPort int `yaml:"apiPort" jsonschema:"required"`
 
 		// IngressPort is the port for http server in mesh ingress
-		IngressPort int `yaml:"ingressPort" jsonschema:"omitempty"`
+		IngressPort int `yaml:"ingressPort" jsonschema:"required"`
 	}
 
 	// Service contains the information of service.

--- a/pkg/object/meshcontroller/worker/egress.go
+++ b/pkg/object/meshcontroller/worker/egress.go
@@ -190,8 +190,8 @@ func (egs *EgressServer) reloadHTTPServer(specs map[string]*spec.Service) bool {
 	httpServerSpec.Rules = nil
 
 	for k := range pipelines {
-		rule := httpserver.Rule{
-			Paths: []httpserver.Path{
+		rule := &httpserver.Rule{
+			Paths: []*httpserver.Path{
 				{
 					PathPrefix: "/",
 					Headers: []*httpserver.Header{

--- a/pkg/object/serviceregistry/consulserviceregistry/consulserviceregistry.go
+++ b/pkg/object/serviceregistry/consulserviceregistry/consulserviceregistry.go
@@ -58,7 +58,7 @@ type (
 	// Spec describes the ConsulServiceRegistry.
 	Spec struct {
 		Address      string   `yaml:"address" jsonschema:"required"`
-		Scheme       string   `yaml:"scheme" jsonschema:"omitempty,enum=http,enum=https"`
+		Scheme       string   `yaml:"scheme" jsonschema:"required,enum=http,enum=https"`
 		Datacenter   string   `yaml:"datacenter" jsonschema:"omitempty"`
 		Token        string   `yaml:"token" jsonschema:"omitempty"`
 		Namespace    string   `yaml:"namespace" jsonschema:"omitempty"`

--- a/pkg/object/serviceregistry/zookeeperserviceregistry/zookeeperserviceregistry.go
+++ b/pkg/object/serviceregistry/zookeeperserviceregistry/zookeeperserviceregistry.go
@@ -59,10 +59,6 @@ type (
 
 	// Spec describes the ZookeeperServiceRegistry.
 	Spec struct {
-		super     *supervisor.Supervisor
-		superSpec *supervisor.Spec
-		spec      *Spec
-
 		ConnTimeout  string   `yaml:"conntimeout" jsonschema:"required,format=duration"`
 		ZKServices   []string `yaml:"zkservices" jsonschema:"required,uniqueItems=true"`
 		Prefix       string   `yaml:"prefix" jsonschema:"required,pattern=^/"`
@@ -160,7 +156,7 @@ func (zk *ZookeeperServiceRegistry) buildConn() (*zookeeper.Conn, error) {
 		return nil, err
 	}
 
-	if exist == false {
+	if !exist {
 		logger.Errorf("zookeeper path: %s no exist", zk.spec.Prefix)
 		return nil, fmt.Errorf("path [%s] no exist", zk.spec.Prefix)
 	}

--- a/pkg/util/yamltool/yamltool.go
+++ b/pkg/util/yamltool/yamltool.go
@@ -6,6 +6,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+// Marshal wraps yaml.Marshal by panic instead of returning error.
 func Marshal(in interface{}) []byte {
 	buff, err := yaml.Marshal(in)
 	if err != nil {
@@ -14,6 +15,7 @@ func Marshal(in interface{}) []byte {
 	return buff
 }
 
+// Unmarshal wraps yaml.Unmarshal by panic instead of returning error.
 func Unmarshal(in []byte, out interface{}) {
 	err := yaml.Unmarshal(in, out)
 	if err != nil {

--- a/pkg/util/yamltool/yamltool.go
+++ b/pkg/util/yamltool/yamltool.go
@@ -1,0 +1,23 @@
+package yamltool
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v2"
+)
+
+func Marshal(in interface{}) []byte {
+	buff, err := yaml.Marshal(in)
+	if err != nil {
+		panic(fmt.Errorf("marshal %s to yaml string failed: %v", in, err))
+	}
+	return buff
+}
+
+func Unmarshal(in []byte, out interface{}) {
+	err := yaml.Unmarshal(in, out)
+	if err != nil {
+		panic(fmt.Errorf("unmarshal yaml string %s to %#v failed: %v",
+			in, out, err))
+	}
+}

--- a/pkg/v/validaterecorder.go
+++ b/pkg/v/validaterecorder.go
@@ -90,6 +90,11 @@ func requiredFromField(field *reflect.StructField) bool {
 	}
 }
 
+func (vr *ValidateRecorder) record(val *reflect.Value, field *reflect.StructField) {
+	vr.recordFormat(val, field)
+	vr.recordGeneral(val, field)
+}
+
 func (vr *ValidateRecorder) recordFormat(val *reflect.Value, field *reflect.StructField) {
 	if field == nil {
 		return


### PR DESCRIPTION
A bugfix next to https://github.com/megaease/easegress/pull/96. 

It fixed:

- object&filter won't use default spec to cover empty fields.
- HTTPPipeline.Validate won't recursively check subfields.

But here left an issue:

`required` string type in jsonschema allow empty string[1], for example, the field `Name` in `ratelimiter.Policy` can be an empty string. We need to fix it.

[1] https://stackoverflow.com/a/54426110/1705845