### PR TITLE
[bugfix] correct update restfulapi in ctl

### DIFF
--- a/cmd/client/command/object.go
+++ b/cmd/client/command/object.go
@@ -81,7 +81,7 @@ func updateObjectCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			visitor := buildVisitorFromFileOrStdin(specFile, cmd)
 			visitor.Visit(func(s *spec) {
-				handleRequest(http.MethodPost, makeURL(objectsURL), []byte(s.doc), cmd)
+				handleRequest(http.MethodPut, makeURL(objectURL, s.Name), []byte(s.doc), cmd)
 			})
 		},
 	}


### PR DESCRIPTION
* Fixing bug introducing by #230 
* `Update` type RESTful API should use `PUT` method with object name in URL.