### PR TITLE
[filter] refactor apiaggregator

### DIFF
--- a/pkg/context/httptemplate.go
+++ b/pkg/context/httptemplate.go
@@ -185,6 +185,9 @@ func NewHTTPTemplateDummy() *HTTPTemplate {
 
 func readBody(body io.Reader, maxBodySize int64) (*bytes.Buffer, error) {
 	buff := bytes.NewBuffer(nil)
+	if body == nil {
+		return buff, nil
+	}
 	written, err := io.CopyN(buff, body, defaultMaxBodySize+1)
 
 	if err != nil && err != io.EOF {

--- a/pkg/filter/apiaggregator/apiaggregator.go
+++ b/pkg/filter/apiaggregator/apiaggregator.go
@@ -52,7 +52,7 @@ func init() {
 }
 
 type (
-	// APIAggregator is a filter to combine several HTTP API responses together.
+	// APIAggregator is a filter to aggregate several HTTP API responses.
 	APIAggregator struct {
 		filterSpec *httppipeline.FilterSpec
 		spec       *Spec

--- a/pkg/filter/apiaggregator/apiaggregator.go
+++ b/pkg/filter/apiaggregator/apiaggregator.go
@@ -32,7 +32,7 @@ import (
 	"github.com/megaease/easegress/pkg/context"
 	"github.com/megaease/easegress/pkg/logger"
 	"github.com/megaease/easegress/pkg/object/httppipeline"
-	"github.com/megaease/easegress/pkg/protocol"
+	"github.com/megaease/easegress/pkg/object/rawconfigtrafficcontroller"
 	"github.com/megaease/easegress/pkg/tracing"
 	"github.com/megaease/easegress/pkg/util/httpheader"
 	"github.com/megaease/easegress/pkg/util/pathadaptor"
@@ -48,45 +48,56 @@ const (
 var results = []string{resultFailed}
 
 func init() {
-	// FIXME: Rewrite APIAggregator because the HTTPProxy is eliminated
-	// I(@xxx7xxxx) think we should not empower filter to cross pipelines.
-
-	// httppipeline.Register(&APIAggregator{})
+	httppipeline.Register(&APIAggregator{})
 }
 
 type (
-	// APIAggregator is the entity to complete rate limiting.
+	// APIAggregator is a filter to combine several HTTP API responses together.
 	APIAggregator struct {
 		filterSpec *httppipeline.FilterSpec
 		spec       *Spec
 
-		muxMapper protocol.MuxMapper
+		// rctc is for getting Pipeline in default namespace.
+		rctc *rawconfigtrafficcontroller.RawConfigTrafficController
 	}
 
-	// Spec describes APIAggregator.
+	// Spec is APIAggregator's spec.
 	Spec struct {
 		// MaxBodyBytes in [0, 10MB]
-		MaxBodyBytes   int64  `yaml:"maxBodyBytes" jsonschema:"omitempty,minimum=0,maximum=102400"`
-		PartialSucceed bool   `yaml:"partialSucceed"`
-		Timeout        string `yaml:"timeout" jsonschema:"omitempty,format=duration"`
-		MergeResponse  bool   `yaml:"mergeResponse"`
+		MaxBodyBytes int64 `yaml:"maxBodyBytes" jsonschema:"omitempty,minimum=0,maximum=102400"`
 
-		// User describes HTTP service target via an existing HTTPProxy
-		APIProxies []*APIProxy `yaml:"apiProxies" jsonschema:"required"`
+		// PartialSucceed indicates wether Whether regards the result of the original request as successful
+		// or not when a request to some of the API pipelines fails.
+		PartialSucceed bool `yaml:"partialSucceed"`
+
+		// Timeout is the request duration for each APIs.
+		Timeout string `yaml:"timeout" jsonschema:"omitempty,format=duration"`
+
+		// MergeResponse indicates whether to merge JSON response bodies or not.
+		MergeResponse bool `yaml:"mergeResponse"`
+
+		// User describes HTTP service target via an existing Pipeline.
+		Pipelines []*Pipeline `yaml:"pipelines" jsonschema:"required"`
 
 		timeout *time.Duration
 	}
 
-	// APIProxy describes the single API in EG's HTTPProxy object.
-	APIProxy struct {
-		// HTTPProxy's name in EG
-		HTTPProxyName string `yaml:"httpProxyName" jsonschema:"required"`
+	// Pipeline is the single API HTTP Pipeline in default namespace.
+	Pipeline struct {
+		// Name is the name of pipeline in EG
+		Name string `yaml:"name" jsonschema:"required"`
 
-		// Describes details about the request-target
-		Method      string                `yaml:"method" jsonschema:"omitempty,format=httpmethod"`
-		Path        *pathadaptor.Spec     `yaml:"path,omitempty" jsonschema:"omitempty"`
-		Header      *httpheader.AdaptSpec `yaml:"header,omitempty" jsonschema:"omitempty"`
-		DisableBody bool                  `yaml:"disableBody" jsonschema:"omitempty"`
+		// Method is the HTTP method for requesting this pipeline.
+		Method string `yaml:"method" jsonschema:"omitempty,format=httpmethod"`
+
+		// Path is the HTTP request path adaptor for requesting this pipeline.
+		Path *pathadaptor.Spec `yaml:"path,omitempty" jsonschema:"omitempty"`
+
+		// Header is the HTTP header adaptor for requestring this pipeline.
+		Header *httpheader.AdaptSpec `yaml:"header,omitempty" jsonschema:"omitempty"`
+
+		// DisableBody discart this pipeline's response body if it set to true.
+		DisableBody bool `yaml:"disableBody" jsonschema:"omitempty"`
 
 		pa *pathadaptor.PathAdaptor
 	}
@@ -118,6 +129,16 @@ func (aa *APIAggregator) Results() []string {
 // Init initializes APIAggregator.
 func (aa *APIAggregator) Init(filterSpec *httppipeline.FilterSpec) {
 	aa.filterSpec, aa.spec = filterSpec, filterSpec.FilterSpec().(*Spec)
+	entity, exists := filterSpec.Super().GetSystemController(rawconfigtrafficcontroller.Kind)
+	if !exists {
+		panic(fmt.Errorf("BUG: raw config traffic controller not found"))
+	}
+
+	rctc, ok := entity.Instance().(*rawconfigtrafficcontroller.RawConfigTrafficController)
+	if !ok {
+		panic(fmt.Errorf("BUG: want *RawConfigTrafficController, got %T", entity.Instance()))
+	}
+	aa.rctc = rctc
 	aa.reload()
 }
 
@@ -138,9 +159,9 @@ func (aa *APIAggregator) reload() {
 		}
 	}
 
-	for _, proxy := range aa.spec.APIProxies {
-		if proxy.Path != nil {
-			proxy.pa = pathadaptor.New(proxy.Path)
+	for _, p := range aa.spec.Pipelines {
+		if p.Path != nil {
+			p.pa = pathadaptor.New(p.Path)
 		}
 	}
 }
@@ -149,11 +170,6 @@ func (aa *APIAggregator) reload() {
 func (aa *APIAggregator) Handle(ctx context.HTTPContext) (result string) {
 	result = aa.handle(ctx)
 	return ctx.CallNextHandler(result)
-}
-
-// InjectMuxMapper injects mux mapper into APIAggregator.
-func (aa *APIAggregator) InjectMuxMapper(mapper protocol.MuxMapper) {
-	aa.muxMapper = mapper
 }
 
 func (aa *APIAggregator) handle(ctx context.HTTPContext) (result string) {
@@ -173,39 +189,41 @@ func (aa *APIAggregator) handle(ctx context.HTTPContext) (result string) {
 	}
 
 	wg := &sync.WaitGroup{}
-	wg.Add(len(aa.spec.APIProxies))
+	wg.Add(len(aa.spec.Pipelines))
 
-	httpResps := make([]context.HTTPResponse, len(aa.spec.APIProxies))
-	for i, proxy := range aa.spec.APIProxies {
-		req, err := aa.newHTTPReq(ctx, proxy, buff)
+	httpRsps := make([]context.HTTPResponse, len(aa.spec.Pipelines))
+	for i, p := range aa.spec.Pipelines {
+		req, err := aa.newHTTPReq(ctx, p, buff)
 		if err != nil {
-			logger.Errorf("BUG: new HTTPProxy request failed %v proxyname[%d]", err, aa.spec.APIProxies[i].HTTPProxyName)
+			logger.Errorf("BUG: new HTTP request failed: %v, pipelinename: %s", err, aa.spec.Pipelines[i].Name)
 			ctx.Response().SetStatusCode(http.StatusBadRequest)
 			return resultFailed
 		}
 
 		go func(i int, name string, req *http.Request) {
 			defer wg.Done()
-			copyCtx, err := aa.newCtx(ctx, req, buff)
-			if err != nil {
-				httpResps[i] = nil
-				return
-			}
-
-			handler, exists := aa.muxMapper.GetHandler(name)
-
+			handler, exists := aa.rctc.GetHTTPPipeline(name)
 			if !exists {
-				httpResps[i] = nil
+				logger.Errorf("pipeline: %s not found in default ns", name)
+				httpRsps[i] = nil
 			} else {
+				w := httptest.NewRecorder()
+				copyCtx := context.New(w, req, tracing.NoopTracing, "no trace")
 				handler.Handle(copyCtx)
-				httpResps[i] = copyCtx.Response()
+				rsp := copyCtx.Response()
+
+				if rsp != nil && rsp.StatusCode() == http.StatusOK {
+					httpRsps[i] = rsp
+				} else {
+					httpRsps[i] = nil
+				}
 			}
-		}(i, proxy.HTTPProxyName, req)
+		}(i, p.Name, req)
 	}
 
 	wg.Wait()
 
-	for _, resp := range httpResps {
+	for _, resp := range httpRsps {
 		_resp := resp
 
 		if resp != nil {
@@ -217,19 +235,17 @@ func (aa *APIAggregator) handle(ctx context.HTTPContext) (result string) {
 
 	data := make(map[string][]byte)
 
-	// Get all HTTPProxy response' body
-	for i, resp := range httpResps {
+	// Get all HTTPPipeline response' body
+	for i, resp := range httpRsps {
 		if resp == nil && !aa.spec.PartialSucceed {
-			ctx.AddTag(fmt.Sprintf("apiAggregator: failed in HTTPProxy %s",
-				aa.spec.APIProxies[i].HTTPProxyName))
+			ctx.Response().Std().Header().Set("X-EG-Aggregator", fmt.Sprintf("failed-in-%s",
+				aa.spec.Pipelines[i].Name))
 			ctx.Response().SetStatusCode(http.StatusServiceUnavailable)
 			return resultFailed
 		}
 
-		// call HTTPProxy could be successful even with a no exist backend
-		// so resp is not nil, but resp.Body() is nil.
 		if resp != nil && resp.Body() != nil {
-			if res := aa.copyHTTPBody2Map(resp.Body(), ctx, data, aa.spec.APIProxies[i].HTTPProxyName); len(res) != 0 {
+			if res := aa.copyHTTPBody2Map(resp.Body(), ctx, data, aa.spec.Pipelines[i].Name); len(res) != 0 {
 				return res
 			}
 		}
@@ -238,22 +254,7 @@ func (aa *APIAggregator) handle(ctx context.HTTPContext) (result string) {
 	return aa.formatResponse(ctx, data)
 }
 
-func (aa *APIAggregator) newCtx(ctx context.HTTPContext, req *http.Request, buff *bytes.Buffer) (context.HTTPContext, error) {
-	// Construct a new context for the HTTPProxy
-	// responseWriter is an HTTP responseRecorder, not the original context's real
-	// responseWriter, or these Proxies will overwrite each others
-	w := httptest.NewRecorder()
-	var stdctx stdcontext.Context = ctx
-	if aa.spec.timeout != nil {
-		stdctx, _ = stdcontext.WithTimeout(stdctx, *aa.spec.timeout)
-	}
-
-	copyCtx := context.New(w, req, tracing.NoopTracing, "no trace")
-
-	return copyCtx, nil
-}
-
-func (aa *APIAggregator) newHTTPReq(ctx context.HTTPContext, proxy *APIProxy, buff *bytes.Buffer) (*http.Request, error) {
+func (aa *APIAggregator) newHTTPReq(ctx context.HTTPContext, p *Pipeline, buff *bytes.Buffer) (*http.Request, error) {
 	var stdctx stdcontext.Context = ctx
 	if aa.spec.timeout != nil {
 		// NOTE: Cancel function could be omitted here.
@@ -261,17 +262,17 @@ func (aa *APIAggregator) newHTTPReq(ctx context.HTTPContext, proxy *APIProxy, bu
 	}
 
 	method := ctx.Request().Method()
-	if proxy.Method != "" {
-		method = proxy.Method
+	if p.Method != "" {
+		method = p.Method
 	}
 
 	url := ctx.Request().Std().URL
-	if proxy.pa != nil {
-		url.Path = proxy.pa.Adapt(url.Path)
+	if p.pa != nil {
+		url.Path = p.pa.Adapt(url.Path)
 	}
 
 	var body io.Reader
-	if !proxy.DisableBody {
+	if !p.DisableBody {
 		body = bytes.NewReader(buff.Bytes())
 	}
 

--- a/pkg/object/rawconfigtrafficcontroller/rawconfigtrafficcontroller.go
+++ b/pkg/object/rawconfigtrafficcontroller/rawconfigtrafficcontroller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/megaease/easegress/pkg/object/httppipeline"
 	"github.com/megaease/easegress/pkg/object/httpserver"
 	"github.com/megaease/easegress/pkg/object/trafficcontroller"
+	"github.com/megaease/easegress/pkg/protocol"
 	"github.com/megaease/easegress/pkg/supervisor"
 )
 
@@ -52,8 +53,7 @@ type (
 	}
 
 	// Spec describes RawConfigTrafficController.
-	Spec struct {
-	}
+	Spec struct{}
 
 	// Status is the status of RawConfigTrafficController.
 	Status = trafficcontroller.StatusInSameNamespace
@@ -88,6 +88,16 @@ func (rctc *RawConfigTrafficController) Init(superSpec *supervisor.Spec) {
 func (rctc *RawConfigTrafficController) Inherit(spec *supervisor.Spec, previousGeneration supervisor.Object) {
 	previousGeneration.Close()
 	rctc.Init(spec)
+}
+
+// GetHTTPPipeline gets Pipeline within the default namespace
+func (rctc *RawConfigTrafficController) GetHTTPPipeline(name string) (protocol.HTTPHandler, bool) {
+	p, exist := rctc.tc.GetHTTPPipeline(DefaultNamespace, name)
+	if !exist {
+		return nil, false
+	}
+	handler := p.Instance().(protocol.HTTPHandler)
+	return handler, true
 }
 
 func (rctc *RawConfigTrafficController) reload() {


### PR DESCRIPTION
For closing #149 
1. Adding `GetHTTPPipeline` into `RawConfigTrafficController`
2. Updating `APIAggregator` to use  `RawConfigTrafficController` for getting pipeline in default namespace.