### PR TITLE
Add missing `return err` after `if err == <ErrorType>` statement.

### DIFF
--- a/pkg/object/meshcontroller/worker/egress.go
+++ b/pkg/object/meshcontroller/worker/egress.go
@@ -128,6 +128,7 @@ func (egs *EgressServer) InitEgress(service *spec.Service) error {
 			logger.Errorf("add ingress spec watching service: %s failed: %v", service.Name, err)
 			return err
 		}
+		return err
 	}
 
 	if err := egs.inf.OnAllServiceInstanceSpecs(egs.reloadByInstances); err != nil {
@@ -135,6 +136,7 @@ func (egs *EgressServer) InitEgress(service *spec.Service) error {
 			logger.Errorf("add ingress spec watching service: %s failed: %v", service.Name, err)
 			return err
 		}
+		return err
 	}
 	return nil
 }

--- a/pkg/object/meshcontroller/worker/ingress.go
+++ b/pkg/object/meshcontroller/worker/ingress.go
@@ -126,6 +126,9 @@ func (ings *IngressServer) InitIngress(service *spec.Service, port uint32) error
 			logger.Errorf("add ingress spec watching service: %s failed: %v", service.Name, err)
 			return err
 		}
+		// If missing this statement, some errors will be ignored, but it will cause hidden the reason of `err`,
+		// That is bad.
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
If missing `return err` after `if` statement, some errors will be ignored. It will cause hidden the reason of `err`. That is a bad practice.