### PR TITLE
[bug] fix http template dict empty error

### DIFF
--- a/pkg/object/httppipeline/httppipeline.go
+++ b/pkg/object/httppipeline/httppipeline.go
@@ -444,16 +444,16 @@ func (hp *HTTPPipeline) Handle(ctx context.HTTPContext) {
 	filterStat := &FilterStat{}
 
 	handle := func(lastResult string) string {
-		// For saving the `filterIndex`'s filter generated HTTP Response
-		// Note! the sequence of pipeline is stack liked, we save the filter's response into template
-		//       at the beginning of the next filter.
+		// For saving the `filterIndex`'s filter generated HTTP Response.
+		// Note: the sequence of pipeline is stack-liked, we save the filter's response into template
+		// at the beginning of the next filter.
 		if filterIndex != -1 {
 			name := hp.runningFilters[filterIndex].spec.Name()
 			if err := ctx.SaveRspToTemplate(name); err != nil {
 				format := "save http rsp failed, dict is %#v err is %v"
 				logger.Errorf(format, ctx.Template().GetDict(), err)
 			}
-			logger.Debugf("filter name:%s, save rsp dict :%v", name, ctx.Template().GetDict())
+			logger.Debugf("filter %s, saved response dict %v", name, ctx.Template().GetDict())
 		}
 
 		// Filters are called recursively as a stack, so we need to save current
@@ -480,7 +480,7 @@ func (hp *HTTPPipeline) Handle(ctx context.HTTPContext) {
 			logger.Errorf(format, ctx.Template().GetDict(), err)
 		}
 
-		logger.Debugf("filter name:%s, save req dict :%v", name, ctx.Template().GetDict())
+		logger.Debugf("filter %s saved request dict %v", name, ctx.Template().GetDict())
 		filterStat = &FilterStat{Name: name, Kind: filter.spec.Kind()}
 
 		startTime := time.Now()

--- a/pkg/object/httppipeline/httppipeline.go
+++ b/pkg/object/httppipeline/httppipeline.go
@@ -489,10 +489,6 @@ func (hp *HTTPPipeline) Handle(ctx context.HTTPContext) {
 		filterStat.Duration = time.Since(startTime)
 		filterStat.Result = result
 
-		if err := ctx.SaveRspToTemplate(name); err != nil {
-			format := "save http rsp failed, dict is %#v err is %v"
-			logger.Errorf(format, ctx.Template().GetDict(), err)
-		}
 
 		lastStat.Next = append(lastStat.Next, filterStat)
 		return result

--- a/pkg/object/httppipeline/httppipeline.go
+++ b/pkg/object/httppipeline/httppipeline.go
@@ -444,6 +444,18 @@ func (hp *HTTPPipeline) Handle(ctx context.HTTPContext) {
 	filterStat := &FilterStat{}
 
 	handle := func(lastResult string) string {
+		// For saving the `filterIndex`'s filter generated HTTP Response
+		// Note! the sequence of pipeline is stack liked, we save the filter's response into template
+		//       at the beginning of the next filter.
+		if filterIndex != -1 {
+			name := hp.runningFilters[filterIndex].spec.Name()
+			if err := ctx.SaveRspToTemplate(name); err != nil {
+				format := "save http rsp failed, dict is %#v err is %v"
+				logger.Errorf(format, ctx.Template().GetDict(), err)
+			}
+			logger.Debugf("filter name:%s, save rsp dict :%v", name, ctx.Template().GetDict())
+		}
+
 		// Filters are called recursively as a stack, so we need to save current
 		// state and restore it before return
 		lastIndex := filterIndex
@@ -468,6 +480,7 @@ func (hp *HTTPPipeline) Handle(ctx context.HTTPContext) {
 			logger.Errorf(format, ctx.Template().GetDict(), err)
 		}
 
+		logger.Debugf("filter name:%s, save req dict :%v", name, ctx.Template().GetDict())
 		filterStat = &FilterStat{Name: name, Kind: filter.spec.Kind()}
 
 		startTime := time.Now()

--- a/pkg/object/httppipeline/httppipeline.go
+++ b/pkg/object/httppipeline/httppipeline.go
@@ -489,7 +489,6 @@ func (hp *HTTPPipeline) Handle(ctx context.HTTPContext) {
 		filterStat.Duration = time.Since(startTime)
 		filterStat.Result = result
 
-
 		lastStat.Next = append(lastStat.Next, filterStat)
 		return result
 	}


### PR DESCRIPTION
## Problem
1. HTTPTemplate doesn't work as expected in HTTPPipeline

## Details
* As the former design, `HTTPTempalte` will save one filter's request, and the response modified by it into context's template dictionary if necessary(If it can find the template in filter's spec), the flow is a sequence. That means the flow will look like

``` bash
1. save http request to be handle by filter1
2. fitler1 handle
3. save http response modified by filter1
4. save http request to be handle by filter2
5. filter2 handle
6. save http response modified by filter2
....

```
* After we introduced `responsibility chain` into HTTPPipline, the flow logic had been changed from `sequence` to `stack`. That means the flow looks like 

``` bash
1. save http request to be handle by filter1
2. filter1 handle
3. save http request to be handle by filter2
4. filter2 handle
5. save http response modified by filter2
6. save http response modified by filter1
....

```

* This bug fixing is aiming to correct the HTTPTemplate saving flow back to the sequence type.