### PR TITLE
update cluster example, no std-log-level in option

### DIFF
--- a/doc/benchmark.md
+++ b/doc/benchmark.md
@@ -151,7 +151,7 @@ cpu-profile-file:
 memory-profile-file:
 log-dir: ./log
 member-dir: ./member
-std-log-level: INFO
+debug: false
 ```
 
 2.HTTPServer+Pipeline

--- a/example/reader-004/conf/config.yaml
+++ b/example/reader-004/conf/config.yaml
@@ -13,4 +13,4 @@ cpu-profile-file:
 memory-profile-file:
 log-dir: ./log
 member-dir: ./member
-std-log-level: INFO
+debug: false

--- a/example/reader-005/conf/config.yaml
+++ b/example/reader-005/conf/config.yaml
@@ -13,4 +13,4 @@ cpu-profile-file:
 memory-profile-file:
 log-dir: ./log
 member-dir: ./member
-std-log-level: INFO
+debug: false

--- a/example/sbin/conf/config.yaml
+++ b/example/sbin/conf/config.yaml
@@ -11,4 +11,4 @@ cpu-profile-file:
 memory-profile-file:
 log-dir: ./log
 member-dir: ./member
-std-log-level: INFO
+debug: false

--- a/example/writer-001/conf/config.yaml
+++ b/example/writer-001/conf/config.yaml
@@ -13,4 +13,4 @@ cpu-profile-file:
 memory-profile-file:
 log-dir: ./log
 member-dir: ./member
-std-log-level: INFO
+debug: false

--- a/example/writer-002/conf/config.yaml
+++ b/example/writer-002/conf/config.yaml
@@ -13,4 +13,4 @@ cpu-profile-file:
 memory-profile-file:
 log-dir: ./log
 member-dir: ./member
-std-log-level: INFO
+debug: false

--- a/example/writer-003/conf/config.yaml
+++ b/example/writer-003/conf/config.yaml
@@ -13,4 +13,4 @@ cpu-profile-file:
 memory-profile-file:
 log-dir: ./log
 member-dir: ./member
-std-log-level: INFO
+debug: false


### PR DESCRIPTION
No `std-log-level` in Easegress option, the default log level is INFO. To use log level of DEBUG, set `debug: true` in Easegress yaml. To replace `std-log-level: INFO` with `debug: false` will hint the people who want to use debug mode.