### PR TITLE
add test and fix bugs for websocket

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.8.1
+	github.com/stretchr/testify v1.7.0
 	github.com/tcnksm/go-httpstat v0.2.1-0.20191008022543-e866bb274419
 	github.com/tidwall/gjson v1.11.0
 	github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce

--- a/pkg/object/websocketserver/proxy.go
+++ b/pkg/object/websocketserver/proxy.go
@@ -149,11 +149,13 @@ func (p *Proxy) run() {
 	p.dialer = dialer
 	p.upgrader = defaultUpgrader
 
-	http.HandleFunc("/", p.handle)
+	// http.HandleFunc("/", p.handle)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", p.handle)
 	addr := fmt.Sprintf(":%d", spec.Port)
 	svr := &http.Server{
 		Addr:    addr,
-		Handler: nil,
+		Handler: mux,
 	}
 
 	if spec.HTTPS {

--- a/pkg/object/websocketserver/proxy.go
+++ b/pkg/object/websocketserver/proxy.go
@@ -154,10 +154,9 @@ func (p *Proxy) run() {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", p.handle)
 	addr := fmt.Sprintf(":%d", spec.Port)
-	svr := &http.Server{
-		Addr:    addr,
-		Handler: mux,
-	}
+
+	p.server.Addr = addr
+	p.server.Handler = mux
 
 	if spec.HTTPS {
 		tlsConfig, err := spec.tlsConfig()
@@ -165,10 +164,10 @@ func (p *Proxy) run() {
 			logger.Errorf("%s gen websocketserver's httpserver tlsConfig: %#v, failed: %v",
 				p.superSpec.Name(), spec, err)
 		}
-		svr.TLSConfig = tlsConfig
+		p.server.TLSConfig = tlsConfig
 	}
 
-	if err := svr.ListenAndServe(); err != nil {
+	if err := p.server.ListenAndServe(); err != nil {
 		logger.Errorf("%s websocketserver ListenAndServe failed: %v", p.superSpec.Name(), err)
 	}
 }

--- a/pkg/object/websocketserver/proxy.go
+++ b/pkg/object/websocketserver/proxy.go
@@ -167,8 +167,14 @@ func (p *Proxy) run() {
 		p.server.TLSConfig = tlsConfig
 	}
 
-	if err := p.server.ListenAndServe(); err != nil {
-		logger.Errorf("%s websocketserver ListenAndServe failed: %v", p.superSpec.Name(), err)
+	if p.server.TLSConfig != nil {
+		if err := p.server.ListenAndServeTLS("", ""); err != nil {
+			logger.Errorf("%s websocketserver ListenAndServeTLS failed: %v", p.superSpec.Name(), err)
+		}
+	} else {
+		if err := p.server.ListenAndServe(); err != nil {
+			logger.Errorf("%s websocketserver ListenAndServe failed: %v", p.superSpec.Name(), err)
+		}
 	}
 }
 

--- a/pkg/object/websocketserver/proxy.go
+++ b/pkg/object/websocketserver/proxy.go
@@ -149,7 +149,8 @@ func (p *Proxy) run() {
 	p.dialer = dialer
 	p.upgrader = defaultUpgrader
 
-	// http.HandleFunc("/", p.handle)
+	// here if use DefaultServeMux, when do inherit, will cause panic
+	// panic: http: multiple registrations for /
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", p.handle)
 	addr := fmt.Sprintf(":%d", spec.Port)

--- a/pkg/object/websocketserver/proxy_test.go
+++ b/pkg/object/websocketserver/proxy_test.go
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2017, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package websocketserver
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProxyCopyHeader(t *testing.T) {
+	assert := assert.New(t)
+	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1", nil)
+	require.Nil(t, err)
+	req.Header.Add("Origin", "origin")
+	req.Header.Add("Sec-WebSocket-Protocol", "protocol")
+	req.Header.Add("Cookie", "cookie1=1")
+	req.RemoteAddr = fmt.Sprintf("%s:%d", req.Host, 8888)
+
+	p := &Proxy{}
+	header := p.copyHeader(req)
+	assert.Equal("origin", header.Get("Origin"))
+	assert.Equal("", header.Get("Sec-WebSocket-Protocol"))
+	assert.Equal("cookie1=1", header.Get("Cookie"))
+	assert.Equal("127.0.0.1", header.Get(xForwardedFor))
+	assert.Equal("127.0.0.1", header.Get(xForwardedHost))
+	assert.Equal("http", header.Get(xForwardedProto))
+	fmt.Printf("header: %v\n", header)
+}
+
+func TestProxyUpgradeRspHeader(t *testing.T) {
+	assert := assert.New(t)
+	resp := &http.Response{}
+	resp.Header = make(http.Header)
+	resp.Header.Add("Sec-Websocket-Protocol", "protocol")
+	resp.Header.Add("Set-Cookie", "cookie=1")
+	resp.Header.Add("Sec-Websocket-Extensions", "extensions")
+
+	p := &Proxy{}
+	newHeader := p.upgradeRspHeader(resp)
+	assert.Equal("protocol", newHeader.Get("Sec-Websocket-Protocol"))
+	assert.Equal("cookie=1", newHeader.Get("Set-Cookie"))
+	// only copy protocol and cookie
+	assert.Equal("", newHeader.Get("Sec-Websocket-Extensions"))
+}

--- a/pkg/object/websocketserver/proxy_test.go
+++ b/pkg/object/websocketserver/proxy_test.go
@@ -20,6 +20,7 @@ package websocketserver
 import (
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -60,4 +61,17 @@ func TestProxyUpgradeRspHeader(t *testing.T) {
 	assert.Equal("cookie=1", newHeader.Get("Set-Cookie"))
 	// only copy protocol and cookie
 	assert.Equal("", newHeader.Get("Sec-Websocket-Extensions"))
+}
+
+func TestCopyResponse(t *testing.T) {
+	testSrv := getTestServer(t, "127.0.0.1:8000")
+	defer testSrv.Close()
+
+	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:8000/start", nil)
+	require.Nil(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.Nil(t, err)
+	copyResp := httptest.NewRecorder()
+	copyResponse(copyResp, resp)
+	assert.Equal(t, copyResp.Header(), resp.Header)
 }

--- a/pkg/object/websocketserver/spec_test.go
+++ b/pkg/object/websocketserver/spec_test.go
@@ -72,6 +72,8 @@ func TestSpecValidate(t *testing.T) {
 	}
 }
 
+// this certPem and keyPem come from golang crypto/tls/testdata
+// with original name: example-cert.pem and example-key.pem
 const certPem = `
 -----BEGIN CERTIFICATE-----
 MIIBhTCCASugAwIBAgIQIRi6zePL6mKjOipn+dNuaTAKBggqhkjOPQQDAjASMRAw

--- a/pkg/object/websocketserver/spec_test.go
+++ b/pkg/object/websocketserver/spec_test.go
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2017, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package websocketserver
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSpecValidate(t *testing.T) {
+	tests := []struct {
+		spec  *Spec
+		valid bool
+	}{
+		{
+			spec: &Spec{
+				Port:    10081,
+				HTTPS:   false,
+				Backend: "127.0.0.1:8888",
+			},
+			valid: false,
+		},
+		{
+			spec: &Spec{
+				Port:    10081,
+				HTTPS:   false,
+				Backend: "http://127.0.0.1:8888",
+			},
+			valid: false,
+		},
+		{
+			spec: &Spec{
+				Port:    10081,
+				HTTPS:   true,
+				Backend: "ws://127.0.0.1:8888",
+			},
+			valid: false,
+		},
+		{
+			spec: &Spec{
+				Port:    10081,
+				HTTPS:   false,
+				Backend: "wss://127.0.0.1:8888",
+			},
+			valid: false,
+		},
+	}
+	for _, testCase := range tests {
+		err := testCase.spec.Validate()
+		if testCase.valid {
+			assert.Nil(t, err)
+		} else {
+			assert.NotNil(t, err)
+		}
+	}
+}
+
+const certPem = `
+-----BEGIN CERTIFICATE-----
+MIIBhTCCASugAwIBAgIQIRi6zePL6mKjOipn+dNuaTAKBggqhkjOPQQDAjASMRAw
+DgYDVQQKEwdBY21lIENvMB4XDTE3MTAyMDE5NDMwNloXDTE4MTAyMDE5NDMwNlow
+EjEQMA4GA1UEChMHQWNtZSBDbzBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABD0d
+7VNhbWvZLWPuj/RtHFjvtJBEwOkhbN/BnnE8rnZR8+sbwnc/KhCk3FhnpHZnQz7B
+5aETbbIgmuvewdjvSBSjYzBhMA4GA1UdDwEB/wQEAwICpDATBgNVHSUEDDAKBggr
+BgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MCkGA1UdEQQiMCCCDmxvY2FsaG9zdDo1
+NDUzgg4xMjcuMC4wLjE6NTQ1MzAKBggqhkjOPQQDAgNIADBFAiEA2zpJEPQyz6/l
+Wf86aX6PepsntZv2GYlA5UpabfT2EZICICpJ5h/iI+i341gBmLiAFQOyTDT+/wQc
+6MF9+Yw1Yy0t
+-----END CERTIFICATE-----
+`
+const keyPem = `
+-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIIrYSSNQFaA2Hwf1duRSxKtLYX5CB04fSeQ6tF1aY/PuoAoGCCqGSM49
+AwEHoUQDQgAEPR3tU2Fta9ktY+6P9G0cWO+0kETA6SFs38GecTyudlHz6xvCdz8q
+EKTcWGekdmdDPsHloRNtsiCa697B2O9IFA==
+-----END EC PRIVATE KEY-----
+`
+
+func TestSpecTLS(t *testing.T) {
+	cert := base64.StdEncoding.EncodeToString([]byte(certPem))
+	key := base64.StdEncoding.EncodeToString([]byte(keyPem))
+	spec := &Spec{
+		CertBase64:    cert,
+		KeyBase64:     key,
+		WssCertBase64: cert,
+		WssKeyBase64:  key,
+	}
+	_, err := spec.wssTLSConfig()
+	assert.Nil(t, err)
+	_, err = spec.tlsConfig()
+	assert.Nil(t, err)
+
+	spec = &Spec{}
+	_, err = spec.wssTLSConfig()
+	assert.NotNil(t, err)
+	_, err = spec.tlsConfig()
+	assert.NotNil(t, err)
+
+	spec = &Spec{
+		CertBase64:    "cert",
+		KeyBase64:     "key",
+		WssCertBase64: "cert",
+		WssKeyBase64:  "key",
+	}
+	_, err = spec.wssTLSConfig()
+	assert.NotNil(t, err)
+	_, err = spec.tlsConfig()
+	assert.NotNil(t, err)
+}

--- a/pkg/object/websocketserver/websocket_test.go
+++ b/pkg/object/websocketserver/websocket_test.go
@@ -184,3 +184,34 @@ wssKeyBase64: %v
 	time.Sleep(50 * time.Millisecond)
 	ws.Close()
 }
+
+func TestWebSocketEmptyTLS(t *testing.T) {
+	testSrv := getTestServer(t, "127.0.0.1:8000")
+	defer testSrv.Close()
+
+	wsYaml := `
+kind: WebSocketServer
+name: websocket-demo
+port: 10081
+https: true
+backend: wss://127.0.0.1:8000
+certBase64: 1234
+keyBase64: 2234
+wssCertBase64: 3234
+wssKeyBase64: 4234
+`
+	super := supervisor.NewDefaultMock()
+	superSpec, err := super.NewSpec(wsYaml)
+	require.Nil(t, err)
+
+	_, err = superSpec.ObjectSpec().(*Spec).tlsConfig()
+	assert.NotNil(t, err)
+	_, err = superSpec.ObjectSpec().(*Spec).wssTLSConfig()
+	assert.NotNil(t, err)
+
+	ws := &WebSocketServer{}
+	ws.Init(superSpec)
+	assert.Nil(t, ws.Validate())
+	time.Sleep(50 * time.Millisecond)
+	ws.Close()
+}

--- a/pkg/object/websocketserver/websocket_test.go
+++ b/pkg/object/websocketserver/websocket_test.go
@@ -129,7 +129,7 @@ func doClient(t *testing.T, wg *sync.WaitGroup, url, cid string) {
 }
 
 func TestWebSocket(t *testing.T) {
-	testSrv := getTestServer(t, "127.0.0.1:8888")
+	testSrv := getTestServer(t, "127.0.0.1:8000")
 	defer testSrv.Close()
 
 	wsYaml := `
@@ -137,7 +137,7 @@ kind: WebSocketServer
 name: websocket-demo
 port: 10081
 https: false
-backend: ws://127.0.0.1:8888`
+backend: ws://127.0.0.1:8000`
 	ws := getWebSocket(t, wsYaml, "ws://127.0.0.1:10081")
 
 	clientNum := 50
@@ -156,7 +156,7 @@ backend: ws://127.0.0.1:8888`
 }
 
 func TestWebSocketTLS(t *testing.T) {
-	testSrv := getTestServer(t, "127.0.0.1:8888")
+	testSrv := getTestServer(t, "127.0.0.1:8000")
 	defer testSrv.Close()
 
 	cert := base64.StdEncoding.EncodeToString([]byte(certPem))
@@ -166,7 +166,7 @@ kind: WebSocketServer
 name: websocket-demo
 port: 10081
 https: true
-backend: wss://127.0.0.1:8888
+backend: wss://127.0.0.1:8000
 certBase64: %v
 keyBase64: %v
 wssCertBase64: %v

--- a/pkg/object/websocketserver/websocket_test.go
+++ b/pkg/object/websocketserver/websocket_test.go
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2017, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package websocketserver
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/megaease/easegress/pkg/logger"
+	"github.com/megaease/easegress/pkg/supervisor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	testUpgrader = &websocket.Upgrader{}
+)
+
+func init() {
+	logger.InitNop()
+}
+
+func upgrade(w http.ResponseWriter, r *http.Request) {
+	conn, err := testUpgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+	for {
+		mt, msg, err := conn.ReadMessage()
+		if err != nil {
+			break
+		}
+		err = conn.WriteMessage(mt, msg)
+		if err != nil {
+			break
+		}
+	}
+}
+
+func checkStart(w http.ResponseWriter, r *http.Request) {
+}
+
+func getTestServer(t *testing.T, addr string) *http.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", upgrade)
+	mux.HandleFunc("/start", checkStart)
+	server := &http.Server{
+		Addr:    addr,
+		Handler: mux,
+	}
+	go server.ListenAndServe()
+
+	started := false
+	for i := 0; i < 10; i++ {
+		req, err := http.NewRequest(http.MethodGet, "http://"+addr+"/start", nil)
+		require.Nil(t, err)
+		_, err = http.DefaultClient.Do(req)
+		if err == nil {
+			started = true
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	require.Equal(t, true, started, "server not started")
+	return server
+}
+
+func getWebSocket(t *testing.T, yamlStr string, checkUrl string) *WebSocketServer {
+	super := supervisor.NewDefaultMock()
+	superSpec, err := super.NewSpec(yamlStr)
+	ws := &WebSocketServer{}
+	require.Nil(t, err)
+	ws.Init(superSpec)
+
+	started := false
+	for i := 0; i < 10; i++ {
+		ws, _, err := websocket.DefaultDialer.Dial(checkUrl, nil)
+		if err == nil {
+			started = true
+			ws.Close()
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	require.Equal(t, true, started)
+	return ws
+}
+
+func doClient(t *testing.T, wg *sync.WaitGroup, url, cid string) {
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ws, _, err := websocket.DefaultDialer.Dial(url, nil)
+		require.Nil(t, err)
+		defer ws.Close()
+
+		for j := 0; j < 10; j++ {
+			val := fmt.Sprintf("%s_%d", cid, j)
+			err := ws.WriteMessage(websocket.TextMessage, []byte(val))
+			assert.Nil(t, err)
+			_, p, err := ws.ReadMessage()
+			assert.Nil(t, err)
+			assert.Equal(t, val, string(p))
+		}
+	}()
+}
+
+func TestWebSocket(t *testing.T) {
+	testSrv := getTestServer(t, "127.0.0.1:8888")
+	defer testSrv.Close()
+
+	wsYaml := `
+kind: WebSocketServer
+name: websocket-demo
+port: 10081
+https: false
+backend: ws://127.0.0.1:8888`
+	ws := getWebSocket(t, wsYaml, "ws://127.0.0.1:10081")
+	defer ws.Close()
+
+	clientNum := 50
+	wg := &sync.WaitGroup{}
+	for i := 0; i < clientNum; i++ {
+		doClient(t, wg, "ws://127.0.0.1:10081", strconv.Itoa(i))
+	}
+	wg.Wait()
+}

--- a/pkg/object/websocketserver/websocket_test.go
+++ b/pkg/object/websocketserver/websocket_test.go
@@ -92,6 +92,7 @@ func getWebSocket(t *testing.T, yamlStr string, checkUrl string) *WebSocketServe
 	ws := &WebSocketServer{}
 	require.Nil(t, err)
 	ws.Init(superSpec)
+	assert.Nil(t, ws.Validate())
 
 	started := false
 	for i := 0; i < 10; i++ {
@@ -137,7 +138,6 @@ port: 10081
 https: false
 backend: ws://127.0.0.1:8888`
 	ws := getWebSocket(t, wsYaml, "ws://127.0.0.1:10081")
-	defer ws.Close()
 
 	clientNum := 50
 	wg := &sync.WaitGroup{}
@@ -145,4 +145,11 @@ backend: ws://127.0.0.1:8888`
 		doClient(t, wg, "ws://127.0.0.1:10081", strconv.Itoa(i))
 	}
 	wg.Wait()
+
+	// test inherit
+	newWs := WebSocketServer{}
+	newWs.Inherit(ws.superSpec, ws)
+	newWs.Status()
+	time.Sleep(100 * time.Millisecond)
+	newWs.Close()
 }

--- a/pkg/object/websocketserver/websocket_test.go
+++ b/pkg/object/websocketserver/websocket_test.go
@@ -87,7 +87,7 @@ func getTestServer(t *testing.T, addr string) *http.Server {
 	return server
 }
 
-func getWebSocket(t *testing.T, yamlStr string, checkUrl string) *WebSocketServer {
+func getWebSocket(t *testing.T, yamlStr string, checkURL string) *WebSocketServer {
 	super := supervisor.NewDefaultMock()
 	superSpec, err := super.NewSpec(yamlStr)
 	ws := &WebSocketServer{}
@@ -97,7 +97,7 @@ func getWebSocket(t *testing.T, yamlStr string, checkUrl string) *WebSocketServe
 
 	started := false
 	for i := 0; i < 10; i++ {
-		ws, _, err := websocket.DefaultDialer.Dial(checkUrl, nil)
+		ws, _, err := websocket.DefaultDialer.Dial(checkURL, nil)
 		if err == nil {
 			started = true
 			ws.Close()

--- a/pkg/object/websocketserver/websocket_test.go
+++ b/pkg/object/websocketserver/websocket_test.go
@@ -18,6 +18,7 @@
 package websocketserver
 
 import (
+	"encoding/base64"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -152,4 +153,26 @@ backend: ws://127.0.0.1:8888`
 	newWs.Status()
 	time.Sleep(100 * time.Millisecond)
 	newWs.Close()
+}
+
+func TestWebSocketTLS(t *testing.T) {
+	testSrv := getTestServer(t, "127.0.0.1:8888")
+	defer testSrv.Close()
+
+	cert := base64.StdEncoding.EncodeToString([]byte(certPem))
+	key := base64.StdEncoding.EncodeToString([]byte(keyPem))
+	wsYaml := `
+kind: WebSocketServer
+name: websocket-demo
+port: 10081
+https: false
+backend: ws://127.0.0.1:8888
+certBase64: %v
+keyBase64: %v
+wssCertBase64: %v
+wssKeyBase64: %v
+`
+	wsYaml = fmt.Sprintf(wsYaml, cert, key, cert, key)
+	ws := getWebSocket(t, wsYaml, "ws://127.0.0.1:10081")
+	defer ws.Close()
 }

--- a/pkg/object/websocketserver/websocket_test.go
+++ b/pkg/object/websocketserver/websocket_test.go
@@ -165,14 +165,22 @@ func TestWebSocketTLS(t *testing.T) {
 kind: WebSocketServer
 name: websocket-demo
 port: 10081
-https: false
-backend: ws://127.0.0.1:8888
+https: true
+backend: wss://127.0.0.1:8888
 certBase64: %v
 keyBase64: %v
 wssCertBase64: %v
 wssKeyBase64: %v
 `
 	wsYaml = fmt.Sprintf(wsYaml, cert, key, cert, key)
-	ws := getWebSocket(t, wsYaml, "ws://127.0.0.1:10081")
-	defer ws.Close()
+
+	super := supervisor.NewDefaultMock()
+	superSpec, err := super.NewSpec(wsYaml)
+	require.Nil(t, err)
+
+	ws := &WebSocketServer{}
+	ws.Init(superSpec)
+	assert.Nil(t, ws.Validate())
+	time.Sleep(50 * time.Millisecond)
+	ws.Close()
 }

--- a/pkg/supervisor/mock.go
+++ b/pkg/supervisor/mock.go
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2017, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package supervisor
+
+import (
+	"sync"
+
+	"github.com/megaease/easegress/pkg/cluster"
+	"github.com/megaease/easegress/pkg/option"
+)
+
+// NewMock return a mock supervisor for testing purpose
+func NewMock(options *option.Options, cls cluster.Cluster, businessControllers sync.Map,
+	systemControllers sync.Map, objectRegistry *ObjectRegistry, watcher *ObjectEntityWatcher,
+	firstHandle bool, firstHandleDone chan struct{}, done chan struct{}) *Supervisor {
+	return &Supervisor{
+		options:             options,
+		cls:                 cls,
+		businessControllers: businessControllers,
+		systemControllers:   systemControllers,
+		objectRegistry:      objectRegistry,
+		watcher:             watcher,
+		firstHandle:         firstHandle,
+		firstHandleDone:     firstHandleDone,
+		done:                done,
+	}
+}
+
+// NewDefaultMock return a mock supervisor for testing purpose
+func NewDefaultMock() *Supervisor {
+	return &Supervisor{}
+}


### PR DESCRIPTION
1. add more test
2. add mock for supervisor
3. fix inherit panic (double registry http.DefaultMux by call http.HandleFunc in `Init` and `Inherit`).
4. fix close problem (proxy.server not set)
5. fix tls not work (use `ListenAndServeTLS`)
6. update `copyHeader` to copy all headers except ones used in `gorilla/websocket`