### PR TITLE
fix compile error

### DIFF
--- a/pkg/api/wasm.go
+++ b/pkg/api/wasm.go
@@ -34,8 +34,8 @@ func (s *Server) postWasmCodeUpdateEvent() string {
 	return value
 }
 
-func appendWasmAPI(s *Server, group *APIGroup) {
-	entry := &APIEntry{
+func appendWasmAPI(s *Server, group *Group) {
+	entry := &Entry{
 		Path:   "/wasm/code",
 		Method: "POST",
 		Handler: func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
APIGroup and APIEntry were renamed to Group and Entry, but some of their usages haven't been updated simultaneously.