### PR TITLE
Fix unit test failure of semaphore and cluster

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	go.etcd.io/etcd/client/v3 v3.5.0
 	go.etcd.io/etcd/server/v3 v3.5.0
 	go.uber.org/zap v1.17.0
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.20.7
 	k8s.io/apimachinery v0.20.7

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -33,7 +33,11 @@ func mockClusters(count int) []*cluster {
 		panic(fmt.Errorf("new cluster failed: %v", err))
 	}
 	clusters[0] = bootCluster.(*cluster)
-	time.Sleep(HeartbeatInterval)
+
+	// Note: using testHeartbeatInterval instead of HeartBeatInterval is for running
+	// this test routine in resource limited environment,e.g.,Github Ubuntu/MacOS test env.
+	testHeartbeatInterval := 20 * time.Second
+	time.Sleep(testHeartbeatInterval)
 
 	for i := 1; i < count; i++ {
 		opts[i].ClusterJoinURLs = opts[0].ClusterListenPeerURLs

--- a/pkg/cluster/member_test.go
+++ b/pkg/cluster/member_test.go
@@ -19,6 +19,7 @@ package cluster
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -33,16 +34,17 @@ import (
 	"github.com/megaease/easegress/pkg/option"
 )
 
-const tempDir = "/tmp/eg-test"
-
-var memberCounter = 0
+var (
+	memberCounter = 0
+	tempDir       = os.TempDir()
+)
 
 func TestMain(m *testing.M) {
-	// try to remove the previous unsuccessfully removed test dir firstly
-	os.RemoveAll(tempDir)
+	absLogDir, err := ioutil.TempDir(tempDir, "global-log")
+	if err != nil {
+		panic(fmt.Errorf("create tmp dir failed: %v", err))
+	}
 
-	absLogDir := filepath.Join(tempDir, "global-log")
-	os.MkdirAll(absLogDir, 0o755)
 	logger.Init(&option.Options{
 		Name:      "member-for-log",
 		AbsLogDir: absLogDir,
@@ -52,7 +54,6 @@ func TestMain(m *testing.M) {
 
 	logger.Sync()
 	os.RemoveAll(tempDir)
-
 	os.Exit(code)
 }
 

--- a/pkg/cluster/member_test.go
+++ b/pkg/cluster/member_test.go
@@ -38,6 +38,9 @@ const tempDir = "/tmp/eg-test"
 var memberCounter = 0
 
 func TestMain(m *testing.M) {
+	// try to remove the previous unsuccessfully removed test dir firstly
+	os.RemoveAll(tempDir)
+
 	absLogDir := filepath.Join(tempDir, "global-log")
 	os.MkdirAll(absLogDir, 0o755)
 	logger.Init(&option.Options{

--- a/pkg/object/httpserver/listen.go
+++ b/pkg/object/httpserver/listen.go
@@ -72,7 +72,7 @@ func (l *LimitListener) Accept() (net.Conn, error) {
 
 // SetMaxConnection sets max connection.
 func (l *LimitListener) SetMaxConnection(n uint32) {
-	l.sem.SetMaxCount(n)
+	l.sem.SetMaxCount(int64(n))
 }
 
 // Close closes LimitListener.

--- a/pkg/util/sem/semaphore_test.go
+++ b/pkg/util/sem/semaphore_test.go
@@ -18,15 +18,11 @@
 package sem
 
 import (
-	"math/rand"
+	"context"
 	"sync"
 	"testing"
 	"time"
 )
-
-type Case struct {
-	maxSem int
-}
 
 func TestSemaphore0(t *testing.T) {
 	s := NewSem(0)
@@ -44,112 +40,41 @@ func TestSemaphore0(t *testing.T) {
 	}
 }
 
-func TestSemaphoreRobust(t *testing.T) {
+func TestSemaphoreChangeAtRuntime(t *testing.T) {
 	s := NewSem(10)
-	w := &sync.WaitGroup{}
-	w.Add(101)
-	// change maxSem randomly
-	go func() {
-		for i := 0; i < 500; i++ {
-			time.Sleep(1 * time.Millisecond)
-			s.SetMaxCount(uint32(rand.Intn(100000)))
-		}
-		w.Done()
-	}()
 
-	for x := 0; x < 100; x++ {
+	testcases := []int64{40, 2}
+	for _, c := range testcases {
+		runCase(s, c, t)
+
+	}
+
+}
+
+func runCase(s *Semaphore, maxCount int64, t *testing.T) {
+	// step 0, change max count at runtime
+	done := s.SetMaxCount(maxCount)
+	<- done
+
+	// step 1, try to acquire max count, should be OK
+	wg := &sync.WaitGroup{}
+	wg.Add(int(maxCount))
+	for i := 0; i < int(maxCount); i++ {
 		go func() {
-			for j := 0; j < 100; j++ {
-				s.Acquire()
-				time.Sleep(5 * time.Millisecond)
-				s.Release()
-			}
-			w.Done()
+			s.Acquire()
+			wg.Done()
 		}()
 	}
-	w.Wait()
+	wg.Wait()
 
-	// confirm it still works
-	s.SetMaxCount(20)
-	time.Sleep(10 * time.Millisecond)
-
-	runCase(s, &Case{23}, t)
-}
-
-func TestSemaphoreN(t *testing.T) {
-	s := NewSem(20)
-	Cases := []*Case{
-		{maxSem: 37},
-		{maxSem: 45},
-		{maxSem: 3},
-		{maxSem: 1000},
-		{maxSem: 235},
-		{maxSem: 800},
-		{maxSem: 587},
+	// step 2: try to acquire one more, should timeout
+	ctx, _ := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	err := s.AcquireWithContext(ctx)
+	if err == nil {
+		t.Fatalf("sema count exceeds the maxCount: %d", maxCount)
 	}
 
-	for _, c := range Cases {
-		runCase(s, c, t)
-	}
-}
-
-func BenchmarkSemaphore(b *testing.B) {
-	s := NewSem(uint32(b.N/2 + 1))
-	for i := 0; i < b.N; i++ {
-		b.RunParallel(func(pb *testing.PB) {
-			for pb.Next() {
-				s.Acquire()
-				s.Release()
-			}
-		})
-	}
-}
-
-func runCase(s *Semaphore, c *Case, t *testing.T) {
-	s.SetMaxCount(uint32(c.maxSem))
-	time.Sleep(10 * time.Millisecond)
-
-	w := &sync.WaitGroup{}
-	w.Add(c.maxSem)
-	for i := 0; i < c.maxSem; i++ {
-		go func(w *sync.WaitGroup) {
-			s.Acquire()
-			defer s.Release()
-			time.Sleep(100 * time.Millisecond)
-			w.Done()
-		}(w)
-	}
-	begin := time.Now()
-	w.Wait()
-	d := time.Since(begin)
-	if d > 100*time.Millisecond+10*time.Millisecond {
-		t.Errorf("time too long: %v, sem: %d, trans: %d", d, c.maxSem, c.maxSem)
-	}
-	if d < 100*time.Millisecond-10*time.Millisecond {
-		t.Errorf("time too short: %v, sem: %d, trans: %d", d, c.maxSem, c.maxSem)
-	}
-
-	s.SetMaxCount(uint32(c.maxSem - 1))
-	time.Sleep(10 * time.Millisecond)
-
-	w = &sync.WaitGroup{}
-	w.Add(c.maxSem)
-	for i := 0; i < c.maxSem; i++ {
-		go func(w *sync.WaitGroup) {
-			s.Acquire()
-			defer s.Release()
-			time.Sleep(100 * time.Millisecond)
-			w.Done()
-		}(w)
-	}
-	begin = time.Now()
-	w.Wait()
-	d = time.Since(begin)
-	if d < 200*time.Millisecond-10*time.Millisecond {
-		t.Errorf("time too short: %v, sem: %d, trans: %d", d, c.maxSem-1, c.maxSem)
-	}
-
-	if d > 200*time.Millisecond+10*time.Millisecond {
-		t.Errorf("time too long: %v, sem: %d, trans: %d", d, c.maxSem-1, c.maxSem)
+	for i := 0; i < int(maxCount); i++ {
+		s.Release()
 	}
 }


### PR DESCRIPTION
1. Changing to use `golang.org/x/sync.sem` instead of implementing it by ourselves with `chan struct{}`.
2. Had run `make test` successfully in MacBook env. 
```bash
49.474833ms
/abc/com/merchant/*/other/30/details
--- PASS: TestURLClusterAnalyzer (0.05s)
PASS
ok  	github.com/megaease/easegress/pkg/util/urlclusteranalyzer	(cached)
=== RUN   TestURLRULEMatch
--- PASS: TestURLRULEMatch (0.00s)
=== RUN   TestURLRegxMatch
--- PASS: TestURLRegxMatch (0.00s)
=== RUN   TestURLExactMatch
--- PASS: TestURLExactMatch (0.00s)
=== RUN   TestURLExactNotMatch
--- PASS: TestURLExactNotMatch (0.00s)
=== RUN   TestURLPrefixNotMatch
--- PASS: TestURLPrefixNotMatch (0.00s)
=== RUN   TestURLRULENoMatchMethod
--- PASS: TestURLRULENoMatchMethod (0.00s)
=== RUN   TestURLRULENoMatchURL
--- PASS: TestURLRULENoMatchURL (0.00s)
PASS
ok  	github.com/megaease/easegress/pkg/util/urlrule	(cached)
?   	github.com/megaease/easegress/pkg/util/yamltool	[no test files]
?   	github.com/megaease/easegress/pkg/v	[no test files]
?   	github.com/megaease/easegress/pkg/version	[no test files]
√ easegress $ 
```