### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/cmd/client/command/common.go
+++ b/cmd/client/command/common.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 
@@ -128,7 +127,7 @@ func handleRequest(httpMethod string, url string, reqBody []byte, cmd *cobra.Com
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		ExitWithErrorf("%s failed: %v", cmd.Short, err)
 	}

--- a/doc/developer-guide.md
+++ b/doc/developer-guide.md
@@ -125,7 +125,7 @@ func (c *StatusInLocalController) syncStatus() {
 		return
 	}
 
-	ioutil.WriteFile(c.spec.Path, buff, 0644)
+	os.WriteFile(c.spec.Path, buff, 0644)
 }
 ```
 
@@ -137,7 +137,7 @@ All objects must satisfy the interface `Object` in [`pkg/object/supervisor/regis
 package statusinlocalcontroller
 
 import (
-	"io/ioutil"
+	"os"
 	"runtime/debug"
 	"time"
 
@@ -209,7 +209,7 @@ func (c *StatusInLocalController) syncStatus() {
 		return
 	}
 
-	ioutil.WriteFile(c.spec.Path, buff, 0644)
+	os.WriteFile(c.spec.Path, buff, 0644)
 }
 
 // Category returns the category of StatusInLocalController.

--- a/example/backend-service/remote/remote.go
+++ b/example/backend-service/remote/remote.go
@@ -3,7 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -44,7 +44,7 @@ func main() {
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			return

--- a/pkg/api/object.go
+++ b/pkg/api/object.go
@@ -19,7 +19,7 @@ package api
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sort"
 
@@ -86,7 +86,7 @@ func (s *Server) objectAPIEntries() []*Entry {
 }
 
 func (s *Server) readObjectSpec(w http.ResponseWriter, r *http.Request) (*supervisor.Spec, error) {
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return nil, fmt.Errorf("read body failed: %v", err)
 	}

--- a/pkg/api/wasm.go
+++ b/pkg/api/wasm.go
@@ -22,7 +22,7 @@ package api
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -117,7 +117,7 @@ func (s *Server) wasmApplyData(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, e := ioutil.ReadAll(r.Body)
+	body, e := io.ReadAll(r.Body)
 	if e != nil {
 		HandleAPIError(w, r, http.StatusBadRequest, e)
 		return

--- a/pkg/cluster/member.go
+++ b/pkg/cluster/member.go
@@ -20,7 +20,6 @@ package cluster
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -110,7 +109,7 @@ func (m *members) load() error {
 		return nil
 	}
 
-	buff, err := ioutil.ReadFile(m.file)
+	buff, err := os.ReadFile(m.file)
 	if err != nil {
 		return err
 	}
@@ -146,7 +145,7 @@ func (m *members) store() {
 		}
 	}
 
-	err = ioutil.WriteFile(m.file, buff, 0o644)
+	err = os.WriteFile(m.file, buff, 0o644)
 	if err != nil {
 		logger.Errorf("write file %s failed: %v", m.file, err)
 	} else {

--- a/pkg/context/httprequest.go
+++ b/pkg/context/httprequest.go
@@ -165,7 +165,7 @@ func (r *httpRequest) Size() uint64 {
 
 func (r *httpRequest) finish() {
 	// NOTE: We don't use this line in case of large flow attack.
-	// io.Copy(ioutil.Discard, r.std.Body)
+	// io.Copy(io.Discard, r.std.Body)
 
 	// NOTE: The server will do it for us.
 	// r.std.Body.Close()

--- a/pkg/filter/proxy/pool.go
+++ b/pkg/filter/proxy/pool.go
@@ -20,7 +20,6 @@ package proxy
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 
@@ -198,7 +197,7 @@ func (p *pool) handle(ctx context.HTTPContext, reqBody io.Reader, client *http.C
 		// And we do NOT do statistics of duration and respSize
 		// for it, because we can't wait for it to finish.
 		defer resp.Body.Close()
-		io.Copy(ioutil.Discard, resp.Body)
+		io.Copy(io.Discard, resp.Body)
 	}()
 
 	return ""

--- a/pkg/filter/retryer/retryer.go
+++ b/pkg/filter/retryer/retryer.go
@@ -20,7 +20,7 @@ package retryer
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"strings"
 	"time"
@@ -176,7 +176,7 @@ func (r *Retryer) handle(ctx context.HTTPContext, u *URLRule) string {
 	attempt := 0
 	base := float64(u.policy.waitDuration)
 
-	data, _ := ioutil.ReadAll(ctx.Request().Body())
+	data, _ := io.ReadAll(ctx.Request().Body())
 	for {
 		attempt++
 		ctx.Request().SetBody(bytes.NewReader(data))

--- a/pkg/object/function/worker/api.go
+++ b/pkg/object/function/worker/api.go
@@ -19,7 +19,7 @@ package worker
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -120,7 +120,7 @@ func (worker *Worker) Create(w http.ResponseWriter, r *http.Request) {
 }
 
 func (worker *Worker) readAPISpec(w http.ResponseWriter, r *http.Request, spec interface{}) error {
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return fmt.Errorf("read body failed: %v", err)
 	}

--- a/pkg/object/meshcontroller/worker/api_consul.go
+++ b/pkg/object/meshcontroller/worker/api_consul.go
@@ -20,7 +20,7 @@ package worker
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -73,7 +73,7 @@ func (worker *Worker) consulAPIs() []*apiEntry {
 }
 
 func (worker *Worker) consulRegister(w http.ResponseWriter, r *http.Request) {
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		api.HandleAPIError(w, r, http.StatusBadRequest,
 			fmt.Errorf("read body failed: %v", err))

--- a/pkg/object/meshcontroller/worker/api_eureka.go
+++ b/pkg/object/meshcontroller/worker/api_eureka.go
@@ -22,7 +22,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -139,7 +139,7 @@ func (worker *Worker) detectedAccept(accept string) string {
 }
 
 func (worker *Worker) eurekaRegister(w http.ResponseWriter, r *http.Request) {
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		api.HandleAPIError(w, r, http.StatusBadRequest,
 			fmt.Errorf("read body failed: %v", err))

--- a/pkg/pidfile/pidfile.go
+++ b/pkg/pidfile/pidfile.go
@@ -19,7 +19,6 @@ package pidfile
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -38,7 +37,7 @@ var pidfilePath string
 func Write(opt *option.Options) error {
 	pidfilePath = filepath.Join(opt.AbsHomeDir, pidfileName)
 
-	err := ioutil.WriteFile(pidfilePath, []byte(fmt.Sprintf("%d", os.Getpid())), 0o644)
+	err := os.WriteFile(pidfilePath, []byte(fmt.Sprintf("%d", os.Getpid())), 0o644)
 	if err != nil {
 		logger.Errorf("write %s failed: %s", pidfilePath, err)
 		return err
@@ -51,7 +50,7 @@ func Write(opt *option.Options) error {
 func Read(opt *option.Options) (int, error) {
 	pidfilePath = filepath.Join(opt.AbsHomeDir, pidfileName)
 
-	data, err := ioutil.ReadFile(pidfilePath)
+	data, err := os.ReadFile(pidfilePath)
 	if err != nil {
 		logger.Errorf("read %s failed: %s", pidfilePath, err)
 		return 0, err

--- a/pkg/supervisor/object.go
+++ b/pkg/supervisor/object.go
@@ -20,7 +20,7 @@ package supervisor
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"runtime/debug"
@@ -300,7 +300,7 @@ func (or *ObjectRegistry) storeConfigInLocal(config map[string]string) {
 	}
 	buff.Write(configBuff)
 
-	err = ioutil.WriteFile(or.configLocalPath, buff.Bytes(), 0o644)
+	err = os.WriteFile(or.configLocalPath, buff.Bytes(), 0o644)
 	if err != nil {
 		logger.Errorf("write %s failed: %v", or.configLocalPath, err)
 		return

--- a/pkg/util/jmxtool/common.go
+++ b/pkg/util/jmxtool/common.go
@@ -21,7 +21,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -107,7 +107,7 @@ func handleRequest(httpMethod string, url string, reqBody []byte) ([]byte, error
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/signer/signer.go
+++ b/pkg/util/signer/signer.go
@@ -23,7 +23,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/textproto"
 	"net/url"
@@ -507,12 +507,12 @@ func (ctx *SigningContext) hashBody(req *http.Request, verify bool) error {
 		// sha256 of empty string
 		ctx.BodyHash = sha256Empty
 	} else {
-		body, e := ioutil.ReadAll(req.Body)
+		body, e := io.ReadAll(req.Body)
 		if e != nil {
 			return e
 		}
 		req.Body.Close()
-		req.Body = ioutil.NopCloser(bytes.NewReader(body))
+		req.Body = io.NopCloser(bytes.NewReader(body))
 		ctx.BodyHash = sha256DegistAndEncodeToHexString(body)
 	}
 

--- a/pkg/util/signer/signer_test.go
+++ b/pkg/util/signer/signer_test.go
@@ -19,7 +19,6 @@ package signer
 
 import (
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
@@ -315,7 +314,7 @@ func TestPresignVerify(t *testing.T) {
 	}
 
 	signer.SetTTL(0)
-	req.Body = ioutil.NopCloser(strings.NewReader("aaaaa"))
+	req.Body = io.NopCloser(strings.NewReader("aaaaa"))
 	if e := signer.Verify(req); e == nil {
 		t.Errorf("verification should failed, but didn't")
 	}


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.