### PR TITLE
golint warning fixes

### DIFF
--- a/cmd/client/command/common.go
+++ b/cmd/client/command/common.go
@@ -97,7 +97,7 @@ const (
 	// MeshServiceInstanceURL is the mesh service path.
 	MeshServiceInstanceURL = apiURL + "/mesh/serviceinstances/%s/%s"
 
-	// MeshIngressURL is the mesh ingress prefix.
+	// MeshIngressesURL is the mesh ingress prefix.
 	MeshIngressesURL = apiURL + "/mesh/ingresses"
 
 	// MeshIngressURL is the mesh ingress path.

--- a/pkg/api/metadata.go
+++ b/pkg/api/metadata.go
@@ -74,22 +74,22 @@ func (s *Server) initMetadata() {
 
 func (s *Server) metadataAPIEntries() []*APIEntry {
 	return []*APIEntry{
-		&APIEntry{
+		{
 			Path:    FilterMetaPrefix,
 			Method:  "GET",
 			Handler: s.listFilters,
 		},
-		&APIEntry{
+		{
 			Path:    FilterMetaPrefix + "/{kind}" + "/description",
 			Method:  "GET",
 			Handler: s.getFilterDescription,
 		},
-		&APIEntry{
+		{
 			Path:    FilterMetaPrefix + "/{kind}" + "/schema",
 			Method:  "GET",
 			Handler: s.getFilterSchema,
 		},
-		&APIEntry{
+		{
 			Path:    FilterMetaPrefix + "/{kind}" + "/results",
 			Method:  "GET",
 			Handler: s.getFilterResults,

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -506,15 +506,15 @@ func (c *cluster) initLease() error {
 		resp, err := client.Lease.TimeToLive(c.requestContext(), *leaseID)
 		if err != nil || resp.TTL < minTTL {
 			return c.grantNewLease()
-		} else {
-			// NOTE: Use existed lease.
-			c.lease = leaseID
-			logger.Infof("lease is ready(use existed one: %x)", *c.lease)
-			return nil
 		}
-	} else {
-		return c.grantNewLease()
+		// NOTE: Use existed lease.
+		c.lease = leaseID
+		logger.Infof("lease is ready(use existed one: %x)", *c.lease)
+		return nil
+
 	}
+	return c.grantNewLease()
+
 }
 
 func (c *cluster) grantNewLease() error {

--- a/pkg/common/callback.go
+++ b/pkg/common/callback.go
@@ -20,8 +20,8 @@ package common
 const (
 	CallbacksInitCapacity = 20
 
-	NORMAL_PRIORITY_CALLBACK   = "__NoRmAl_PrIoRiTy_CaLlBaCk"
-	CRITICAL_PRIORITY_CALLBACK = "__CrItIcAl_PrIoRiTy_CaLlBaCk"
+	NormalPriorityCallback   = "__NoRmAl_PrIoRiTy_CaLlBaCk"
+	CriticalPriorityCallback = "__CrItIcAl_PrIoRiTy_CaLlBaCk"
 )
 
 ////
@@ -96,10 +96,10 @@ func AddCallback(cbs *NamedCallbackSet, name string, callback interface{}, prior
 	cb := NewNamedCallback(name, callback)
 	idx := 0
 
-	if priority == NORMAL_PRIORITY_CALLBACK {
+	if priority == NormalPriorityCallback {
 		idx = len(cbs.callbacks)
 		cbs.callbacks = append(cbs.callbacks, cb)
-	} else if priority == CRITICAL_PRIORITY_CALLBACK {
+	} else if priority == CriticalPriorityCallback {
 		// idx = 0
 		cbs.callbacks = append([]*NamedCallback{cb}, cbs.callbacks...)
 	} else {

--- a/pkg/common/option.go
+++ b/pkg/common/option.go
@@ -138,9 +138,9 @@ func (i *Uint64RangeValue) Get() interface{} { return *i.v }
 func (i *Uint64RangeValue) String() string {
 	if i.v == nil {
 		return strconv.FormatUint(0, 10) // zero value
-	} else {
-		return strconv.FormatUint(*i.v, 10)
 	}
+	return strconv.FormatUint(*i.v, 10)
+
 }
 
 ////
@@ -184,9 +184,9 @@ func (i *Uint32RangeValue) Get() interface{} { return *i.v }
 func (i *Uint32RangeValue) String() string {
 	if i.v == nil {
 		return strconv.FormatUint(0, 10) // zero value
-	} else {
-		return strconv.FormatUint(uint64(*i.v), 10)
 	}
+	return strconv.FormatUint(uint64(*i.v), 10)
+
 }
 
 ////
@@ -230,9 +230,9 @@ func (i *Uint16RangeValue) Get() interface{} { return *i.v }
 func (i *Uint16RangeValue) String() string {
 	if i.v == nil {
 		return strconv.FormatUint(0, 10) // zero value
-	} else {
-		return strconv.FormatUint(uint64(*i.v), 10)
 	}
+	return strconv.FormatUint(uint64(*i.v), 10)
+
 }
 
 ////

--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -28,7 +28,7 @@ import (
 	"strings"
 )
 
-const TOKEN_ESCAPE_CHAR string = `\`
+const TokenEscapeChar string = `\`
 
 // GraphiteSplit slices s into all substrings separated by sep
 // returns a slice of the substrings without length prefix separated by lensep.
@@ -86,13 +86,13 @@ func ScanTokens(str string, removeEscapeChar bool, visitor TokenVisitor) (string
 			return false
 		}
 
-		return string(v[pos-1]) == TOKEN_ESCAPE_CHAR
+		return string(v[pos-1]) == TokenEscapeChar
 	}
 
 	escaper := func(s string) string {
 		return strings.Replace(
-			strings.Replace(s, TOKEN_ESCAPE_CHAR+`{`, "{", -1),
-			TOKEN_ESCAPE_CHAR+`}`, "}", -1)
+			strings.Replace(s, TokenEscapeChar+`{`, "{", -1),
+			TokenEscapeChar+`}`, "}", -1)
 	}
 
 	token := bytes.NewBuffer(nil)
@@ -177,8 +177,8 @@ func PanicToErr(f func(), err *error) (failed bool) {
 }
 
 var (
-	TRUE_STRINGS  = []string{"1", "t", "true", "on", "y", "yes"}
-	FALSE_STRINGS = []string{"0", "f", "false", "off", "n", "no"}
+	TrueStrings  = []string{"1", "t", "true", "on", "y", "yes"}
+	FalseStrings = []string{"0", "f", "false", "off", "n", "no"}
 )
 
 func RemoveRepeatedByte(s string, needRemoveByte byte) string {
@@ -198,6 +198,7 @@ func RemoveRepeatedByte(s string, needRemoveByte byte) string {
 	return out.String()
 }
 
+// NextNumberPowerOf2 return the number of power of 2
 // Via: https://stackoverflow.com/a/466242/1705845
 //      https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
 func NextNumberPowerOf2(v uint64) uint64 {
@@ -212,11 +213,11 @@ func NextNumberPowerOf2(v uint64) uint64 {
 	return v
 }
 
-// safe characters for friendly url, rfc3986 section 2.3
-var URL_FRIENDLY_CHARACTERS_REGEX = regexp.MustCompile(`^[A-Za-z0-9\-_\.~]{1,253}$`)
+// URLFriendlyCharactersRegex - safe characters for friendly url, rfc3986 section 2.3
+var URLFriendlyCharactersRegex = regexp.MustCompile(`^[A-Za-z0-9\-_\.~]{1,253}$`)
 
 func ValidateName(name string) error {
-	if !URL_FRIENDLY_CHARACTERS_REGEX.Match([]byte(name)) {
+	if !URLFriendlyCharactersRegex.Match([]byte(name)) {
 		return fmt.Errorf("invalid constant: %s", name)
 	}
 

--- a/pkg/filter/canary/matcher.go
+++ b/pkg/filter/canary/matcher.go
@@ -430,7 +430,7 @@ func (p *parser) getSourceKey() (string, error) {
 	if p.conditions[p.offset] != '.' {
 		return "", errors.New("illegal key")
 	}
-	p.offset += 1
+	p.offset++
 	return p.pop(), nil
 }
 

--- a/pkg/filter/ratelimiter/ratelimiter.go
+++ b/pkg/filter/ratelimiter/ratelimiter.go
@@ -51,7 +51,7 @@ type (
 		LimitForPeriod     int    `yaml:"limitForPeriod" jsonschema:"omitempty,minimum=1"`
 	}
 
-	// RateLimiterURLRule defines the rate limiter rule for a URL pattern
+	// URLRule defines the rate limiter rule for a URL pattern
 	URLRule struct {
 		urlrule.URLRule `yaml:",inline"`
 		policy          *Policy

--- a/pkg/object/function/provider/provider.go
+++ b/pkg/object/function/provider/provider.go
@@ -107,7 +107,7 @@ func (kc *knativeClient) Delete(name string) error {
 	return kc.deleteService(name)
 }
 
-// NewProviderClient returns FaaSProvider client. It only supports Knative now.
+// NewProvider returns FaaSProvider client. It only supports Knative now.
 func NewProvider(superSpec *supervisor.Spec) FaaSProvider {
 	return &knativeClient{
 		superSpec: superSpec,

--- a/pkg/object/function/spec/fsm.go
+++ b/pkg/object/function/spec/fsm.go
@@ -22,7 +22,7 @@ import (
 )
 
 type (
-	// functionFSM is a finite state machine for managing faas function.
+	// FSM function is a finite state machine for managing faas function.
 	FSM struct {
 		currentState State
 	}
@@ -43,15 +43,17 @@ type (
 
 const (
 	// State value of FaaSFunction
+
 	FailedState   State = "failed"
 	InitialState  State = "initial"
 	ActiveState   State = "active"
 	InactiveState State = "inactive"
 
-	// only for keep fsm working
+	// DestroyedState - only for keep fsm working
 	DestroyedState State = "destroyed"
 
 	// Function event invoked by APIs.
+
 	CreateEvent Event = "create"
 	StartEvent  Event = "start"
 	StopEvent   Event = "stop"
@@ -59,6 +61,7 @@ const (
 	DeleteEvent Event = "delete"
 
 	// Function Event invoked by FaaSProvider
+
 	ReadyEvent   Event = "ready"
 	PendingEvent Event = "pending"
 	ErrorEvent   Event = "error"

--- a/pkg/object/function/storage/storage.go
+++ b/pkg/object/function/storage/storage.go
@@ -63,7 +63,7 @@ type (
 	}
 )
 
-// New creates a storage.
+// NewStorage creates a storage.
 func NewStorage(name string, cls cluster.Cluster) Storage {
 	cs := &clusterStorage{
 		name: name,
@@ -156,7 +156,7 @@ func (cs *clusterStorage) Syncer() (*cluster.Syncer, error) {
 	return cs.cls.Syncer(time.Minute)
 }
 
-// GetFunctionStatePrefix returns the prefix of one function statues.
+// GetFunctionStatusPrefix returns the prefix of one function statues.
 func GetFunctionStatusPrefix(controllerName, functionName string) string {
 	return fmt.Sprintf(functionStatusPrefix, controllerName, functionName)
 }

--- a/pkg/object/function/worker/worker.go
+++ b/pkg/object/function/worker/worker.go
@@ -49,7 +49,7 @@ type (
 	}
 )
 
-// newWorker return a worker
+// NewWorker return a worker
 func NewWorker(superSpec *supervisor.Spec) *Worker {
 	store := storage.NewStorage(superSpec.Name(), superSpec.Super().Cluster())
 	faasProvider := provider.NewProvider(superSpec)

--- a/pkg/object/ingresscontroller/ingresscontroller.go
+++ b/pkg/object/ingresscontroller/ingresscontroller.go
@@ -42,7 +42,7 @@ type (
 	IngressController struct {
 		super     *supervisor.Supervisor
 		superSpec *supervisor.Spec
-		spec      *IngressControllerSpec
+		spec      *Spec
 
 		tc        *trafficcontroller.TrafficController
 		namespace string
@@ -52,7 +52,7 @@ type (
 		wg     sync.WaitGroup
 	}
 
-	IngressControllerSpec struct {
+	Spec struct {
 		HTTPServer   *httpserver.Spec `yaml:"httpServer" jsonschema:"required"`
 		KubeConfig   string           `yaml:"kubeConfig" jsonschema:"omitempty"`
 		MasterURL    string           `yaml:"masterURL" jsonschema:"omitempty"`
@@ -77,7 +77,7 @@ func (ic *IngressController) Kind() string {
 
 // DefaultSpec returns the default spec of IngressController.
 func (ic *IngressController) DefaultSpec() interface{} {
-	return &IngressControllerSpec{
+	return &Spec{
 		HTTPServer: &httpserver.Spec{
 			KeepAlive:        true,
 			KeepAliveTimeout: "60s",
@@ -90,7 +90,7 @@ func (ic *IngressController) DefaultSpec() interface{} {
 // Init initializes IngressController.
 func (ic *IngressController) Init(superSpec *supervisor.Spec) {
 	ic.superSpec = superSpec
-	ic.spec = superSpec.ObjectSpec().(*IngressControllerSpec)
+	ic.spec = superSpec.ObjectSpec().(*Spec)
 	ic.super = superSpec.Super()
 	ic.reload()
 }

--- a/pkg/object/ingresscontroller/translator.go
+++ b/pkg/object/ingresscontroller/translator.go
@@ -165,15 +165,15 @@ func (st *specTranslator) getEndpoints(namespace string, service *apinetv1.Ingre
 	if svcPort == nil {
 		return nil, fmt.Errorf("service port in service %s/%s", namespace, service.Name)
 	}
-	protocal := "http"
+	protocol := "http"
 	if svcPort.Port == 443 {
-		protocal = "https"
+		protocol = "https"
 	}
 
 	var result []string
 	if svc.Spec.Type == apicorev1.ServiceTypeExternalName {
 		hostPort := net.JoinHostPort(svc.Spec.ExternalName, strconv.Itoa(int(svcPort.Port)))
-		ep := fmt.Sprintf("%s://%s", protocal, hostPort)
+		ep := fmt.Sprintf("%s://%s", protocol, hostPort)
 		result = append(result, ep)
 		return result, nil
 	}
@@ -196,7 +196,7 @@ func (st *specTranslator) getEndpoints(namespace string, service *apinetv1.Ingre
 
 		for _, addr := range subset.Addresses {
 			hostPort := net.JoinHostPort(addr.IP, strconv.Itoa(int(port)))
-			ep := fmt.Sprintf("%s://%s", protocal, hostPort)
+			ep := fmt.Sprintf("%s://%s", protocol, hostPort)
 			result = append(result, ep)
 		}
 	}

--- a/pkg/object/meshcontroller/api/api_service.go
+++ b/pkg/object/meshcontroller/api/api_service.go
@@ -39,7 +39,7 @@ func (s servicesByOrder) Less(i, j int) bool { return s[i].Name < s[j].Name }
 func (s servicesByOrder) Len() int           { return len(s) }
 func (s servicesByOrder) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 
-func (m *API) readServiceName(w http.ResponseWriter, r *http.Request) (string, error) {
+func (a *API) readServiceName(w http.ResponseWriter, r *http.Request) (string, error) {
 	serviceName := chi.URLParam(r, "serviceName")
 	if serviceName == "" {
 		return "", fmt.Errorf("empty service name")

--- a/pkg/object/meshcontroller/api/api_serviceinstance.go
+++ b/pkg/object/meshcontroller/api/api_serviceinstance.go
@@ -39,7 +39,7 @@ func (s serviceInstancesByOrder) Less(i, j int) bool {
 func (s serviceInstancesByOrder) Len() int      { return len(s) }
 func (s serviceInstancesByOrder) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 
-func (m *API) readServiceInstanceInfo(w http.ResponseWriter, r *http.Request) (string, string, error) {
+func (a *API) readServiceInstanceInfo(w http.ResponseWriter, r *http.Request) (string, string, error) {
 	serviceName := chi.URLParam(r, "serviceName")
 	if serviceName == "" {
 		return "", "", fmt.Errorf("empty service name")

--- a/pkg/object/meshcontroller/informer/informer.go
+++ b/pkg/object/meshcontroller/informer/informer.go
@@ -79,13 +79,13 @@ type (
 	// ServiceSpecFunc is the callback function type for service spec.
 	ServiceSpecFunc func(event Event, serviceSpec *spec.Service) bool
 
-	// ServiceSpecFunc is the callback function type for service specs.
+	// ServiceSpecsFunc is the callback function type for service specs.
 	ServiceSpecsFunc func(value map[string]*spec.Service) bool
 
-	// ServiceInstanceSpecFunc is the callback function type for service instance spec.
+	// ServicesInstanceSpecFunc is the callback function type for service instance spec.
 	ServicesInstanceSpecFunc func(event Event, instanceSpec *spec.ServiceInstanceSpec) bool
 
-	// ServiceInstanceSpecFunc is the callback function type for service instance specs.
+	// ServiceInstanceSpecsFunc is the callback function type for service instance specs.
 	ServiceInstanceSpecsFunc func(value map[string]*spec.ServiceInstanceSpec) bool
 
 	// ServiceInstanceStatusFunc is the callback function type for service instance status.
@@ -103,7 +103,7 @@ type (
 	// IngressSpecFunc is the callback function type for service spec.
 	IngressSpecFunc func(event Event, ingressSpec *spec.Ingress) bool
 
-	// IngressSpecFunc is the callback function type for service specs.
+	// IngressSpecsFunc is the callback function type for service specs.
 	IngressSpecsFunc func(value map[string]*spec.Ingress) bool
 
 	// Informer is the interface for informing two type of storage changed for every Mesh spec structure.

--- a/pkg/object/meshcontroller/registrycenter/discovery.go
+++ b/pkg/object/meshcontroller/registrycenter/discovery.go
@@ -171,14 +171,14 @@ func (rcs *Server) Discovery() ([]*ServiceRegistryInfo, error) {
 		}
 	}
 
-	if tenant, ok := tenantInfos[rcs.tenant]; !ok {
+	tenant, ok := tenantInfos[rcs.tenant]
+	if !ok {
 		err = fmt.Errorf("BUG: can't find service: %s's registry tenant: %s", rcs.serviceName, rcs.tenant)
 		logger.Errorf("%v", err)
 		return serviceInfos, err
-	} else {
-		if tenant.info.Version > version {
-			version = tenant.info.Version
-		}
+	}
+	if tenant.info.Version > version {
+		version = tenant.info.Version
 	}
 
 	for _, v := range tenantInfos[rcs.tenant].tenant.Services {

--- a/pkg/object/meshcontroller/service/service.go
+++ b/pkg/object/meshcontroller/service/service.go
@@ -60,7 +60,7 @@ func (s *Service) Lock() {
 	}
 }
 
-// Unlock - unlocks all store, it will do cluster panic if failed.
+// Unlock unlocks all store, it will do cluster panic if failed.
 func (s *Service) Unlock() {
 	err := s.store.Unlock()
 	if err != nil {

--- a/pkg/object/meshcontroller/service/service.go
+++ b/pkg/object/meshcontroller/service/service.go
@@ -52,7 +52,7 @@ func New(superSpec *supervisor.Spec) *Service {
 	return s
 }
 
-// Lock - locks all store, it will do cluster panic if failed.
+// Lock locks all store, it will do cluster panic if failed.
 func (s *Service) Lock() {
 	err := s.store.Lock()
 	if err != nil {

--- a/pkg/object/meshcontroller/service/service.go
+++ b/pkg/object/meshcontroller/service/service.go
@@ -52,7 +52,7 @@ func New(superSpec *supervisor.Spec) *Service {
 	return s
 }
 
-// Lock locks all store, it will do cluster panic if failed.
+// Lock - locks all store, it will do cluster panic if failed.
 func (s *Service) Lock() {
 	err := s.store.Lock()
 	if err != nil {
@@ -60,7 +60,7 @@ func (s *Service) Lock() {
 	}
 }
 
-// Lock unlocks all store, it will do cluster panic if failed.
+// Unlock - unlocks all store, it will do cluster panic if failed.
 func (s *Service) Unlock() {
 	err := s.store.Unlock()
 	if err != nil {

--- a/pkg/object/meshcontroller/spec/spec.go
+++ b/pkg/object/meshcontroller/spec/spec.go
@@ -123,7 +123,7 @@ type (
 		URLs                  []*urlrule.URLRule              `yaml:"urls" jsonschema:"required"`
 	}
 
-	// GlobalCanaryLabels is the spec of global service
+	// GlobalCanaryHeaders is the spec of global service
 	GlobalCanaryHeaders struct {
 		ServiceHeaders map[string][]string `yaml:"serviceHeaders" jsonschema:"omitempty"`
 	}

--- a/pkg/object/meshcontroller/worker/api.go
+++ b/pkg/object/meshcontroller/worker/api.go
@@ -46,7 +46,7 @@ func (worker *Worker) runAPIServer() {
 	worker.apiServer.registerAPIs(apis)
 }
 
-func (wrk *Worker) emptyHandler(w http.ResponseWriter, r *http.Request) {
+func (worker *Worker) emptyHandler(w http.ResponseWriter, r *http.Request) {
 	// EaseMesh does not need to implement some APIS like
 	// delete, heartbeat of Eureka/Consul/Nacos.
 }

--- a/pkg/object/meshcontroller/worker/worker.go
+++ b/pkg/object/meshcontroller/worker/worker.go
@@ -170,9 +170,8 @@ func (worker *Worker) run() {
 	if len(worker.serviceName) == 0 {
 		logger.Errorf("mesh service name is empty")
 		return
-	} else {
-		logger.Infof("%s works for service %s", worker.serviceName)
 	}
+	logger.Infof("%s works for service %s", worker.serviceName)
 
 	_, err = url.ParseRequestURI(worker.aliveProbe)
 	if err != nil {

--- a/pkg/object/trafficcontroller/trafficcontroller.go
+++ b/pkg/object/trafficcontroller/trafficcontroller.go
@@ -59,7 +59,7 @@ type (
 		httppipelines sync.Map
 	}
 
-	// WalkHTTPServerFunc is the type of the function called for
+	// WalkFunc is the type of the function called for
 	// walking http server and http pipeline.
 	WalkFunc = supervisor.WalkFunc
 
@@ -100,7 +100,7 @@ func newNamespace(namespace string) *Namespace {
 	}
 }
 
-// Space gets handler within the namspace of it.
+// GetHandler - Space gets handler within the namspace of it.
 func (ns *Namespace) GetHandler(name string) (protocol.HTTPHandler, bool) {
 	entity, exists := ns.httppipelines.Load(name)
 	if !exists {

--- a/pkg/object/trafficcontroller/trafficcontroller.go
+++ b/pkg/object/trafficcontroller/trafficcontroller.go
@@ -100,7 +100,7 @@ func newNamespace(namespace string) *Namespace {
 	}
 }
 
-// GetHandler - Space gets handler within the namspace of it.
+// GetHandler gets handler within the namespace
 func (ns *Namespace) GetHandler(name string) (protocol.HTTPHandler, bool) {
 	entity, exists := ns.httppipelines.Load(name)
 	if !exists {

--- a/pkg/supervisor/spec.go
+++ b/pkg/supervisor/spec.go
@@ -66,12 +66,12 @@ func NewSpec(yamlConfig string) (*Spec, error) {
 }
 
 // NewSpec creates a spec and validates it.
-func (super *Supervisor) NewSpec(yamlConfig string) (s *Spec, err error) {
-	s = &Spec{super: super}
+func (s *Supervisor) NewSpec(yamlConfig string) (spec *Spec, err error) {
+	spec = &Spec{super: s}
 
 	defer func() {
 		if r := recover(); r != nil {
-			s = nil
+			spec = nil
 			err = fmt.Errorf("%v", r)
 		} else {
 			err = nil
@@ -110,10 +110,10 @@ func (super *Supervisor) NewSpec(yamlConfig string) (s *Spec, err error) {
 
 	yamlConfig = string(yamltool.Marshal(rawSpec))
 
-	s.meta = meta
-	s.objectSpec = objectSpec
-	s.rawSpec = rawSpec
-	s.yamlConfig = yamlConfig
+	spec.meta = meta
+	spec.objectSpec = objectSpec
+	spec.rawSpec = rawSpec
+	spec.yamlConfig = yamlConfig
 
 	return
 }

--- a/pkg/supervisor/supervisor.go
+++ b/pkg/supervisor/supervisor.go
@@ -179,7 +179,7 @@ func (s *Supervisor) ObjectRegistry() *ObjectRegistry {
 	return s.objectRegistry
 }
 
-// WalkObjectEntitys walks every controllers until walkFn returns false.
+// WalkControllers walks every controllers until walkFn returns false.
 func (s *Supervisor) WalkControllers(walkFn WalkFunc) {
 	defer func() {
 		if err := recover(); err != nil {
@@ -197,7 +197,7 @@ func (s *Supervisor) WalkControllers(walkFn WalkFunc) {
 	})
 }
 
-// GetObjectEntity returns the system controller with the existing flag.
+// GetSystemController returns the system controller with the existing flag.
 // The name of system controller is its own kind.
 func (s *Supervisor) GetSystemController(name string) (*ObjectEntity, bool) {
 	entity, exists := s.systemControllers.Load(name)
@@ -207,7 +207,7 @@ func (s *Supervisor) GetSystemController(name string) (*ObjectEntity, bool) {
 	return entity.(*ObjectEntity), true
 }
 
-// GetObjectEntity returns the business controller with the existing flag.
+// GetBusinessController returns the business controller with the existing flag.
 func (s *Supervisor) GetBusinessController(name string) (*ObjectEntity, bool) {
 	entity, exists := s.businessControllers.Load(name)
 	if !exists {

--- a/pkg/util/httpheader/httpheader.go
+++ b/pkg/util/httpheader/httpheader.go
@@ -159,9 +159,8 @@ func renderTemplate(input string, te texttemplate.TemplateEngine) (output string
 		if err != nil {
 			logger.Errorf("BUG, render header value %s failed err %v", input, err)
 			return
-		} else {
-			ok = true
 		}
+		ok = true
 	}
 	return
 }

--- a/pkg/util/jmxtool/agent_controller.go
+++ b/pkg/util/jmxtool/agent_controller.go
@@ -42,7 +42,7 @@ type AgentInterface interface {
 
 type AgentClient struct {
 	URL        string
-	HttpClient *http.Client
+	HTTPClient *http.Client
 }
 
 func NewAgentClient(host, port string) *AgentClient {
@@ -61,7 +61,7 @@ func (agent *AgentClient) UpdateService(newService *spec.Service, version int64)
 	if err != nil {
 		return fmt.Errorf("convert yaml %s to json failed: %v", buff, err)
 	}
-	kvMap, err := JsonToKVMap(string(jsonBytes))
+	kvMap, err := JSONToKVMap(string(jsonBytes))
 	kvMap["version"] = strconv.FormatInt(version, 10)
 
 	bytes, err := json.Marshal(kvMap)
@@ -84,7 +84,7 @@ func (agent *AgentClient) UpdateCanary(globalHeaders *spec.GlobalCanaryHeaders, 
 	if err != nil {
 		return fmt.Errorf("convert yaml %s to json failed: %v", buff, err)
 	}
-	kvMap, err := JsonToKVMap(string(jsonBytes))
+	kvMap, err := JSONToKVMap(string(jsonBytes))
 	kvMap["version"] = strconv.FormatInt(version, 10)
 
 	bytes, err := json.Marshal(kvMap)

--- a/pkg/util/jmxtool/common.go
+++ b/pkg/util/jmxtool/common.go
@@ -29,7 +29,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-func JsonToKVMap(jsonStr string) (map[string]string, error) {
+func JSONToKVMap(jsonStr string) (map[string]string, error) {
 	m := map[string]interface{}{}
 	err := json.Unmarshal([]byte(jsonStr), &m)
 	if err != nil {
@@ -83,9 +83,9 @@ func extractKVs(prefix string, obj interface{}) []map[string]string {
 func join(prefix string, current string) string {
 	if prefix == "" {
 		return current
-	} else {
-		return strings.Join([]string{prefix, current}, ".")
 	}
+	return strings.Join([]string{prefix, current}, ".")
+
 }
 
 type APIErr struct {

--- a/pkg/util/jmxtool/jmx_controller.go
+++ b/pkg/util/jmxtool/jmx_controller.go
@@ -86,7 +86,7 @@ type (
 
 	JolokiaClient struct {
 		URL        string
-		HttpClient *http.Client
+		HTTPClient *http.Client
 	}
 )
 
@@ -107,7 +107,7 @@ func (client *JolokiaClient) handleRequest(requestBody []byte) (*JolokiaResponse
 		return nil, err
 	}
 	request.Header.Set("Content-Type", "application/json")
-	response, err := client.HttpClient.Do(request)
+	response, err := client.HTTPClient.Do(request)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/jmxtool/jmx_controller_test.go
+++ b/pkg/util/jmxtool/jmx_controller_test.go
@@ -183,7 +183,7 @@ func TestSpecTransform(t *testing.T) {
 		fmt.Println(err)
 	}
 
-	kvMap, err := JsonToKVMap(string(jsonBytes))
+	kvMap, err := JSONToKVMap(string(jsonBytes))
 	for k, v := range kvMap {
 		fmt.Println(k, v)
 	}

--- a/pkg/util/sem/semaphore_test.go
+++ b/pkg/util/sem/semaphore_test.go
@@ -54,7 +54,7 @@ func TestSemaphoreChangeAtRuntime(t *testing.T) {
 func runCase(s *Semaphore, maxCount int64, t *testing.T) {
 	// step 0, change max count at runtime
 	done := s.SetMaxCount(maxCount)
-	<- done
+	<-done
 
 	// step 1, try to acquire max count, should be OK
 	wg := &sync.WaitGroup{}

--- a/pkg/util/signer/signer.go
+++ b/pkg/util/signer/signer.go
@@ -689,11 +689,11 @@ func (ctx *SigningContext) initFromQuery(req *http.Request) error {
 	}
 
 	str = ctx.Query.Get(ctx.literal.Expires)
-	if v, e := strconv.ParseUint(str, 0, 64); e != nil {
+	v, e := strconv.ParseUint(str, 0, 64)
+	if e != nil {
 		return fmt.Errorf(invalidQuery, ctx.literal.Expires)
-	} else {
-		ctx.ExpireTime = time.Duration(v) * time.Second
 	}
+	ctx.ExpireTime = time.Duration(v) * time.Second
 
 	ctx.SignedHeaders = ctx.Query.Get(ctx.literal.SignedHeaders)
 	ctx.Signature = ctx.Query.Get(ctx.literal.Signature)

--- a/pkg/util/texttemplate/texttemplate.go
+++ b/pkg/util/texttemplate/texttemplate.go
@@ -96,7 +96,7 @@ func (DummyTemplate) ExtractTemplateRuleMap(input string) map[string]string {
 	return m
 }
 
-// ExtractTemplateRuleMap dummy implement
+// ExtractRawTemplateRuleMap dummy implement
 func (DummyTemplate) ExtractRawTemplateRuleMap(input string) map[string]string {
 	m := make(map[string]string, 0)
 	return m

--- a/pkg/v/v.go
+++ b/pkg/v/v.go
@@ -61,7 +61,7 @@ var (
 		//   }
 		// }
 		// FIXME if necessary:
-		// The $ref can't find it becasue the slash means a level in json schema.
+		// The $ref can't find it because the slash means a level in json schema.
 		// We can fix it by replace all slashes by `.` or `-`, etc in github.com/alecthomas/jsonschema.
 	}
 	schemaMetasMutex = sync.Mutex{}


### PR DESCRIPTION
major fix the following golint warnings:

- The incorrect comments
- Convert ALL_CAPS variable name to Camels style
- Inconsistent of receiver name
- Stuttering struct name - `IngressController.IngressControllerSpec` -> `IngressController.Spec`
- If block ends with a return statement, so drop this else and outdent its block. Refer to golang/lint#17
- Typo of the variable name. `protocal` -> `protocol`
- Rename some variables. `HttpClient`  -> `HTTPClient`,  `JsonToKVMap` -> `JSONToKVMap`
