### PR TITLE
[Mesh] fixing deadlock  and optimizing mesh controller's master 

### DIFF
--- a/pkg/object/meshcontroller/master/master.go
+++ b/pkg/object/meshcontroller/master/master.go
@@ -176,8 +176,9 @@ func (m *Master) scanInstances() (failedInstances []*spec.ServiceInstanceSpec,
 				}
 			}
 		} else {
-			logger.Errorf("status of %s/%s not found", _spec.ServiceName, _spec.InstanceID)
+			logger.Errorf("status of %s/%s not found, need to delete", _spec.ServiceName, _spec.InstanceID)
 			failedInstances = append(failedInstances, _spec)
+			deadInstances = append(deadInstances, _spec)
 		}
 	}
 	return

--- a/pkg/object/meshcontroller/master/master.go
+++ b/pkg/object/meshcontroller/master/master.go
@@ -96,21 +96,30 @@ func (m *Master) run() {
 	go m.clean()
 }
 
+// only handle master routines when its the cluster leader.
+func (m *Master) needHandle() bool {
+	return m.superSpec.Super().Cluster().IsLeader()
+}
+
 func (m *Master) checkHeartbeat(watchInterval time.Duration) {
 	for {
 		select {
 		case <-m.done:
 			return
 		case <-time.After(watchInterval):
-			func() {
-				defer func() {
-					if err := recover(); err != nil {
-						logger.Errorf("failed to check instance heartbeat %v, stack trace: \n%s\n",
-							err, debug.Stack())
-					}
+			if m.needHandle() {
+				func() {
+					defer func() {
+						if err := recover(); err != nil {
+							logger.Errorf("failed to check instance heartbeat %v, stack trace: \n%s\n",
+								err, debug.Stack())
+						}
+					}()
+					m.checkInstancesHeartbeat()
 				}()
-				m.checkInstancesHeartbeat()
-			}()
+			} else {
+				logger.Infof("not the cluster leader, do nothing")
+			}
 		}
 	}
 }
@@ -121,15 +130,19 @@ func (m *Master) clean() {
 		case <-m.done:
 			return
 		case <-time.After(defaultCleanInterval):
-			func() {
-				defer func() {
-					if err := recover(); err != nil {
-						logger.Errorf("failed to clean dead instances: %v, stack trace: \n%s\n",
-							err, debug.Stack())
-					}
+			if m.needHandle() {
+				func() {
+					defer func() {
+						if err := recover(); err != nil {
+							logger.Errorf("failed to clean dead instances: %v, stack trace: \n%s\n",
+								err, debug.Stack())
+						}
+					}()
+					m.cleanDeadInstances()
 				}()
-				m.cleanDeadInstances()
-			}()
+			} else {
+				logger.Infof("not the cluster leader, do nothing")
+			}
 		}
 	}
 }

--- a/pkg/object/meshcontroller/worker/egress.go
+++ b/pkg/object/meshcontroller/worker/egress.go
@@ -146,6 +146,10 @@ func (egs *EgressServer) InitEgress(service *spec.Service) error {
 func (egs *EgressServer) Ready() bool {
 	egs.mutex.RLock()
 	defer egs.mutex.RUnlock()
+	return egs._ready()
+}
+
+func (egs *EgressServer) _ready() bool {
 	return egs.httpServer != nil
 }
 
@@ -237,7 +241,7 @@ func (egs *EgressServer) Close() {
 	egs.mutex.Lock()
 	defer egs.mutex.Unlock()
 
-	if egs.Ready() {
+	if egs._ready() {
 		egs.tc.DeleteHTTPServer(egs.namespace, egs.httpServer.Spec().Name())
 		for _, entity := range egs.pipelines {
 			egs.tc.DeleteHTTPPipeline(egs.namespace, entity.Spec().Name())

--- a/pkg/object/meshcontroller/worker/ingress.go
+++ b/pkg/object/meshcontroller/worker/ingress.go
@@ -80,6 +80,10 @@ func (ings *IngressServer) Ready() bool {
 	ings.mutex.RLock()
 	defer ings.mutex.RUnlock()
 
+	return ings._ready()
+}
+
+func (ings *IngressServer) _ready() bool {
 	serviceSpec := &spec.Service{
 		Name: ings.serviceName,
 	}
@@ -162,7 +166,7 @@ func (ings *IngressServer) Close() {
 	ings.mutex.Lock()
 	defer ings.mutex.Unlock()
 
-	if ings.Ready() {
+	if ings._ready() {
 		ings.tc.DeleteHTTPServer(ings.namespace, ings.httpServer.Spec().Name())
 		for _, entity := range ings.pipelines {
 			ings.tc.DeleteHTTPPipeline(ings.namespace, entity.Spec().Name())


### PR DESCRIPTION
During the Mesh demo preparation, @xxx7xxxx  found that the sidecar will be pending after updating the mesh controller spec. After investigating, it's because there is a deadlock in Ingress/Egress closing routine. 

* Fixing deadlock in ingress/egress

Currently, master controller's master role is responsible for checking service instance heartbeats and cleaning the dead records. **But all master role instances will process this routine.**
* Adding nil status record into the clean routine.
* Avoiding mesh controller in master role processes the routine when it's not the leader in cluster.