### PR TITLE
fix high CPU usage in mesh (close #319)

### DIFF
--- a/pkg/object/meshcontroller/registrycenter/registry.go
+++ b/pkg/object/meshcontroller/registrycenter/registry.go
@@ -197,25 +197,22 @@ func (rcs *Server) register(ins *spec.ServiceInstanceSpec, ingressReady ReadyFun
 		return nil
 	}
 
-	var tryTimes int
 	var firstSucceed bool
+	ticker := time.NewTicker(5 * time.Second)
 	for {
+		err := routine()
+		if err != nil {
+			logger.Errorf("register failed: %v", err)
+		} else if !firstSucceed {
+			logger.Infof("register instance spec succeed")
+			firstSucceed = true
+		}
+
 		select {
 		case <-rcs.done:
+			ticker.Stop()
 			return
-		default:
-			tryTimes++
-
-			err := routine()
-			if err != nil {
-				logger.Errorf("register failed: %v", err)
-				time.Sleep(5 * time.Second)
-			} else {
-				if !firstSucceed {
-					logger.Infof("register instance spec succeed")
-					firstSucceed = true
-				}
-			}
+		case <-ticker.C:
 		}
 	}
 }


### PR DESCRIPTION
Before the change, when the register attempt (call to `routine`) succeeds, it enters the next iteration immediately.
The fix inserts a wait between each register attempt. 