### PR TITLE
[bug] fix interface nil convert panic

### DIFF
--- a/pkg/object/trafficcontroller/trafficcontroller.go
+++ b/pkg/object/trafficcontroller/trafficcontroller.go
@@ -546,6 +546,9 @@ func (tc *TrafficController) GetHTTPPipeline(namespace, name string) (*superviso
 	}
 
 	entity, exists := space.httppipelines.Load(name)
+	if !exists {
+		return nil, false
+	}
 
 	return entity.(*supervisor.ObjectEntity), exists
 }

--- a/pkg/object/trafficcontroller/trafficcontroller.go
+++ b/pkg/object/trafficcontroller/trafficcontroller.go
@@ -315,6 +315,9 @@ func (tc *TrafficController) GetHTTPServer(namespace, name string) (*supervisor.
 	}
 
 	entity, exists := space.httpservers.Load(name)
+	if !exists {
+		return nil, false
+	}
 
 	return entity.(*supervisor.ObjectEntity), exists
 }


### PR DESCRIPTION
It will cause an unrecovered panic if we are looking for a not exist pipeline by trafficcontroller.

``` bash
panic: interface conversion: interface {} is nil, not *supervisor.ObjectEntity

goroutine 1547 [running]:
github.com/megaease/easegress/pkg/object/trafficcontroller.(*TrafficController).GetHTTPPipeline(0xc01719c5d0, 0x34a9e04, 0x7, 0xc00dbb0430, 0xc, 0x0, 0x0)
        github.com/megaease/easegress/pkg/object/trafficcontroller/trafficcontroller.go:550 +0x1b9
github.com/megaease/easegress/pkg/object/rawconfigtrafficcontroller.(*RawConfigTrafficController).GetHTTPPipeline(0xc017ed6980, 0xc00dbb0430, 0xc, 0xc017eb1740, 0xc000052836, 0x38f4428)
        github.com/megaease/easegress/pkg/object/rawconfigtrafficcontroller/rawconfigtrafficcontroller.go:95 +0x5c
github.com/megaease/easegress/pkg/filter/apiaggregator.(*APIAggregator).handle.func1(0xc0177c79b0, 0xc00050b2d8, 0xc011e52570, 0x1, 0x1, 0x0, 0xc00dbb0430, 0xc, 0xc017324f00)
        github.com/megaease/easegress/pkg/filter/apiaggregator/apiaggregator.go:205 +0x92
created by github.com/megaease/easegress/pkg/filter/apiaggregator.(*APIAggregator).handle
        github.com/megaease/easegress/pkg/filter/apiaggregator/apiaggregator.go:203 +0x18d
cluster-join-urls [http://127.0.0.1:12380 http://127.0.0.1:22380 http://127.0.0.1:32380] changed to empty because it tries to join itself
```
