### PR TITLE
add start script retry

### DIFF
--- a/example/sbin/start.sh
+++ b/example/sbin/start.sh
@@ -18,11 +18,17 @@ fi
 touch  $stdfile
 nohup $server "$@" --config-file $cfgfile   >> $stdfile 2>&1 &
 
-pid=`ps -eo pid,args | grep "$server" | grep -v grep | awk '{print $1}'`
-if [ "$pid" = "" ]; then
-    echo "Error: failed to start $sever"
-    exit 2
-fi
+try_time=0
+pid=""
+while [ "$pid" = "" ]
+do
+    sleep 3
+    pid=`ps -eo pid,args | grep "$server" | grep -v grep | awk '{print $1}'`
+    if [[ $try_time -ge 2 ]]; then
+        echo "Error: failed to start $sever"
+        exit 2
+    fi
+done
 
 popd > /dev/null
 

--- a/example/sbin/start.sh
+++ b/example/sbin/start.sh
@@ -23,6 +23,7 @@ pid=""
 while [ "$pid" = "" ]
 do
     sleep 3
+    try_time=$(($try_time+1))
     pid=`ps -eo pid,args | grep "$server" | grep -v grep | awk '{print $1}'`
     if [[ $try_time -ge 2 ]]; then
         echo "Error: failed to start $sever"


### PR DESCRIPTION
* Fixing Jenkins task `build/test/httpserver_test.sh` failure due to the Easegress process PID detection. 
``` bash
SSH: EXEC: STDOUT/STDERR from command [source ${HOME}/.profile; cd /home/ubuntu/prtest/easegress/build/test;  ./httpserver_test.sh] ...
SSH: EXEC: connected
stop writer-001
stop writer-002
stop writer-003
stop reader-004
stop reader-005
Error: failed to start 
SSH: EXEC: completed after 801 ms
SSH: Disconnecting configuration [km05

```

In the original start.sh script, it checks the PID immediately after starting an Easegress instance in the background. 
Add retry and `sleep 3` for a limited-resource environment. 