### PR TITLE
[mesh] sidecar egress supports routing by request domain

### DIFF
--- a/pkg/object/meshcontroller/worker/egress.go
+++ b/pkg/object/meshcontroller/worker/egress.go
@@ -169,12 +169,12 @@ func (egs *EgressServer) reloadBySpecs(value map[string]*spec.Service) bool {
 	return egs.reloadHTTPServer(value)
 }
 
-// regex rule: ^(|(\w+\.)+)vet-services\.(\w+)\.svc\..+$
+// regex rule: ^(\w+\.)*vet-services\.(\w+)\.svc\..+$
 //  can match e.g. _tcp.vet-services.easemesh.svc.cluster.local
 //   		   vet-services.easemesh.svc.cluster.local
 //   		   _zip._tcp.vet-services.easemesh.svc.com
 func (egs *EgressServer) buildHostRegex(serviceName string) string {
-	return `^(|(\w+\.)+)` + serviceName + `\.(\w+)\.svc\..+`
+	return `^(\w+\.)*` + serviceName + `\.(\w+)\.svc\..+`
 }
 
 func (egs *EgressServer) reloadHTTPServer(specs map[string]*spec.Service) bool {


### PR DESCRIPTION
EaseMesh sidecar egress enhancement: 
* Add egress HTTPServer rules for domain routing in DNS-based RPC scenario
* Domain matching by using exactly matching and regular expression. 