### PR TITLE
fix: the wrong link for ingress controller guide

### DIFF
--- a/doc/cookbook/k8s_ingress_controller.md
+++ b/doc/cookbook/k8s_ingress_controller.md
@@ -10,7 +10,7 @@
 
 The IngressController is an implementation of [Kubernetes ingress controller](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/), it watches Kubernetes Ingress, Service, Endpoints, and Secrets then translates them to Easegress HTTP server and pipelines.
 
-This document list example configurations for typical scenarios, more details could be found at [the guide of ingress controller](./ingresscontroller.md).
+This document list example configurations for typical scenarios, more details could be found at [the guide of ingress controller](../ingresscontroller.md).
 
 ## Why Use an Ingress Controller
 


### PR DESCRIPTION
`./ingresscontroller.md` -> `../ingresscontroller.md`.

Guess the guide is https://github.com/megaease/easegress/blob/main/doc/ingresscontroller.md