### PR TITLE
fix lint warning 

### DIFF
--- a/cmd/client/command/visitor.go
+++ b/cmd/client/command/visitor.go
@@ -21,7 +21,7 @@ type spec struct {
 	Name string
 	doc  string
 }
-
+// StreamVisitor is the struct of Visitor Pattern
 type StreamVisitor struct {
 	io.Reader
 }

--- a/cmd/client/command/visitor.go
+++ b/cmd/client/command/visitor.go
@@ -22,13 +22,13 @@ type spec struct {
 	doc  string
 }
 
-type streamVisitor struct {
+type StreamVisitor struct {
 	io.Reader
 }
 
 // NewStreamVisitor returns a streamVisitor.
-func NewStreamVisitor(src string) *streamVisitor {
-	return &streamVisitor{
+func NewStreamVisitor(src string) *StreamVisitor {
+	return &StreamVisitor{
 		Reader: strings.NewReader(src),
 	}
 }
@@ -58,7 +58,7 @@ func (d *yamlDecoder) Decode(into interface{}) error {
 }
 
 // Visit implements Visitor over a stream.
-func (v *streamVisitor) Visit(fn VisitorFunc) {
+func (v *StreamVisitor) Visit(fn VisitorFunc) {
 	d := newYAMLDecoder(v.Reader)
 	var validSpecs []spec
 	for {

--- a/cmd/client/command/visitor.go
+++ b/cmd/client/command/visitor.go
@@ -21,6 +21,7 @@ type spec struct {
 	Name string
 	doc  string
 }
+
 // StreamVisitor is the struct of Visitor Pattern
 type StreamVisitor struct {
 	io.Reader

--- a/pkg/api/wasm.go
+++ b/pkg/api/wasm.go
@@ -1,3 +1,4 @@
+//go:build wasmhost
 // +build wasmhost
 
 /*

--- a/pkg/common/os_test.go
+++ b/pkg/common/os_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/common/signal_unix.go
+++ b/pkg/common/signal_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/common/signal_unix_test.go
+++ b/pkg/common/signal_unix_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/common/signal_windows.go
+++ b/pkg/common/signal_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*

--- a/pkg/common/time_unix.go
+++ b/pkg/common/time_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/common/time_windows.go
+++ b/pkg/common/time_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*

--- a/pkg/filter/wasmhost/hostfunc.go
+++ b/pkg/filter/wasmhost/hostfunc.go
@@ -1,3 +1,4 @@
+//go:build wasmhost
 // +build wasmhost
 
 /*

--- a/pkg/filter/wasmhost/vm.go
+++ b/pkg/filter/wasmhost/vm.go
@@ -1,3 +1,4 @@
+//go:build wasmhost
 // +build wasmhost
 
 /*

--- a/pkg/filter/wasmhost/wasmhost.go
+++ b/pkg/filter/wasmhost/wasmhost.go
@@ -1,3 +1,4 @@
+//go:build wasmhost
 // +build wasmhost
 
 /*


### PR DESCRIPTION
- fix lint warning - `exported func NewStreamVisitor returns unexported type *command.streamVisitor, which can be annoying to use`
- go 1.17 - `go:build` line 