### PR TITLE
add `linker.DefineWasi()` after `wasmtime.NewLinker`

### DIFF
--- a/pkg/filter/wasmhost/vm.go
+++ b/pkg/filter/wasmhost/vm.go
@@ -115,6 +115,11 @@ func newWasmVM(host *WasmHost, engine *wasmtime.Engine, module *wasmtime.Module,
 	linker := wasmtime.NewLinker(engine)
 	vm.importHostFuncs(linker)
 
+	e = linker.DefineWasi()
+	if e != nil {
+		return nil, e
+	}
+
 	inst, e := linker.Instantiate(store, module)
 	if e != nil {
 		return nil, e


### PR DESCRIPTION
`DefineWasi links a WASI module into this linker, ensuring that all exported functions are available for linking`
—— from `github.com/bytecodealliance/wasmtime-go/linker.go`

#279 