### PR TITLE
[mesh] fix initTrafficGate panic when service not found

### DIFF
--- a/pkg/object/meshcontroller/worker/worker.go
+++ b/pkg/object/meshcontroller/worker/worker.go
@@ -305,6 +305,10 @@ func (worker *Worker) pushSpecToJavaAgent() {
 
 func (worker *Worker) initTrafficGate() error {
 	service := worker.service.GetServiceSpec(worker.serviceName)
+	if service == nil {
+		logger.Errorf("gets service: %s failed: not found", worker.serviceName)
+		return spec.ErrServiceNotFound
+	}
 
 	if err := worker.ingressServer.InitIngress(service, worker.applicationPort); err != nil {
 		return fmt.Errorf("create ingress for service: %s failed: %v", worker.serviceName, err)

--- a/pkg/object/meshcontroller/worker/worker.go
+++ b/pkg/object/meshcontroller/worker/worker.go
@@ -306,7 +306,7 @@ func (worker *Worker) pushSpecToJavaAgent() {
 func (worker *Worker) initTrafficGate() error {
 	service := worker.service.GetServiceSpec(worker.serviceName)
 	if service == nil {
-		logger.Errorf("gets service: %s failed: not found", worker.serviceName)
+		logger.Errorf("service %s not found", worker.serviceName)
 		return spec.ErrServiceNotFound
 	}
 


### PR DESCRIPTION
* When Sidecar is deployed and there is not such mesh service in the system, the initTrafficGate routine will panic due to the missing judgment of the nill pointer. 

``` bash
2021-07-24T09:32:04.611Z	ERROR	worker/worker.go:232	easemesh-controller: recover from: runtime error: invalid memory address or nil pointer dereference, stack trace:
goroutine 242 [running]:
runtime/debug.Stack(0xc000ccbb08, 0x24cd940, 0x3e2b860)
	runtime/debug/stack.go:24 +0x9f
github.com/megaease/easegress/pkg/object/meshcontroller/worker.(*Worker).heartbeat.func1.1(0xc00084e1a0)
	github.com/megaease/easegress/pkg/object/meshcontroller/worker/worker.go:233 +0x9a
panic(0x24cd940, 0x3e2b860)
	runtime/panic.go:965 +0x1b9
github.com/megaease/easegress/pkg/object/meshcontroller/spec.(*Service).IngressPipelineName(...)
	github.com/megaease/easegress/pkg/object/meshcontroller/spec/spec.go:591
github.com/megaease/easegress/pkg/object/meshcontroller/worker.(*IngressServer).InitIngress(0xc000036000, 0x0, 0x2328, 0x0, 0x0)
	github.com/megaease/easegress/pkg/object/meshcontroller/worker/ingress.go:99 +0xb2
github.com/megaease/easegress/pkg/object/meshcontroller/worker.(*Worker).initTrafficGate(0xc00084e1a0, 0x0, 0xc000c82dc0)
	github.com/megaease/easegress/pkg/object/meshcontroller/worker/worker.go:310 +0x79
github.com/megaease/easegress/pkg/object/meshcontroller/worker.(*Worker).heartbeat.func1()
	github.com/megaease/easegress/pkg/object/meshcontroller/worker/worker.go:238 +0x1dd
github.com/megaease/easegress/pkg/object/meshcontroller/worker.(*Worker).heartbeat(0xc00084e1a0)
	github.com/megaease/easegress/pkg/object/meshcontroller/worker/worker.go:268 +0x8e
created by github.com/megaease/easegress/pkg/object/meshcontroller/worker.(*Worker).run
	github.com/megaease/easegress/pkg/object/meshcontroller/worker/worker.go:222 +0x1f9
```