### PR TITLE
fix MQTT client close bugs

### DIFF
--- a/pkg/object/mqttproxy/broker.go
+++ b/pkg/object/mqttproxy/broker.go
@@ -287,6 +287,16 @@ func (b *Broker) getClient(clientID string) *Client {
 	return nil
 }
 
+func (b *Broker) removeClient(clientID string) {
+	b.Lock()
+	defer b.Unlock()
+	if val, ok := b.clients[clientID]; ok {
+		if val.disconnected() {
+			delete(b.clients, clientID)
+		}
+	}
+}
+
 func (b *Broker) topicsPublishHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		api.HandleAPIError(w, r, http.StatusBadRequest, fmt.Errorf("suppose POST request but got %s", r.Method))

--- a/pkg/object/mqttproxy/session_manager.go
+++ b/pkg/object/mqttproxy/session_manager.go
@@ -114,9 +114,8 @@ func (sm *SessionManager) get(clientID string) *Session {
 }
 
 func (sm *SessionManager) delLocal(clientID string) {
-	sess := sm.get(clientID)
-	if sess != nil {
+	if val, ok := sm.sessionMap.LoadAndDelete(clientID); ok {
+		sess := val.(*Session)
 		sess.close()
 	}
-	sm.sessionMap.Delete(clientID)
 }


### PR DESCRIPTION
This pr mainly fix two bugs. 
1. When MQTT client and broker close at the same time, the client session may be closed twice, then double close channel will cause panic. (call `SessionManager.delLocal` method).
2. When close client, the broker does not rm client from its map. Remove client from map is easy, but it may cause race condition. For example, when old client close and remove from broker, at same time, new client with same clientID come and store it to broker. Then broker may remove new client. 

I hope this pr fix these bugs.