### PR TITLE
mqtt connect management, publish management, session management update

### DIFF
--- a/pkg/cluster/cluster_interface.go
+++ b/pkg/cluster/cluster_interface.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/megaease/easegress/pkg/logger"
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/concurrency"
@@ -37,6 +38,7 @@ type (
 		GetPrefix(prefix string) (map[string]string, error)
 		GetRaw(key string) (*mvccpb.KeyValue, error)
 		GetRawPrefix(prefix string) (map[string]*mvccpb.KeyValue, error)
+		GetWithOp(key string, ops ...WatchOp) (map[string]string, error)
 
 		Put(key, value string) error
 		PutUnderLease(key, value string) error
@@ -78,7 +80,24 @@ type (
 )
 
 const (
-	OpPrefix WatchOp = "prefix"
-	OpPut    WatchOp = "put"
-	OpDelete WatchOp = "delete"
+	OpPrefix       WatchOp = "prefix"
+	OpFilterPut    WatchOp = "put"
+	OpFilterDelete WatchOp = "delete"
+	OpKeysOnly     WatchOp = "keysOnly"
 )
+
+func getOpOption(op WatchOp) clientv3.OpOption {
+	switch op {
+	case OpPrefix:
+		return clientv3.WithPrefix()
+	case OpFilterPut:
+		return clientv3.WithFilterPut()
+	case OpFilterDelete:
+		return clientv3.WithFilterDelete()
+	case OpKeysOnly:
+		return clientv3.WithKeysOnly()
+	default:
+		logger.Errorf("not support operation type %v", op)
+		return nil
+	}
+}

--- a/pkg/cluster/cluster_interface.go
+++ b/pkg/cluster/cluster_interface.go
@@ -64,12 +64,21 @@ type (
 		PurgeMember(member string) error
 	}
 
+	WatchOp string
+
 	// Watcher wraps etcd watcher.
 	Watcher interface {
 		Watch(key string) (<-chan *string, error)
 		WatchPrefix(prefix string) (<-chan map[string]*string, error)
 		WatchRaw(key string) (<-chan *clientv3.Event, error)
 		WatchRawPrefix(prefix string) (<-chan map[string]*clientv3.Event, error)
+		WatchWithOp(key string, ops ...WatchOp) (<-chan map[string]*string, error)
 		Close()
 	}
+)
+
+const (
+	OpPrefix WatchOp = "prefix"
+	OpPut    WatchOp = "put"
+	OpDelete WatchOp = "delete"
 )

--- a/pkg/cluster/cluster_interface_test.go
+++ b/pkg/cluster/cluster_interface_test.go
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2017, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cluster
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+func Test_getOpOption(t *testing.T) {
+	tests := []struct {
+		wantFunc clientv3.OpOption
+		op       WatchOp
+	}{
+		{clientv3.WithPrefix(), OpPrefix},
+		{clientv3.WithFilterPut(), OpFilterPut},
+		{clientv3.WithFilterDelete(), OpFilterDelete},
+		{clientv3.WithKeysOnly(), OpKeysOnly},
+	}
+	for _, tc := range tests {
+		op1 := clientv3.Op{}
+		op2 := clientv3.Op{}
+		tc.wantFunc(&op1)
+		getOpOption(tc.op)(&op2)
+		assert.Equal(t, op1, op2)
+	}
+}

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -216,6 +216,9 @@ func TestClusterSyncer(t *testing.T) {
 	if _, err = c.GetPrefix("/abcd"); err != nil {
 		t.Errorf("cluster get prefix failed: %v", err)
 	}
+	if _, err = c.GetWithOp("/abcd", OpPrefix); err != nil {
+		t.Errorf("cluster get prefix failed: %v", err)
+	}
 
 	for {
 		value := make(map[string]string, 1)
@@ -298,6 +301,10 @@ func TestClusterWatcher(t *testing.T) {
 	if err != nil {
 		t.Errorf("watcher watch failed: %v", err)
 	}
+	opchan, err := watcher.WatchWithOp("/ab", OpPrefix)
+	if err != nil {
+		t.Errorf("watcher watch failed: %v", err)
+	}
 
 	rawpchan, err := watcher.WatchRawPrefix("/abcd")
 	if err != nil {
@@ -311,6 +318,14 @@ func TestClusterWatcher(t *testing.T) {
 		value := make(map[string]*string, 1)
 		select {
 		case value = <-pchan:
+			fmt.Printf("watch prefix value is %v\n", value)
+		}
+		break
+	}
+	for {
+		value := make(map[string]*string, 1)
+		select {
+		case value = <-opchan:
 			fmt.Printf("watch prefix value is %v\n", value)
 		}
 		break
@@ -331,6 +346,14 @@ func TestClusterWatcher(t *testing.T) {
 		value := make(map[string]*string, 1)
 		select {
 		case value = <-pchan:
+			fmt.Printf("watch delete prefix value is %v\n", value)
+		}
+		break
+	}
+	for {
+		value := make(map[string]*string, 1)
+		select {
+		case value = <-opchan:
 			fmt.Printf("watch delete prefix value is %v\n", value)
 		}
 		break

--- a/pkg/cluster/op.go
+++ b/pkg/cluster/op.go
@@ -175,6 +175,31 @@ func (c *cluster) GetRawPrefix(prefix string) (map[string]*mvccpb.KeyValue, erro
 	return kvs, nil
 }
 
+func (c *cluster) GetWithOp(key string, op ...WatchOp) (map[string]string, error) {
+	kvs := make(map[string]string)
+
+	client, err := c.getClient()
+	if err != nil {
+		return kvs, err
+	}
+
+	newOps := []clientv3.OpOption{}
+	for _, o := range op {
+		op := getOpOption(o)
+		if op != nil {
+			newOps = append(newOps, op)
+		}
+	}
+	resp, err := client.Get(c.requestContext(), key, newOps...)
+	if err != nil {
+		return kvs, err
+	}
+	for _, kv := range resp.Kvs {
+		kvs[string(kv.Key)] = string(kv.Value)
+	}
+	return kvs, nil
+}
+
 func (c *cluster) STM(apply func(concurrency.STM) error) error {
 	client, err := c.getClient()
 	if err != nil {

--- a/pkg/cluster/watcher.go
+++ b/pkg/cluster/watcher.go
@@ -223,13 +223,9 @@ func (w *watcher) WatchRawPrefix(prefix string) (<-chan map[string]*clientv3.Eve
 func (w *watcher) WatchWithOp(key string, ops ...WatchOp) (<-chan map[string]*string, error) {
 	newOps := []clientv3.OpOption{}
 	for _, o := range ops {
-		switch o {
-		case OpPrefix:
-			newOps = append(newOps, clientv3.WithPrefix())
-		case OpPut:
-			newOps = append(newOps, clientv3.WithFilterPut())
-		case OpDelete:
-			newOps = append(newOps, clientv3.WithFilterDelete())
+		op := getOpOption(o)
+		if op != nil {
+			newOps = append(newOps, op)
 		}
 	}
 

--- a/pkg/cluster/watcher.go
+++ b/pkg/cluster/watcher.go
@@ -220,6 +220,63 @@ func (w *watcher) WatchRawPrefix(prefix string) (<-chan map[string]*clientv3.Eve
 	return prefixChan, nil
 }
 
+func (w *watcher) WatchWithOp(key string, ops ...WatchOp) (<-chan map[string]*string, error) {
+	newOps := []clientv3.OpOption{}
+	for _, o := range ops {
+		switch o {
+		case OpPrefix:
+			newOps = append(newOps, clientv3.WithPrefix())
+		case OpPut:
+			newOps = append(newOps, clientv3.WithFilterPut())
+		case OpDelete:
+			newOps = append(newOps, clientv3.WithFilterDelete())
+		}
+	}
+
+	// NOTE: Can't use Context with timeout here.
+	ctx, cancel := context.WithCancel(context.Background())
+	watchResp := w.w.Watch(ctx, key, newOps...)
+	prefixChan := make(chan map[string]*string, 10)
+
+	go func() {
+		defer cancel()
+		defer close(prefixChan)
+
+		for {
+			select {
+			case <-w.done:
+				return
+			case resp := <-watchResp:
+				if resp.Canceled {
+					logger.Errorf("watch %s with ops %v canceled: %v", key, ops, resp.Err())
+					return
+				}
+				if resp.IsProgressNotify() {
+					continue
+				}
+				for _, event := range resp.Events {
+					switch event.Type {
+					case mvccpb.PUT:
+						value := string(event.Kv.Value)
+						prefixChan <- map[string]*string{
+							string(event.Kv.Key): &value,
+						}
+					case mvccpb.DELETE:
+						prefixChan <- map[string]*string{
+							string(event.Kv.Key): nil,
+						}
+					default:
+						logger.Errorf("BUG: key %s with ops %v received unknown event type %v",
+							key, ops, event.Type)
+					}
+				}
+			}
+		}
+	}()
+
+	return prefixChan, nil
+}
+
 func (w *watcher) Close() {
 	close(w.done)
 

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -49,6 +49,18 @@ func InitNop() {
 	stderrLogger = defaultLogger
 }
 
+// InitMock initializes all logger to print stdout, mainly for unit testing
+func InitMock() {
+	mock := zap.NewExample()
+	httpFilterAccessLogger = mock.Sugar()
+	httpFilterDumpLogger = mock.Sugar()
+	restAPILogger = mock.Sugar()
+
+	defaultLogger = mock.Sugar()
+	gressLogger = defaultLogger
+	stderrLogger = defaultLogger
+}
+
 const (
 	stdoutFilename           = "stdout.log"
 	filterHTTPAccessFilename = "filter_http_access.log"

--- a/pkg/object/mqttproxy/backend.go
+++ b/pkg/object/mqttproxy/backend.go
@@ -23,7 +23,6 @@ import (
 	"github.com/Shopify/sarama"
 	"github.com/eclipse/paho.mqtt.golang/packets"
 	"github.com/megaease/easegress/pkg/context"
-	"github.com/megaease/easegress/pkg/logger"
 )
 
 type (
@@ -67,7 +66,7 @@ func newBackendMQ(spec *Spec) backendMQ {
 		t.msg = make(map[string]map[string]string)
 		return t
 	default:
-		logger.Errorf("backend type <%s> not support", spec.BackendType)
+		spanErrorf(nil, "backend type <%s> not support", spec.BackendType)
 		return nil
 	}
 }
@@ -82,7 +81,7 @@ func newKafkaMQ(spec *Spec) *KafkaMQ {
 	config.Version = sarama.V1_0_0_0
 	producer, err := sarama.NewAsyncProducer(spec.Kafka.Backend, config)
 	if err != nil {
-		logger.Errorf("start sarama producer with address %v failed: %v", spec.Kafka.Backend, err)
+		spanErrorf(nil, "start sarama producer with address %v failed: %v", spec.Kafka.Backend, err)
 		return nil
 	}
 
@@ -95,7 +94,7 @@ func newKafkaMQ(spec *Spec) *KafkaMQ {
 				if !ok {
 					return
 				}
-				logger.Errorf("sarama producer failed: %v", err)
+				spanErrorf(nil, "sarama producer failed: %v", err)
 			}
 		}
 	}()
@@ -106,7 +105,7 @@ func newKafkaMQ(spec *Spec) *KafkaMQ {
 
 func (k *KafkaMQ) publish(p *packets.PublishPacket) error {
 	var msg *sarama.ProducerMessage
-	logger.Debugf("produce msg with topic %s", p.TopicName)
+	spanDebugf(nil, "produce msg with topic %s", p.TopicName)
 
 	if k.mapFunc != nil {
 		topic, headers, err := k.mapFunc(p.TopicName)
@@ -137,7 +136,7 @@ func (k *KafkaMQ) close() {
 	close(k.done)
 	err := k.producer.Close()
 	if err != nil {
-		logger.Errorf("close kafka producer failed: %v", err)
+		spanErrorf(nil, "close kafka producer failed: %v", err)
 	}
 }
 

--- a/pkg/object/mqttproxy/broker.go
+++ b/pkg/object/mqttproxy/broker.go
@@ -439,7 +439,7 @@ func (b *Broker) httpGetAllSessionHandler(w http.ResponseWriter, r *http.Request
 	}
 	span, _ := b3.ExtractHTTP(r)()
 	spanDebugf(span, "http endpoint receive request to get all session")
-	allSession, err := b.sessMgr.store.getPrefix(sessionStoreKey(""))
+	allSession, err := b.sessMgr.store.getPrefix(sessionStoreKey(""), true)
 	if err != nil {
 		spanErrorf(span, "get all sessions with prefix %v failed, %v", sessionStoreKey(""), err)
 		api.HandleAPIError(w, r, http.StatusInternalServerError, fmt.Errorf("get all sessions failed, %v", err))

--- a/pkg/object/mqttproxy/client.go
+++ b/pkg/object/mqttproxy/client.go
@@ -240,7 +240,7 @@ func (c *Client) processPuback(puback *packets.PubackPacket) {
 }
 
 func (c *Client) processSubscribe(packet *packets.SubscribePacket) {
-	spanDebugf(nil, "client %s processSubscribe %v", c.info.cid, packet.Topics)
+	spanDebugf(nil, "client %s subscribe %v with qos %v", c.info.cid, packet.Topics, packet.Qoss)
 	err := c.broker.topicMgr.subscribe(packet.Topics, packet.Qoss, c.info.cid)
 	if err != nil {
 		spanErrorf(nil, "client %v subscribe %v failed: %v", c.info.cid, packet.Topics, err)

--- a/pkg/object/mqttproxy/logger.go
+++ b/pkg/object/mqttproxy/logger.go
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2017, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mqttproxy
+
+import (
+	"github.com/megaease/easegress/pkg/logger"
+	"github.com/openzipkin/zipkin-go/model"
+)
+
+func spanDebugf(context *model.SpanContext, template string, args ...interface{}) {
+	temp := "tid=%v sid=%v " + template
+	if context == nil {
+		logger.Debugf(temp, nil, nil, args)
+	} else {
+		logger.Debugf(temp, context.TraceID, context.ID, args)
+	}
+}
+
+func spanErrorf(context *model.SpanContext, template string, args ...interface{}) {
+	temp := "tid=%v sid=%v " + template
+	if context == nil {
+		logger.Errorf(temp, nil, nil, args)
+	} else {
+		logger.Errorf(temp, context.TraceID, context.ID, args)
+	}
+}

--- a/pkg/object/mqttproxy/logger.go
+++ b/pkg/object/mqttproxy/logger.go
@@ -22,20 +22,19 @@ import (
 	"github.com/openzipkin/zipkin-go/model"
 )
 
-func spanDebugf(context *model.SpanContext, template string, args ...interface{}) {
-	temp := "tid=%v sid=%v " + template
+func getSpanTemplate(context *model.SpanContext, template string) string {
 	if context == nil {
-		logger.Debugf(temp, nil, nil, args)
-	} else {
-		logger.Debugf(temp, context.TraceID, context.ID, args)
+		return "tid=" + "<nil>" + " sid=" + "<nil>" + " " + template
 	}
+	return "tid=" + context.TraceID.String() + " sid=" + context.ID.String() + " " + template
+}
+
+func spanDebugf(context *model.SpanContext, template string, args ...interface{}) {
+	temp := getSpanTemplate(context, template)
+	logger.Debugf(temp, args...)
 }
 
 func spanErrorf(context *model.SpanContext, template string, args ...interface{}) {
-	temp := "tid=%v sid=%v " + template
-	if context == nil {
-		logger.Errorf(temp, nil, nil, args)
-	} else {
-		logger.Errorf(temp, context.TraceID, context.ID, args)
-	}
+	temp := getSpanTemplate(context, template)
+	logger.Errorf(temp, args...)
 }

--- a/pkg/object/mqttproxy/logger_test.go
+++ b/pkg/object/mqttproxy/logger_test.go
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2017, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mqttproxy
+
+import (
+	"testing"
+
+	"github.com/megaease/easegress/pkg/logger"
+	"github.com/openzipkin/zipkin-go/model"
+)
+
+func init() {
+	logger.InitMock()
+}
+
+func TestSpanLog(t *testing.T) {
+	context := &model.SpanContext{
+		TraceID: model.TraceID{
+			High: 100,
+			Low:  200,
+		},
+		ID: 300,
+	}
+	spanDebugf(context, "test span log, %v", "debug with context")
+	spanDebugf(nil, "test span log, %v", "debug without context")
+	spanErrorf(context, "test span log, %v", "error with context")
+	spanDebugf(nil, "test span log, %v", "error without context")
+}

--- a/pkg/object/mqttproxy/mock_test.go
+++ b/pkg/object/mqttproxy/mock_test.go
@@ -81,6 +81,26 @@ func (m *mockCluster) GetPrefix(prefix string) (map[string]string, error) {
 	return out, nil
 }
 
+func (m *mockCluster) GetWithOp(key string, op ...cluster.WatchOp) (map[string]string, error) {
+	prefix := false
+	for _, o := range op {
+		if o == cluster.OpPrefix {
+			prefix = true
+		}
+	}
+	ans := make(map[string]string)
+	if prefix {
+		kvs, _ := m.GetPrefix(key)
+		for k, v := range kvs {
+			ans[k] = v
+		}
+	} else {
+		value, _ := m.Get(key)
+		ans[key] = *value
+	}
+	return ans, nil
+}
+
 func (m *mockCluster) Put(key, value string) error {
 	m.Lock()
 	m.kv[key] = value

--- a/pkg/object/mqttproxy/mock_test.go
+++ b/pkg/object/mqttproxy/mock_test.go
@@ -121,7 +121,7 @@ func TestStorage(t *testing.T) {
 	if err != nil || *val != "1" {
 		t.Errorf("get wrong val")
 	}
-	valmap, err := store.getPrefix("prefix")
+	valmap, err := store.getPrefix("prefix", false)
 	if err != nil || !reflect.DeepEqual(valmap, map[string]string{"prefix_1": "1", "prefix_2": "2"}) {
 		t.Errorf("get wrong prefix val")
 	}
@@ -136,7 +136,7 @@ func TestMockStorage(t *testing.T) {
 	if err != nil || *val != "val1" {
 		t.Errorf("mock storage get return wrong value")
 	}
-	valMap, err := store.getPrefix("key")
+	valMap, err := store.getPrefix("key", false)
 	if err != nil || !reflect.DeepEqual(valMap, map[string]string{"key1": "val1", "key2": "val2", "key3": "val3"}) {
 		t.Errorf("mock storage get prefix return wrong value %v %v", valMap, map[string]string{"key1": "val1", "key2": "val2", "key3": "val3"})
 	}

--- a/pkg/object/mqttproxy/mqtt_test.go
+++ b/pkg/object/mqttproxy/mqtt_test.go
@@ -47,8 +47,8 @@ func (t *testMQ) get() *packets.PublishPacket {
 }
 
 func init() {
-	logger.InitNop()
-	// logger.InitMock()
+	// logger.InitNop()
+	logger.InitMock()
 	pipeline.Register(&pipeline.MockMQTTFilter{})
 }
 
@@ -700,7 +700,7 @@ func TestSendMsgBack(t *testing.T) {
 			for j := 0; j < msgNum; j++ {
 				topic := r.ClientID()
 				text := fmt.Sprintf("sub %d", j)
-				broker.sendMsgToClient(topic, []byte(text), QoS1)
+				broker.sendMsgToClient(nil, topic, []byte(text), QoS1)
 			}
 		}(clients[i])
 	}

--- a/pkg/object/mqttproxy/mqtt_test.go
+++ b/pkg/object/mqttproxy/mqtt_test.go
@@ -48,6 +48,7 @@ func (t *testMQ) get() *packets.PublishPacket {
 
 func init() {
 	logger.InitNop()
+	// logger.InitMock()
 	pipeline.Register(&pipeline.MockMQTTFilter{})
 }
 

--- a/pkg/object/mqttproxy/mqtt_test.go
+++ b/pkg/object/mqttproxy/mqtt_test.go
@@ -1875,6 +1875,7 @@ func TestHTTPDeleteSession(t *testing.T) {
 		if i == 9 {
 			t.Errorf("session delete failed %v", broker.currentClients())
 		}
+		time.Sleep(50 * time.Millisecond)
 	}
 
 	for _, c := range clients {

--- a/pkg/object/mqttproxy/mqttproxy.go
+++ b/pkg/object/mqttproxy/mqttproxy.go
@@ -23,7 +23,6 @@ import (
 	"net/url"
 
 	"github.com/megaease/easegress/pkg/cluster"
-	"github.com/megaease/easegress/pkg/logger"
 	"github.com/megaease/easegress/pkg/supervisor"
 	"gopkg.in/yaml.v2"
 )
@@ -90,10 +89,10 @@ func memberURLFunc(superSpec *supervisor.Spec) func(string, string) ([]string, e
 	c := superSpec.Super().Cluster()
 
 	f := func(egName, name string) ([]string, error) {
-		logger.Debugf("get member url for %v %v", egName, name)
+		spanDebugf(nil, "get member url for %v %v", egName, name)
 		kv, err := c.GetPrefix(c.Layout().StatusMemberPrefix())
 		if err != nil {
-			logger.Errorf("cluster get member list failed: %v", err)
+			spanErrorf(nil, "cluster get member list failed: %v", err)
 			return []string{}, err
 		}
 		urls := []string{}
@@ -101,7 +100,7 @@ func memberURLFunc(superSpec *supervisor.Spec) func(string, string) ([]string, e
 			memberStatus := cluster.MemberStatus{}
 			err := yaml.Unmarshal([]byte(v), &memberStatus)
 			if err != nil {
-				logger.Errorf("cluster status unmarshal failed: %v", err)
+				spanErrorf(nil, "cluster status unmarshal failed: %v", err)
 				return []string{}, err
 			}
 			if memberStatus.Options.Name != egName {
@@ -118,7 +117,7 @@ func memberURLFunc(superSpec *supervisor.Spec) func(string, string) ([]string, e
 				urls = append(urls, newURL+"/apis/v1"+fmt.Sprintf(mqttAPIPrefix, name))
 			}
 		}
-		logger.Debugf("eg %v %v get urls %v", egName, name, urls)
+		spanDebugf(nil, "eg %v %v get urls %v", egName, name, urls)
 		return urls, nil
 	}
 	return f

--- a/pkg/object/mqttproxy/mqttproxy.go
+++ b/pkg/object/mqttproxy/mqttproxy.go
@@ -114,7 +114,7 @@ func memberURLFunc(superSpec *supervisor.Spec) func(string, string) ([]string, e
 				if err != nil {
 					return nil, fmt.Errorf("get url for %v failed: %v", memberStatus.Options.Name, err)
 				}
-				urls = append(urls, newURL+"/apis/v1"+fmt.Sprintf(mqttAPIPrefix, name))
+				urls = append(urls, newURL+"/apis/v1"+fmt.Sprintf(mqttAPITopicPublishPrefix, name))
 			}
 		}
 		spanDebugf(nil, "eg %v %v get urls %v", egName, name, urls)

--- a/pkg/object/mqttproxy/ratelimiter.go
+++ b/pkg/object/mqttproxy/ratelimiter.go
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2017, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mqttproxy
+
+import (
+	"time"
+
+	"github.com/megaease/easegress/pkg/util/ratelimiter"
+)
+
+type Limiter struct {
+	rateLimiter  *ratelimiter.RateLimiter
+	burstLimiter *ratelimiter.RateLimiter
+}
+
+func newLimiter(spec *RateLimit) *Limiter {
+	limiter := &Limiter{}
+	if spec == nil || (spec.Rate == 0 && spec.Burst == 0) {
+		return limiter
+	}
+	timePeriod := 1
+	if spec.TimePeriod > 0 {
+		timePeriod = spec.TimePeriod
+	}
+	if spec.Rate > 0 {
+		policy := ratelimiter.NewPolicy(0, time.Duration(timePeriod)*time.Second, spec.Rate)
+		l := ratelimiter.New(policy)
+		limiter.rateLimiter = l
+	}
+	if spec.Burst > 0 {
+		policy := ratelimiter.NewPolicy(0, time.Duration(timePeriod)*time.Second, spec.Burst)
+		l := ratelimiter.New(policy)
+		limiter.burstLimiter = l
+	}
+	return limiter
+}
+
+func (l *Limiter) acquirePermission(burst int) bool {
+	permitted := true
+	if l.rateLimiter != nil {
+		permitted, _ = l.rateLimiter.AcquirePermission()
+	}
+	if !permitted {
+		return permitted
+	}
+	if l.burstLimiter != nil {
+		permitted, _ = l.burstLimiter.AcquireNPermission(burst)
+	}
+	return permitted
+}

--- a/pkg/object/mqttproxy/ratelimiter_test.go
+++ b/pkg/object/mqttproxy/ratelimiter_test.go
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2017, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mqttproxy
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLimiter(t *testing.T) {
+	// default spec will not block anything
+	spec := &RateLimit{}
+	l := newLimiter(spec)
+	for i := 0; i < 1000; i++ {
+		permitted := l.acquirePermission(100)
+		assert.Equal(t, true, permitted)
+	}
+
+	// only provide rate should only check rate
+	spec = &RateLimit{
+		Rate:       10,
+		TimePeriod: 60,
+	}
+	l = newLimiter(spec)
+	for i := 0; i < 20; i++ {
+		permitted := l.acquirePermission(1000)
+		if i < 10 {
+			assert.Equal(t, true, permitted)
+		} else {
+			assert.Equal(t, false, permitted)
+		}
+	}
+
+	// only provide burst should only check burst
+	spec = &RateLimit{
+		Burst:      100,
+		TimePeriod: 60,
+	}
+	l = newLimiter(spec)
+	for i := 0; i < 20; i++ {
+		permitted := l.acquirePermission(10)
+		if i < 10 {
+			assert.Equal(t, true, permitted)
+		} else {
+			assert.Equal(t, false, permitted)
+		}
+	}
+
+	// not provide time period use one second
+	spec = &RateLimit{
+		Burst: 100,
+	}
+	l = newLimiter(spec)
+	permitted := l.acquirePermission(100)
+	assert.Equal(t, true, permitted)
+	permitted = l.acquirePermission(1)
+	assert.Equal(t, false, permitted)
+	time.Sleep(1100 * time.Millisecond)
+	permitted = l.acquirePermission(100)
+	assert.Equal(t, true, permitted)
+}

--- a/pkg/object/mqttproxy/session_manager.go
+++ b/pkg/object/mqttproxy/session_manager.go
@@ -21,7 +21,6 @@ import (
 	"sync"
 
 	"github.com/eclipse/paho.mqtt.golang/packets"
-	"github.com/megaease/easegress/pkg/logger"
 )
 
 type (
@@ -62,10 +61,10 @@ func (sm *SessionManager) doStore() {
 		case <-sm.done:
 			return
 		case kv := <-sm.storeCh:
-			logger.Debugf("session manager store session %v", kv.key)
+			spanDebugf(nil, "session manager store session %v", kv.key)
 			err := sm.store.put(sessionStoreKey(kv.key), kv.value)
 			if err != nil {
-				logger.Errorf("put session %v into storage failed: %v", kv.key, err)
+				spanErrorf(nil, "put session %v into storage failed: %v", kv.key, err)
 			}
 		}
 	}
@@ -123,6 +122,6 @@ func (sm *SessionManager) delLocal(clientID string) {
 func (sm *SessionManager) delDB(clientID string) {
 	err := sm.store.delete(sessionStoreKey(clientID))
 	if err != nil {
-		logger.Errorf("delete session %v failed, %v", err)
+		spanErrorf(nil, "delete session %v failed, %v", err)
 	}
 }

--- a/pkg/object/mqttproxy/spec.go
+++ b/pkg/object/mqttproxy/spec.go
@@ -44,6 +44,18 @@ type (
 		Pipeline             string        `yaml:"pipeline" jsonschema:"omitempty"`
 		AuthByPipeline       bool          `yaml:"authByPipeline" jsonschema:"omitempty"`
 		MaxAllowedConnection int           `yaml:"maxAllowedConnection" jsonschema:"omitempty"`
+		ConnectionLimit      *RateLimit    `yaml:"connectionLimit" jsonschema:"omitempty"`
+		ClientPublishLimit   *RateLimit    `yaml:"clientPublishLimit" jsonschema:"omitempty"`
+	}
+
+	// RateLimit describes rate limit for connection or publish.
+	// rate: max allowed request in time period
+	// burst: max allowed bytes in time period
+	// timePeriod: time of seconds to count rate and burst, default 1 second
+	RateLimit struct {
+		Rate       int `yaml:"rate" jsonschema:"omitempty"`
+		Burst      int `yaml:"burst" jsonschema:"omitempty"`
+		TimePeriod int `yaml:"timePeriod" jsonschema:"omitempty"`
 	}
 
 	// Certificate describes TLS certifications.

--- a/pkg/object/mqttproxy/spec.go
+++ b/pkg/object/mqttproxy/spec.go
@@ -23,9 +23,11 @@ import (
 )
 
 const (
-	sessionPrefix = "/mqtt/sessionMgr/clientID/%s"
-	topicPrefix   = "/mqtt/topicMgr/topic/%s"
-	mqttAPIPrefix = "/mqttproxy/%s/topics/publish"
+	sessionPrefix              = "/mqtt/sessionMgr/clientID/%s"
+	topicPrefix                = "/mqtt/topicMgr/topic/%s"
+	mqttAPITopicPublishPrefix  = "/mqttproxy/%s/topics/publish"
+	mqttAPISessionQueryPrefix  = "/mqttproxy/%s/session/query"
+	mqttAPISessionDeletePrefix = "/mqttproxy/%s/session/delete"
 )
 
 type (

--- a/pkg/object/mqttproxy/spec.go
+++ b/pkg/object/mqttproxy/spec.go
@@ -31,18 +31,19 @@ const (
 type (
 	// Spec describes the MQTTProxy.
 	Spec struct {
-		EGName         string        `yaml:"-"`
-		Name           string        `yaml:"-"`
-		Port           uint16        `yaml:"port" jsonschema:"required"`
-		BackendType    string        `yaml:"backendType" jsonschema:"required"`
-		Auth           []Auth        `yaml:"auth" jsonschema:"required"`
-		TopicMapper    *TopicMapper  `yaml:"topicMapper" jsonschema:"omitempty"`
-		Kafka          *KafkaSpec    `yaml:"kafkaBroker" jsonschema:"omitempty"`
-		UseTLS         bool          `yaml:"useTLS" jsonschema:"omitempty"`
-		Certificate    []Certificate `yaml:"certificate" jsonschema:"omitempty"`
-		TopicCacheSize int           `yaml:"topicCacheSize" jsonschema:"omitempty"`
-		Pipeline       string        `yaml:"pipeline" jsonschema:"omitempty"`
-		AuthByPipeline bool          `yaml:"authByPipeline" jsonschema:"omitempty"`
+		EGName               string        `yaml:"-"`
+		Name                 string        `yaml:"-"`
+		Port                 uint16        `yaml:"port" jsonschema:"required"`
+		BackendType          string        `yaml:"backendType" jsonschema:"required"`
+		Auth                 []Auth        `yaml:"auth" jsonschema:"required"`
+		TopicMapper          *TopicMapper  `yaml:"topicMapper" jsonschema:"omitempty"`
+		Kafka                *KafkaSpec    `yaml:"kafkaBroker" jsonschema:"omitempty"`
+		UseTLS               bool          `yaml:"useTLS" jsonschema:"omitempty"`
+		Certificate          []Certificate `yaml:"certificate" jsonschema:"omitempty"`
+		TopicCacheSize       int           `yaml:"topicCacheSize" jsonschema:"omitempty"`
+		Pipeline             string        `yaml:"pipeline" jsonschema:"omitempty"`
+		AuthByPipeline       bool          `yaml:"authByPipeline" jsonschema:"omitempty"`
+		MaxAllowedConnection int           `yaml:"maxAllowedConnection" jsonschema:"omitempty"`
 	}
 
 	// Certificate describes TLS certifications.

--- a/pkg/object/mqttproxy/storage.go
+++ b/pkg/object/mqttproxy/storage.go
@@ -137,5 +137,5 @@ func (cs *clusterStorage) watchDelete(prefix string) (<-chan map[string]*string,
 	if cs.watcher == nil {
 		return nil, fmt.Errorf("nil watcher")
 	}
-	return cs.watcher.WatchWithOp(prefix, cluster.OpPrefix, cluster.OpDelete)
+	return cs.watcher.WatchWithOp(prefix, cluster.OpPrefix, cluster.OpFilterDelete)
 }

--- a/pkg/object/mqttproxy/topic.go
+++ b/pkg/object/mqttproxy/topic.go
@@ -24,7 +24,6 @@ import (
 	"sync"
 
 	lru "github.com/hashicorp/golang-lru"
-	"github.com/megaease/easegress/pkg/logger"
 )
 
 type topicMapFunc func(mqttTopic string) (topic string, headers map[string]string, err error)
@@ -248,7 +247,7 @@ func getPolicyRoute(routes []*PolicyRe) map[string]*regexp.Regexp {
 	for _, route := range routes {
 		r, err := regexp.Compile(route.MatchExpr)
 		if err != nil {
-			logger.Errorf("topicMapper policy <%s> match expr <%s> compile failed: %v", route.Name, route.MatchExpr, err)
+			spanErrorf(nil, "topicMapper policy <%s> match expr <%s> compile failed: %v", route.Name, route.MatchExpr, err)
 		} else {
 			ans[route.Name] = r
 		}
@@ -264,7 +263,7 @@ func getTopicRoute(p *Policy) topicRouteType {
 		for _, expr := range route.Exprs {
 			r, err := regexp.Compile(expr)
 			if err != nil {
-				logger.Errorf("topicMapper policy <%s> topic route expr <%s> compile failed: %v", p.Name, expr, err)
+				spanErrorf(nil, "topicMapper policy <%s> topic route expr <%s> compile failed: %v", p.Name, expr, err)
 			} else {
 				m[route.Topic] = append(m[route.Topic], r)
 			}

--- a/pkg/util/ratelimiter/ratelimiter.go
+++ b/pkg/util/ratelimiter/ratelimiter.go
@@ -73,15 +73,15 @@ var stateStrings = []string{
 // NewPolicy create and initialize a policy
 func NewPolicy(timeout, refresh time.Duration, limit int) *Policy {
 	return &Policy{
-		TimeoutDuration:    timeout * time.Millisecond,
-		LimitRefreshPeriod: refresh * time.Millisecond,
+		TimeoutDuration:    timeout,
+		LimitRefreshPeriod: refresh,
 		LimitForPeriod:     limit,
 	}
 }
 
 // NewDefaultPolicy create and initialize a policy with default configuration
 func NewDefaultPolicy() *Policy {
-	return NewPolicy(100, 10, 50)
+	return NewPolicy(100*time.Millisecond, 10*time.Millisecond, 50)
 }
 
 // New creates a rate limiter based on `policy`,

--- a/pkg/util/ratelimiter/ratelimiter_test.go
+++ b/pkg/util/ratelimiter/ratelimiter_test.go
@@ -181,3 +181,66 @@ func TestRateLimiter(t *testing.T) {
 	}
 	limiter.SetState(StateDisabled)
 }
+
+func TestRateLimiterN(t *testing.T) {
+	policy := NewPolicy(50*time.Millisecond, 10*time.Millisecond, 5)
+
+	limiter := New(policy)
+	limiter.SetStateListener(func(event *Event) {
+		fmt.Printf("%v\n", event)
+	})
+	limiter.SetState(StateNormal)
+	for i := 0; i < 15; i++ {
+		permitted, _ := limiter.AcquireNPermission(2)
+		if !permitted {
+			t.Errorf("AcquirePermission should succeed: %d", i)
+		}
+	}
+
+	limiter.SetState(StateDisabled)
+	if permitted, _ := limiter.AcquirePermission(); !permitted {
+		t.Errorf("AcquirePermission should succeeded")
+	}
+
+	limiter.SetState(StateNormal)
+	for i := 0; i < 10; i++ {
+		permitted, _ := limiter.AcquireNPermission(3)
+		if !permitted {
+			t.Errorf("AcquirePermission should succeed: %d", i)
+		}
+	}
+
+	limiter.SetState(StateLimiting)
+	if permitted, _ := limiter.AcquirePermission(); permitted {
+		t.Errorf("AcquirePermission should fail")
+	}
+
+	limiter.SetState(StateLimiting)
+	now = now.Add(time.Millisecond * 5)
+	if permitted, _ := limiter.AcquirePermission(); permitted {
+		t.Errorf("AcquirePermission should fail")
+	}
+
+	now = now.Add(time.Millisecond * 6)
+	for i := 0; i < 5; i++ {
+		if permitted, _ := limiter.AcquirePermission(); !permitted {
+			t.Errorf("AcquirePermission should succeed: %d", i)
+		}
+	}
+
+	if permitted, _ := limiter.AcquirePermission(); permitted {
+		t.Errorf("AcquirePermission should fail")
+	}
+
+	now = now.Add(time.Millisecond * 89)
+	for i := 0; i < 5; i++ {
+		if permitted, _ := limiter.AcquireNPermission(6); !permitted {
+			t.Errorf("AcquirePermission should succeed: %d", i)
+		}
+	}
+
+	if permitted, _ := limiter.AcquirePermission(); permitted {
+		t.Errorf("AcquirePermission should fail")
+	}
+	limiter.SetState(StateDisabled)
+}

--- a/pkg/util/ratelimiter/ratelimiter_test.go
+++ b/pkg/util/ratelimiter/ratelimiter_test.go
@@ -49,7 +49,7 @@ func TestNewDefaultPolicy(t *testing.T) {
 	}
 }
 func TestConcurrent(t *testing.T) {
-	policy := NewPolicy(50, 10, 5)
+	policy := NewPolicy(50*time.Millisecond, 10*time.Millisecond, 5)
 
 	var wg sync.WaitGroup
 	limiter := New(policy)
@@ -100,7 +100,7 @@ func TestConcurrent(t *testing.T) {
 }
 
 func TestRateLimiter(t *testing.T) {
-	policy := NewPolicy(50, 10, 5)
+	policy := NewPolicy(50*time.Millisecond, 10*time.Millisecond, 5)
 
 	limiter := New(policy)
 	limiter.SetStateListener(func(event *Event) {


### PR DESCRIPTION
1. add max connection limit to `MQTTProxy`
2. add rate limit to connection and client publish
3. add span to MQTT HTTP endpoint related logging 
4. add more api for MQTT HTTP endpoint to get all sessions and delete sessions
5. update cluster to allow watch and get etcd data with options (only watch delete data or get prefix with keys only)