### PR TITLE
improve egctl to support sending multi configs at once (fix #29)

### DIFF
--- a/cmd/client/command/common.go
+++ b/cmd/client/command/common.go
@@ -203,3 +203,20 @@ func readFromFileOrStdin(specFile string, cmd *cobra.Command, handler yamlHandle
 		handler(yamlDoc, spec.Name)
 	}
 }
+
+func buildVisitorFromFileOrStdin(specFile string, cmd *cobra.Command) Visitor {
+	var buff []byte
+	var err error
+	if specFile != "" {
+		buff, err = ioutil.ReadFile(specFile)
+		if err != nil {
+			ExitWithErrorf("%s failed: %v", cmd.Short, err)
+		}
+	} else {
+		buff, err = ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			ExitWithErrorf("%s failed: %v", cmd.Short, err)
+		}
+	}
+	return NewStreamVisitor(string(buff))
+}

--- a/cmd/client/command/common.go
+++ b/cmd/client/command/common.go
@@ -163,33 +163,6 @@ func printBody(body []byte) {
 	fmt.Printf("%s", output)
 }
 
-func readFromFileOrStdin(specFile string, cmd *cobra.Command) ([]byte, string) {
-	var buff []byte
-	var err error
-	if specFile != "" {
-		buff, err = ioutil.ReadFile(specFile)
-		if err != nil {
-			ExitWithErrorf("%s failed: %v", cmd.Short, err)
-		}
-	} else {
-		buff, err = ioutil.ReadAll(os.Stdin)
-		if err != nil {
-			ExitWithErrorf("%s failed: %v", cmd.Short, err)
-		}
-	}
-
-	var spec struct {
-		Kind string `yaml:"kind"`
-		Name string `yaml:"name"`
-	}
-	err = yaml.Unmarshal(buff, &spec)
-	if err != nil {
-		ExitWithErrorf("%s failed, invalid spec: %v", cmd.Short, err)
-	}
-
-	return buff, spec.Name
-}
-
 func buildVisitorFromFileOrStdin(specFile string, cmd *cobra.Command) Visitor {
 	var buff []byte
 	var err error

--- a/cmd/client/command/object.go
+++ b/cmd/client/command/object.go
@@ -61,8 +61,11 @@ func createObjectCmd() *cobra.Command {
 		Use:   "create",
 		Short: "Create an object from a yaml file or stdin",
 		Run: func(cmd *cobra.Command, args []string) {
-			readFromFileOrStdin(specFile, cmd, func(doc, name string) {
-				handleRequest(http.MethodPost, makeURL(objectsURL), []byte(doc), cmd)
+			visitor := buildVisitorFromFileOrStdin(specFile, cmd)
+			visitor.Visit(func(docs []spec) {
+				for _, d := range docs {
+					handleRequest(http.MethodPost, makeURL(objectsURL), []byte(d.doc), cmd)
+				}
 			})
 		},
 	}
@@ -78,8 +81,11 @@ func updateObjectCmd() *cobra.Command {
 		Use:   "update",
 		Short: "Update an object from a yaml file or stdin",
 		Run: func(cmd *cobra.Command, args []string) {
-			readFromFileOrStdin(specFile, cmd, func(doc, name string) {
-				handleRequest(http.MethodPut, makeURL(objectURL, name), []byte(doc), cmd)
+			visitor := buildVisitorFromFileOrStdin(specFile, cmd)
+			visitor.Visit(func(docs []spec) {
+				for _, d := range docs {
+					handleRequest(http.MethodPut, makeURL(objectURL, d.Name), []byte(d.doc), cmd)
+				}
 			})
 		},
 	}

--- a/cmd/client/command/object.go
+++ b/cmd/client/command/object.go
@@ -61,8 +61,9 @@ func createObjectCmd() *cobra.Command {
 		Use:   "create",
 		Short: "Create an object from a yaml file or stdin",
 		Run: func(cmd *cobra.Command, args []string) {
-			buff, _ := readFromFileOrStdin(specFile, cmd)
-			handleRequest(http.MethodPost, makeURL(objectsURL), buff, cmd)
+			readFromFileOrStdin(specFile, cmd, func(doc, name string) {
+				handleRequest(http.MethodPost, makeURL(objectsURL), []byte(doc), cmd)
+			})
 		},
 	}
 
@@ -77,8 +78,9 @@ func updateObjectCmd() *cobra.Command {
 		Use:   "update",
 		Short: "Update an object from a yaml file or stdin",
 		Run: func(cmd *cobra.Command, args []string) {
-			buff, name := readFromFileOrStdin(specFile, cmd)
-			handleRequest(http.MethodPut, makeURL(objectURL, name), buff, cmd)
+			readFromFileOrStdin(specFile, cmd, func(doc, name string) {
+				handleRequest(http.MethodPut, makeURL(objectURL, name), []byte(doc), cmd)
+			})
 		},
 	}
 

--- a/cmd/client/command/object.go
+++ b/cmd/client/command/object.go
@@ -62,10 +62,8 @@ func createObjectCmd() *cobra.Command {
 		Short: "Create an object from a yaml file or stdin",
 		Run: func(cmd *cobra.Command, args []string) {
 			visitor := buildVisitorFromFileOrStdin(specFile, cmd)
-			visitor.Visit(func(docs []spec) {
-				for _, d := range docs {
-					handleRequest(http.MethodPost, makeURL(objectsURL), []byte(d.doc), cmd)
-				}
+			visitor.Visit(func(s *spec) {
+				handleRequest(http.MethodPost, makeURL(objectsURL), []byte(s.doc), cmd)
 			})
 		},
 	}
@@ -82,10 +80,8 @@ func updateObjectCmd() *cobra.Command {
 		Short: "Update an object from a yaml file or stdin",
 		Run: func(cmd *cobra.Command, args []string) {
 			visitor := buildVisitorFromFileOrStdin(specFile, cmd)
-			visitor.Visit(func(docs []spec) {
-				for _, d := range docs {
-					handleRequest(http.MethodPut, makeURL(objectURL, d.Name), []byte(d.doc), cmd)
-				}
+			visitor.Visit(func(s *spec) {
+				handleRequest(http.MethodPost, makeURL(objectsURL), []byte(s.doc), cmd)
 			})
 		},
 	}

--- a/cmd/client/command/visitor.go
+++ b/cmd/client/command/visitor.go
@@ -9,7 +9,7 @@ import (
 )
 
 // VisitorFunc executes visition logic
-type VisitorFunc func([]spec)
+type VisitorFunc func(*spec)
 
 // Visitor walk through the document via VisitorFunc
 type Visitor interface {
@@ -60,7 +60,7 @@ func (d *yamlDecoder) Decode(into interface{}) error {
 // Visit implements Visitor over a stream.
 func (v *streamVisitor) Visit(fn VisitorFunc) {
 	d := newYAMLDecoder(v.Reader)
-	var validDocs []spec
+	var validSpecs []spec
 	for {
 		var s spec
 		if err := d.Decode(&s); err != nil {
@@ -72,7 +72,9 @@ func (v *streamVisitor) Visit(fn VisitorFunc) {
 		}
 		s.doc = d.doc
 		//TODO can validate spec's Kind here
-		validDocs = append(validDocs, s)
+		validSpecs = append(validSpecs, s)
 	}
-	fn(validDocs)
+	for _, s := range validSpecs {
+		fn(&s)
+	}
 }

--- a/cmd/client/command/visitor.go
+++ b/cmd/client/command/visitor.go
@@ -44,7 +44,7 @@ func newYAMLDecoder(r io.Reader) *yamlDecoder {
 	}
 }
 
-// Decods reads a YAML document into bytes and try to yaml.Unmarshal it.
+// Decode reads a YAML document into bytes and tries to yaml.Unmarshal it.
 func (d *yamlDecoder) Decode(into interface{}) error {
 	bytes, err := d.reader.Read()
 	if err != nil && err != io.EOF {

--- a/cmd/client/command/visitor.go
+++ b/cmd/client/command/visitor.go
@@ -1,0 +1,78 @@
+package command
+
+import (
+	"bufio"
+	"io"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+// VisitorFunc executes visition logic
+type VisitorFunc func([]spec)
+
+// Visitor walk through the document via VisitorFunc
+type Visitor interface {
+	Visit(VisitorFunc)
+}
+
+type spec struct {
+	Kind string
+	Name string
+	doc  string
+}
+
+type streamVisitor struct {
+	io.Reader
+}
+
+// NewStreamVisitor returns a streamVisitor.
+func NewStreamVisitor(src string) *streamVisitor {
+	return &streamVisitor{
+		Reader: strings.NewReader(src),
+	}
+}
+
+type yamlDecoder struct {
+	reader *yaml.YAMLReader
+	doc    string
+}
+
+func newYAMLDecoder(r io.Reader) *yamlDecoder {
+	return &yamlDecoder{
+		reader: yaml.NewYAMLReader(bufio.NewReader(r)),
+	}
+}
+
+// Decods reads a YAML document into bytes and try to yaml.Unmarshal it.
+func (d *yamlDecoder) Decode(into interface{}) error {
+	bytes, err := d.reader.Read()
+	if err != nil && err != io.EOF {
+		return err
+	}
+	d.doc = string(bytes)
+	if len(bytes) != 0 {
+		err = yaml.Unmarshal(bytes, into)
+	}
+	return err
+}
+
+// Visit implements Visitor over a stream.
+func (v *streamVisitor) Visit(fn VisitorFunc) {
+	d := newYAMLDecoder(v.Reader)
+	var validDocs []spec
+	for {
+		var s spec
+		if err := d.Decode(&s); err != nil {
+			if err == io.EOF {
+				break
+			} else {
+				ExitWithErrorf("error parsing %s: %v", d.doc, err)
+			}
+		}
+		s.doc = d.doc
+		//TODO can validate spec's Kind here
+		validDocs = append(validDocs, s)
+	}
+	fn(validDocs)
+}

--- a/cmd/client/command/wasm.go
+++ b/cmd/client/command/wasm.go
@@ -85,8 +85,11 @@ func wasmApplyDataCmd() *cobra.Command {
 		},
 
 		Run: func(cmd *cobra.Command, args []string) {
-			readFromFileOrStdin(specFile, cmd, func(doc, name string) {
-				handleRequest(http.MethodPut, makeURL(wasmDataURL, args[0], args[1]), []byte(doc), cmd)
+			visitor := buildVisitorFromFileOrStdin(specFile, cmd)
+			visitor.Visit(func(docs []spec) {
+				for _, d := range docs {
+					handleRequest(http.MethodPut, makeURL(wasmDataURL, args[0], args[1]), []byte(d.doc), cmd)
+				}
 			})
 		},
 	}

--- a/cmd/client/command/wasm.go
+++ b/cmd/client/command/wasm.go
@@ -86,10 +86,8 @@ func wasmApplyDataCmd() *cobra.Command {
 
 		Run: func(cmd *cobra.Command, args []string) {
 			visitor := buildVisitorFromFileOrStdin(specFile, cmd)
-			visitor.Visit(func(docs []spec) {
-				for _, d := range docs {
-					handleRequest(http.MethodPut, makeURL(wasmDataURL, args[0], args[1]), []byte(d.doc), cmd)
-				}
+			visitor.Visit(func(s *spec) {
+				handleRequest(http.MethodPost, makeURL(objectsURL), []byte(s.doc), cmd)
 			})
 		},
 	}

--- a/cmd/client/command/wasm.go
+++ b/cmd/client/command/wasm.go
@@ -85,8 +85,9 @@ func wasmApplyDataCmd() *cobra.Command {
 		},
 
 		Run: func(cmd *cobra.Command, args []string) {
-			buf, _ := readFromFileOrStdin(specFile, cmd)
-			handleRequest(http.MethodPut, makeURL(wasmDataURL, args[0], args[1]), buf, cmd)
+			readFromFileOrStdin(specFile, cmd, func(doc, name string) {
+				handleRequest(http.MethodPut, makeURL(wasmDataURL, args[0], args[1]), []byte(doc), cmd)
+			})
 		},
 	}
 	cmd.Flags().StringVarP(&specFile, "file", "f", "", "A yaml file specifying the object.")


### PR DESCRIPTION
I did a fix on #29 . It sends multiple requests via `egctl`, based on how many YAML parts (separated by `---`) it read.

I know it's quick and dirty 😌, but if possible, someone can lead me to work more on it.