### PR TITLE
[build] change go image from alpine to 1.16-alpine

### DIFF
--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine AS builder
+FROM golang:1.16-alpine AS builder
 RUN apk --no-cache add make git
 
 WORKDIR /opt/easegress


### PR DESCRIPTION
* Easegress supports Golang version >= 1.16
* The original `go:alpine` image in Dockfile may be cached locally. That version miss-matched will cause some compile problems.