### PR TITLE
[build] rollback alpine:latest to 3.13 for stablebility

### DIFF
--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -8,7 +8,7 @@ RUN make clean && make build
 
 # ---
 
-FROM alpine:latest
+FROM alpine:3.13
 
 WORKDIR /opt/easegress
 

--- a/build/package/Dockerfile.goreleaser
+++ b/build/package/Dockerfile.goreleaser
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.13
 
 WORKDIR /opt/easegress
 


### PR DESCRIPTION
* In PR #45, the alpine's version in Dockerfile is changed from `3.13` to `latest` by following the community's suggestion.
* But sometimes `make build_docker` in Easegress can be failed due to the environment's docker image cache, or sometimes it's the latest version's `alpine`'s new BUG. If using a dedicated version, these situations can be avoided.
* For stability, we decide to roll back the dependent `alpine` version to `3.13`. 