### PR TITLE
[v]: Use newer json schema generator & fix spec test failure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/ArthurHlt/go-eureka-client v1.1.0
 	github.com/Shopify/sarama v1.29.1
+	github.com/alecthomas/jsonschema v0.0.0-20210526225647-edb03dcab7bc
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/facebookgo/ensure v0.0.0-20200202191622-63f1cf65ac4c // indirect
 	github.com/facebookgo/freeport v0.0.0-20150612182905-d4adf43b75b9 // indirect
@@ -22,7 +23,6 @@ require (
 	github.com/lucas-clemente/quic-go v0.21.1
 	github.com/megaease/easemesh-api v0.0.0-20210604095307-27c2d1f7cf09
 	github.com/megaease/grace v1.0.0
-	github.com/megaease/jsonschema v0.0.0-20191230042224-e92108cfafc5
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/nacos-group/nacos-sdk-go v1.0.8
 	github.com/opentracing/opentracing-go v1.2.0
@@ -32,7 +32,6 @@ require (
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
 	github.com/rs/cors v1.7.0
-	github.com/sanity-io/litter v1.5.1 // indirect
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -137,6 +137,8 @@ github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/ahmetb/gen-crd-api-reference-docs v0.3.1-0.20210420163308-c1402a70e2f1/go.mod h1:TdjdkYhlOifCQWPs1UdTma97kQQMozf5h26hTuG70u8=
 github.com/alecthomas/jsonschema v0.0.0-20180308105923-f2c93856175a/go.mod h1:qpebaTNSsyUn5rPSJMsfqEtDw71TTggXM6stUDI16HA=
+github.com/alecthomas/jsonschema v0.0.0-20210526225647-edb03dcab7bc h1:mT8qSzuyEAkxbv4GBln7yeuQZpBnfikr3PTuiPs6Z3k=
+github.com/alecthomas/jsonschema v0.0.0-20210526225647-edb03dcab7bc/go.mod h1:/n6+1/DWPltRLWL/VKyUxg6tzsl5kHUCcraimt4vr60=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -748,6 +750,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huandu/xstrings v1.0.0/go.mod h1:4qWG/gcEcfX4z/mBDHJ++3ReCw9ibxbsNJbcucJdbSo=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
+github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0 h1:i462o439ZjprVSFSZLZxcsoAe592sZB1rci2Z8j4wdk=
+github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0/go.mod h1:N0Wam8K1arqPXNWjMo21EXnBPOPp36vB07FNRdD2geA=
 github.com/iancoleman/strcase v0.0.0-20180726023541-3605ed457bf7/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -899,8 +903,6 @@ github.com/megaease/easemesh-api v0.0.0-20210604095307-27c2d1f7cf09 h1:8mprlJ15b
 github.com/megaease/easemesh-api v0.0.0-20210604095307-27c2d1f7cf09/go.mod h1:wMeACxBBBbqa/f3u7Epf/65vIP0GmAr92qsfA9AZ8T0=
 github.com/megaease/grace v1.0.0 h1:b44R3j6e/iaN62F4ZUnru9nzL1VaIcxxUZjSPVtTVzI=
 github.com/megaease/grace v1.0.0/go.mod h1:mOR6MVYQ6zGyuz9Y2or/VJ6QWueTL3erxWfIwyCmiIg=
-github.com/megaease/jsonschema v0.0.0-20191230042224-e92108cfafc5 h1:u/LZEzQf2WPzKkSBaxRpiSjcAy3n4Tlh+k52JzMJ+OE=
-github.com/megaease/jsonschema v0.0.0-20191230042224-e92108cfafc5/go.mod h1:dV5GJ+oE0GyckvTBIAx9+R1BmuRKFyodhJwI6biLFYI=
 github.com/microcosm-cc/bluemonday v1.0.1/go.mod h1:hsXNsILzKxV+sX77C5b8FSuKF00vh2OMYv+xgHpAMF4=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.17/go.mod h1:WgzbA6oji13JREwiNsRDNfl7jYdPnmz+VEuLrA+/48M=
@@ -1139,8 +1141,6 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
-github.com/sanity-io/litter v1.5.1 h1:dwnrSypP6q56o3lFxTU+t2fwQ9A+U5qrXVO4Qg9KwVU=
-github.com/sanity-io/litter v1.5.1/go.mod h1:5Z71SvaYy5kcGtyglXOC9rrUi3c1E8CamFWjQsazTh0=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=
@@ -1235,7 +1235,6 @@ github.com/stretchr/objx v0.0.0-20180129172003-8a3f7159479f/go.mod h1:HFkY916IF+
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
-github.com/stretchr/testify v0.0.0-20161117074351-18a02ba4a312/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v0.0.0-20170130113145-4d4bfba8f1d1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v0.0.0-20180303142811-b89eecf5ca5d/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
@@ -1301,15 +1300,12 @@ github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
 github.com/xdg/scram v1.0.3/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v1.0.3/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
-github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v0.0.0-20180618132009-1d523034197f/go.mod h1:5yf86TLmAcydyeJq5YvxkGPE2fm/u4myDekKRoLuqhs=
-github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
-github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/xeipuuv/gojsonschema v1.2.1-0.20201027075954-b076d39a02e5 h1:ImnGIsrcG8vwbovhYvvSY8fagVV6QhCWSWXfzwGDLVs=
 github.com/xeipuuv/gojsonschema v1.2.1-0.20201027075954-b076d39a02e5/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=

--- a/pkg/filter/proxy/proxy.go
+++ b/pkg/filter/proxy/proxy.go
@@ -99,8 +99,6 @@ type (
 
 	// Spec describes the Proxy.
 	Spec struct {
-		httppipeline.FilterMetaSpec `yaml:",inline"`
-
 		Fallback       *FallbackSpec    `yaml:"fallback,omitempty" jsonschema:"omitempty"`
 		MainPool       *PoolSpec        `yaml:"mainPool" jsonschema:"required"`
 		CandidatePools []*PoolSpec      `yaml:"candidatePools,omitempty" jsonschema:"omitempty"`

--- a/pkg/object/meshcontroller/spec/spec_test.go
+++ b/pkg/object/meshcontroller/spec/spec_test.go
@@ -19,6 +19,8 @@ package spec
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/megaease/easegress/pkg/filter/circuitbreaker"
@@ -26,8 +28,28 @@ import (
 	"github.com/megaease/easegress/pkg/filter/ratelimiter"
 	"github.com/megaease/easegress/pkg/filter/retryer"
 	"github.com/megaease/easegress/pkg/filter/timelimiter"
+	"github.com/megaease/easegress/pkg/logger"
+	"github.com/megaease/easegress/pkg/option"
 	"github.com/megaease/easegress/pkg/util/urlrule"
 )
+
+const tempDir = "/tmp/eg-test"
+
+func TestMain(m *testing.M) {
+	absLogDir := filepath.Join(tempDir, "global-log")
+	os.MkdirAll(absLogDir, 0o755)
+	logger.Init(&option.Options{
+		Name:      "meshspec-for-log",
+		AbsLogDir: absLogDir,
+	})
+
+	code := m.Run()
+
+	logger.Sync()
+	os.RemoveAll(tempDir)
+
+	os.Exit(code)
+}
 
 func TestSideCarIngressPipelineSpec(t *testing.T) {
 	s := &Service{
@@ -44,7 +66,10 @@ func TestSideCarIngressPipelineSpec(t *testing.T) {
 		},
 	}
 
-	superSpec, _ := s.SideCarIngressPipelineSpec(443)
+	superSpec, err := s.SideCarIngressPipelineSpec(443)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
 	fmt.Println(superSpec.YAMLConfig())
 }
 

--- a/pkg/v/v.go
+++ b/pkg/v/v.go
@@ -54,7 +54,7 @@ var (
 		ExpandedStruct:             true,
 
 		// NOTE: FullyQualifyTypeNames setting true will generate
-		// "$ref": "#/definitions/github.com/megaease-easegress-pkg-supervisor.MetaSpec",
+		// "$ref": "#/definitions/github.com/megaease/easegress/pkg/supervisor.MetaSpec",
 		// "definitions": {
 		//   "github.com/megaease/easegress/pkg/supervisor.MetaSpec": {
 		//      ...

--- a/pkg/v/v.go
+++ b/pkg/v/v.go
@@ -23,8 +23,8 @@ import (
 	"reflect"
 	"sync"
 
+	genjs "github.com/alecthomas/jsonschema"
 	yamljsontool "github.com/ghodss/yaml"
-	genjs "github.com/megaease/jsonschema"
 	loadjs "github.com/xeipuuv/gojsonschema"
 	yaml "gopkg.in/yaml.v2"
 
@@ -46,22 +46,31 @@ type (
 )
 
 var (
-	validateReflector = &genjs.Reflector{
-		DefinitionNameWithPackage:  true,
+	reflector = &genjs.Reflector{
 		AllowAdditionalProperties:  true,
 		RequiredFromJSONSchemaTags: true,
+		PreferYAMLSchema:           true,
+		DoNotReference:             true,
+		ExpandedStruct:             true,
+
+		// NOTE: FullyQualifyTypeNames setting true will generate
+		// "$ref": "#/definitions/github.com/megaease-easegress-pkg-supervisor.MetaSpec",
+		// "definitions": {
+		//   "github.com/megaease/easegress/pkg/supervisor.MetaSpec": {
+		//      ...
+		//   }
+		// }
+		// FIXME if necessary:
+		// The $ref can't find it becasue the slash means a level in json schema.
+		// We can fix it by replace all slashes by `.` or `-`, etc in github.com/alecthomas/jsonschema.
 	}
-	generateReflector = &genjs.Reflector{
-		DefinitionNameWithPackage:  true,
-		RequiredFromJSONSchemaTags: true,
-	}
-	reflectorSchemaMetasMutex = sync.Mutex{}
-	reflectorSchemaMetas      = map[*genjs.Reflector]map[reflect.Type]*schemaMeta{}
+	schemaMetasMutex = sync.Mutex{}
+	schemaMetas      = map[reflect.Type]*schemaMeta{}
 )
 
 // GetSchemaInYAML returns the json schema of t in yaml format.
 func GetSchemaInYAML(t reflect.Type) ([]byte, error) {
-	sm, err := getSchemaMeta(generateReflector, t)
+	sm, err := getSchemaMeta(t)
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +80,7 @@ func GetSchemaInYAML(t reflect.Type) ([]byte, error) {
 
 // GetSchemaInJSON return the json schema of t in json format.
 func GetSchemaInJSON(t reflect.Type) ([]byte, error) {
-	sm, err := getSchemaMeta(generateReflector, t)
+	sm, err := getSchemaMeta(t)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +102,7 @@ func Validate(v interface{}) *ValidateRecorder {
 		return vr
 	}
 
-	sm, err := getSchemaMeta(validateReflector, reflect.TypeOf(v))
+	sm, err := getSchemaMeta(reflect.TypeOf(v))
 	if err != nil {
 		vr.recordSystem(fmt.Errorf("get schema meta for %T failed: %v", v, err))
 		return vr
@@ -124,15 +133,10 @@ func Validate(v interface{}) *ValidateRecorder {
 	return vr
 }
 
-func getSchemaMeta(reflector *genjs.Reflector, t reflect.Type) (*schemaMeta, error) {
-	reflectorSchemaMetasMutex.Lock()
-	defer reflectorSchemaMetasMutex.Unlock()
+func getSchemaMeta(t reflect.Type) (*schemaMeta, error) {
+	schemaMetasMutex.Lock()
+	defer schemaMetasMutex.Unlock()
 
-	schemaMetas, exists := reflectorSchemaMetas[reflector]
-	if !exists {
-		schemaMetas = make(map[reflect.Type]*schemaMeta)
-		reflectorSchemaMetas[reflector] = schemaMetas
-	}
 	sm, exists := schemaMetas[t]
 	if exists {
 		return sm, nil


### PR DESCRIPTION
The failure reason of unit test of mesh spec path are:

1. `github.com/megaease/jsonschema` is outdated
2. There was an outdated config field in the proxy filter

But the ecosystem of json schema in golang is poor, there left an issue(not a problem for now) which is `github.com/alecthomas/jsonschema` can't generate the correct json schema with `$ref` and `definitions`. I put it in the code comment.