### PR TITLE
make `docker run` with default config with not param 

### DIFF
--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -20,4 +20,4 @@ RUN apk --no-cache add tini tzdata && \
 
 ENV PATH /opt/easegress/bin:$PATH
 
-ENTRYPOINT ["/sbin/tini", "--", "/entrypoint.sh"]
+ENTRYPOINT ["/sbin/tini", "/entrypoint.sh"]

--- a/build/package/Dockerfile.goreleaser
+++ b/build/package/Dockerfile.goreleaser
@@ -10,4 +10,4 @@ RUN apk --no-cache add tini tzdata && \
 
 ENV PATH /opt/easegress/bin:$PATH
 
-ENTRYPOINT ["/sbin/tini", "--", "/entrypoint.sh"]
+ENTRYPOINT ["/sbin/tini",  "/entrypoint.sh"]

--- a/build/package/entrypoint.sh
+++ b/build/package/entrypoint.sh
@@ -4,6 +4,6 @@ set -e
 if [ $# != 0  ] ; then
   exec "$@"
 else
-  exec /opt/easegress/bin/easegress-server "$@"
+  exec /opt/easegress/bin/easegress-server
 fi
 

--- a/build/package/entrypoint.sh
+++ b/build/package/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
+set -e
 
-if [ "$(echo $1 | head -c 1)" != "-" ] ; then
+if [ $# != 0  ] ; then
   exec "$@"
 else
   exec /opt/easegress/bin/easegress-server "$@"


### PR DESCRIPTION
* Remove `--` in bash command
* Modify ENTRYPOINT.sh, if not parameter provided, run `/opt/easegress/bin/easegress-server` directly, else run the fully command provided by user. 