### PR TITLE
remove goroutine from a test (close #347)

### DIFF
--- a/pkg/object/mqttproxy/mqtt_test.go
+++ b/pkg/object/mqttproxy/mqtt_test.go
@@ -848,8 +848,8 @@ func (ts *testServer) addHandlerFunc(pattern string, f http.HandlerFunc) {
 func (ts *testServer) start() error {
 	go ts.srv.ListenAndServe()
 	// Poll server until it is ready
-	for t := 0; t < 5; t++ {
-		time.Sleep(20)
+	for t := 0; t < 25; t++ {
+		time.Sleep(50 * time.Millisecond)
 		req, _ := http.NewRequest(http.MethodGet, "http://localhost:"+ts.addr, nil)
 		_, err := http.DefaultClient.Do(req)
 		if err == nil {

--- a/pkg/object/mqttproxy/mqtt_test.go
+++ b/pkg/object/mqttproxy/mqtt_test.go
@@ -850,7 +850,7 @@ func (ts *testServer) start() error {
 	// Poll server until it is ready
 	for t := 0; t < 25; t++ {
 		time.Sleep(50 * time.Millisecond)
-		req, _ := http.NewRequest(http.MethodGet, "http://localhost:"+ts.addr, nil)
+		req, _ := http.NewRequest(http.MethodGet,  "http://localhost"+ts.addr, nil)
 		_, err := http.DefaultClient.Do(req)
 		if err == nil {
 			return nil

--- a/pkg/object/mqttproxy/mqtt_test.go
+++ b/pkg/object/mqttproxy/mqtt_test.go
@@ -973,7 +973,7 @@ func TestHTTPPublish(t *testing.T) {
 				Payload: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%d", i))),
 				Base64:  true,
 			}
-			go func(data HTTPJsonData) {
+			func(data HTTPJsonData) {
 				code := topicsPublish(t, data)
 				if code != http.StatusOK {
 					t.Errorf("wrong status code return")

--- a/pkg/object/mqttproxy/mqtt_test.go
+++ b/pkg/object/mqttproxy/mqtt_test.go
@@ -850,7 +850,7 @@ func (ts *testServer) start() error {
 	// Poll server until it is ready
 	for t := 0; t < 25; t++ {
 		time.Sleep(50 * time.Millisecond)
-		req, _ := http.NewRequest(http.MethodGet,  "http://localhost"+ts.addr, nil)
+		req, _ := http.NewRequest(http.MethodGet, "http://localhost"+ts.addr, nil)
 		_, err := http.DefaultClient.Do(req)
 		if err == nil {
 			return nil


### PR DESCRIPTION
Fix https://github.com/megaease/easegress/issues/347.

There was nondeterministic issue with http.Server creation and closing and sending messages. 
- Changing [topicsPublish](https://github.com/megaease/easegress/blob/main/pkg/object/mqttproxy/mqtt_test.go#L852-L867) invocations from concurrent goroutines to sequential invocations to avoid race condition
- Modify mqtt_test.go's testServer.start() to wait until the server is ready

To verify that test fails 0/30 runs :
```bash
cd pkg/object/mqttproxy 
for (( i=0; i < 30; i=i+1 )); do go test | tail -n 1 | cut -c 1-4; done
```
and output should have only `ok`'s.

## Todo
I found new error that should be investigated
`--- FAIL: TestCleanSession (0.00s)
    mqtt_test.go:231: topicMgr should contain topic test/cleanSession/0 when client reconnect, but got map[]`