### PR TITLE
Add service canary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ build_docker:
 	megaease/golang:1.17-alpine make build DOCKER=true
 	docker build -t megaease/easegress:${RELEASE} -f ./build/package/Dockerfile .
 	docker tag megaease/easegress:${RELEASE} megaease/easegress:latest
+	docker tag megaease/easegress:latest megaease/easegress:server-sidecar
 
 test:
 	cd ${MKFILE_DIR}

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/libdns/route53 v1.1.2
 	github.com/libdns/vultr v0.0.0-20211122184636-cd4cb5c12e51
 	github.com/lucas-clemente/quic-go v0.24.0
-	github.com/megaease/easemesh-api v1.3.3
+	github.com/megaease/easemesh-api v1.3.4
 	github.com/megaease/grace v1.0.0
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/nacos-group/nacos-sdk-go v1.0.8
@@ -61,7 +61,7 @@ require (
 	go.etcd.io/etcd/client/v3 v3.5.0
 	go.etcd.io/etcd/server/v3 v3.5.0
 	go.uber.org/zap v1.19.0
-	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
+	golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871
 	golang.org/x/net v0.0.0-20211118161319-6a13c67c3ce4
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20211030160813-b3129d9d1021

--- a/go.sum
+++ b/go.sum
@@ -421,7 +421,7 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v0.3.0-java/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/envoyproxy/protoc-gen-validate v0.6.1/go.mod h1:txg5va2Qkip90uYoSKH+nkAAmXrb2j3iq4FLwdrCbXQ=
+github.com/envoyproxy/protoc-gen-validate v0.6.2/go.mod h1:2t7qjJNvHPx8IjnBOzl9E9/baC+qXE/TeeyBRzgJDws=
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
@@ -771,7 +771,7 @@ github.com/huandu/xstrings v1.0.0/go.mod h1:4qWG/gcEcfX4z/mBDHJ++3ReCw9ibxbsNJbc
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0 h1:i462o439ZjprVSFSZLZxcsoAe592sZB1rci2Z8j4wdk=
 github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0/go.mod h1:N0Wam8K1arqPXNWjMo21EXnBPOPp36vB07FNRdD2geA=
-github.com/iancoleman/strcase v0.0.0-20180726023541-3605ed457bf7/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
+github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.4/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
@@ -895,7 +895,7 @@ github.com/lightstep/tracecontext.go v0.0.0-20181129014701-1757c391b1ac/go.mod h
 github.com/lucas-clemente/quic-go v0.24.0 h1:ToR7SIIEdrgOhgVTHvPgdVRJfgVy+N0wQAagH7L4d5g=
 github.com/lucas-clemente/quic-go v0.24.0/go.mod h1:paZuzjXCE5mj6sikVLMvqXk8lJV2AsqtJ6bDhjEfxx0=
 github.com/lunixbochs/vtclean v1.0.0/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=
-github.com/lyft/protoc-gen-star v0.5.1/go.mod h1:9toiA3cC7z5uVbODF7kEQ91Xn7XNFkVUl+SrEe+ZORU=
+github.com/lyft/protoc-gen-star v0.5.3/go.mod h1:V0xaHgaf5oCCqmcxYcWiDfTiKsZsRc87/1qhoTACD8w=
 github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -937,8 +937,6 @@ github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpe
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
-github.com/megaease/easemesh-api v1.3.3 h1:jaTdi6KkZ1BoQuqBDtV22HEI5GXNjsj+rhum6+vUnYs=
-github.com/megaease/easemesh-api v1.3.3/go.mod h1:cNKMXb0iK3M+woe0JzivXFfnvP0E1MeF+zbeWFEuU7g=
 github.com/megaease/easemesh-api v1.3.4 h1:0paB8GGyFofg094Cz4piv9KV/tMVDLNQKbEk0mN3iRI=
 github.com/megaease/easemesh-api v1.3.4/go.mod h1:VJWyuh/airQFJPJ9nfzAjholezslTHYZ70kU4Oq37MU=
 github.com/megaease/grace v1.0.0 h1:b44R3j6e/iaN62F4ZUnru9nzL1VaIcxxUZjSPVtTVzI=
@@ -1210,7 +1208,6 @@ github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasO
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/afero v1.3.3/go.mod h1:5KUK8ByomD5Ti5Artl0RtHeI5pTF7MIDuXL3yY520V4=
-github.com/spf13/afero v1.3.4/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
 github.com/spf13/afero v1.6.0 h1:xoax2sJ2DT8S8xA2paPFjDCScCNeWsg75VG0DLRreiY=
 github.com/spf13/afero v1.6.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
@@ -1450,10 +1447,8 @@ golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWP
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.0.0-20210915214749-c084706c2272/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210920023735-84f357641f63/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 h1:7I4JAnoQBe7ZtJcBaYHi5UtiO8tQHbUSXxL+pnGRANg=
-golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871 h1:/pEO3GD/ABYAjuakUS6xSEmmlyVS4kxBNkeA9tLJiTI=
 golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -1494,8 +1489,9 @@ golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.5.0 h1:UG21uOlmZabA4fW5i7ZX6bjw1xELEGg/ZLgZq9auk/Q=
+golang.org/x/mod v0.5.0/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1560,8 +1556,10 @@ golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210520170846-37e1c6afe023/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210825183410-e898025ed96a/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210917221730-978cfadd31cf/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211118161319-6a13c67c3ce4 h1:DZshvxDdVoeKIbudAdFEKi+f70l51luSy/7b76ibTY0=
 golang.org/x/net v0.0.0-20211118161319-6a13c67c3ce4/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -1701,6 +1699,7 @@ golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210603125802-9665404d3644/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210816183151-1e6c022a8912/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211030160813-b3129d9d1021 h1:giLT+HuUP/gXYrG2Plg9WTjj4qhfgaW424ZIFog3rlk=
 golang.org/x/sys v0.0.0-20211030160813-b3129d9d1021/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
@@ -1781,7 +1780,6 @@ golang.org/x/tools v0.0.0-20200505023115-26f46d2f7ef8/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200512001501-aaeff5de670a/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200512131952-2bc93b1c0c88/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200515010526-7d3b6ebf133d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
-golang.org/x/tools v0.0.0-20200522201501-cb1345f3a375/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200618134242-20370b0cb4b2/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
@@ -1916,8 +1914,8 @@ google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c/go.mod h1:UODoCrxH
 google.golang.org/genproto v0.0.0-20210604141403-392c879c8b08/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=
 google.golang.org/genproto v0.0.0-20210608205507-b6d2f5bf0d7d/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=
 google.golang.org/genproto v0.0.0-20210624195500-8bfb893ecb84/go.mod h1:SzzZ/N+nwJDaO1kznhnlzqS8ocJICar6hYhVyhi++24=
-google.golang.org/genproto v0.0.0-20210916144049-3192f974c780 h1:RE6jTVCXBKZ7U9atSg8N3bsjRvvUujhEPspbEhdyy8s=
-google.golang.org/genproto v0.0.0-20210916144049-3192f974c780/go.mod h1:eFjDcFEctNawg4eG61bRv87N7iHBWyVhJu7u1kqDUXY=
+google.golang.org/genproto v0.0.0-20211129164237-f09f9a12af12 h1:DN5b3HU13J4sMd/QjDx34U6afpaexKTDdop+26pdjdk=
+google.golang.org/genproto v0.0.0-20211129164237-f09f9a12af12/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/grpc v0.0.0-20160317175043-d3ddb4469d5a/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.14.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.16.0/go.mod h1:0JHn/cJsOMiMfNA9+DeHDlAU7KAAB5GDlYFpa9MZMio=

--- a/go.sum
+++ b/go.sum
@@ -422,7 +422,6 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v0.3.0-java/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v0.6.1/go.mod h1:txg5va2Qkip90uYoSKH+nkAAmXrb2j3iq4FLwdrCbXQ=
-github.com/envoyproxy/protoc-gen-validate v0.6.2/go.mod h1:2t7qjJNvHPx8IjnBOzl9E9/baC+qXE/TeeyBRzgJDws=
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
@@ -773,7 +772,6 @@ github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq
 github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0 h1:i462o439ZjprVSFSZLZxcsoAe592sZB1rci2Z8j4wdk=
 github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0/go.mod h1:N0Wam8K1arqPXNWjMo21EXnBPOPp36vB07FNRdD2geA=
 github.com/iancoleman/strcase v0.0.0-20180726023541-3605ed457bf7/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
-github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.4/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
@@ -898,7 +896,6 @@ github.com/lucas-clemente/quic-go v0.24.0 h1:ToR7SIIEdrgOhgVTHvPgdVRJfgVy+N0wQAa
 github.com/lucas-clemente/quic-go v0.24.0/go.mod h1:paZuzjXCE5mj6sikVLMvqXk8lJV2AsqtJ6bDhjEfxx0=
 github.com/lunixbochs/vtclean v1.0.0/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=
 github.com/lyft/protoc-gen-star v0.5.1/go.mod h1:9toiA3cC7z5uVbODF7kEQ91Xn7XNFkVUl+SrEe+ZORU=
-github.com/lyft/protoc-gen-star v0.5.3/go.mod h1:V0xaHgaf5oCCqmcxYcWiDfTiKsZsRc87/1qhoTACD8w=
 github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -1457,7 +1454,6 @@ golang.org/x/crypto v0.0.0-20210915214749-c084706c2272/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20210920023735-84f357641f63/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 h1:7I4JAnoQBe7ZtJcBaYHi5UtiO8tQHbUSXxL+pnGRANg=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871 h1:/pEO3GD/ABYAjuakUS6xSEmmlyVS4kxBNkeA9tLJiTI=
 golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -1500,8 +1496,6 @@ golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.5.0 h1:UG21uOlmZabA4fW5i7ZX6bjw1xELEGg/ZLgZq9auk/Q=
-golang.org/x/mod v0.5.0/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1566,10 +1560,8 @@ golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210520170846-37e1c6afe023/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210825183410-e898025ed96a/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210917221730-978cfadd31cf/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211118161319-6a13c67c3ce4 h1:DZshvxDdVoeKIbudAdFEKi+f70l51luSy/7b76ibTY0=
 golang.org/x/net v0.0.0-20211118161319-6a13c67c3ce4/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -1709,7 +1701,6 @@ golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210603125802-9665404d3644/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210816183151-1e6c022a8912/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211030160813-b3129d9d1021 h1:giLT+HuUP/gXYrG2Plg9WTjj4qhfgaW424ZIFog3rlk=
 golang.org/x/sys v0.0.0-20211030160813-b3129d9d1021/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
@@ -1927,8 +1918,6 @@ google.golang.org/genproto v0.0.0-20210608205507-b6d2f5bf0d7d/go.mod h1:UODoCrxH
 google.golang.org/genproto v0.0.0-20210624195500-8bfb893ecb84/go.mod h1:SzzZ/N+nwJDaO1kznhnlzqS8ocJICar6hYhVyhi++24=
 google.golang.org/genproto v0.0.0-20210916144049-3192f974c780 h1:RE6jTVCXBKZ7U9atSg8N3bsjRvvUujhEPspbEhdyy8s=
 google.golang.org/genproto v0.0.0-20210916144049-3192f974c780/go.mod h1:eFjDcFEctNawg4eG61bRv87N7iHBWyVhJu7u1kqDUXY=
-google.golang.org/genproto v0.0.0-20211129164237-f09f9a12af12 h1:DN5b3HU13J4sMd/QjDx34U6afpaexKTDdop+26pdjdk=
-google.golang.org/genproto v0.0.0-20211129164237-f09f9a12af12/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/grpc v0.0.0-20160317175043-d3ddb4469d5a/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.14.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.16.0/go.mod h1:0JHn/cJsOMiMfNA9+DeHDlAU7KAAB5GDlYFpa9MZMio=

--- a/go.sum
+++ b/go.sum
@@ -422,6 +422,7 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v0.3.0-java/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v0.6.1/go.mod h1:txg5va2Qkip90uYoSKH+nkAAmXrb2j3iq4FLwdrCbXQ=
+github.com/envoyproxy/protoc-gen-validate v0.6.2/go.mod h1:2t7qjJNvHPx8IjnBOzl9E9/baC+qXE/TeeyBRzgJDws=
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
@@ -772,6 +773,7 @@ github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq
 github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0 h1:i462o439ZjprVSFSZLZxcsoAe592sZB1rci2Z8j4wdk=
 github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0/go.mod h1:N0Wam8K1arqPXNWjMo21EXnBPOPp36vB07FNRdD2geA=
 github.com/iancoleman/strcase v0.0.0-20180726023541-3605ed457bf7/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
+github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.4/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
@@ -896,6 +898,7 @@ github.com/lucas-clemente/quic-go v0.24.0 h1:ToR7SIIEdrgOhgVTHvPgdVRJfgVy+N0wQAa
 github.com/lucas-clemente/quic-go v0.24.0/go.mod h1:paZuzjXCE5mj6sikVLMvqXk8lJV2AsqtJ6bDhjEfxx0=
 github.com/lunixbochs/vtclean v1.0.0/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=
 github.com/lyft/protoc-gen-star v0.5.1/go.mod h1:9toiA3cC7z5uVbODF7kEQ91Xn7XNFkVUl+SrEe+ZORU=
+github.com/lyft/protoc-gen-star v0.5.3/go.mod h1:V0xaHgaf5oCCqmcxYcWiDfTiKsZsRc87/1qhoTACD8w=
 github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -939,6 +942,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182aff
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/megaease/easemesh-api v1.3.3 h1:jaTdi6KkZ1BoQuqBDtV22HEI5GXNjsj+rhum6+vUnYs=
 github.com/megaease/easemesh-api v1.3.3/go.mod h1:cNKMXb0iK3M+woe0JzivXFfnvP0E1MeF+zbeWFEuU7g=
+github.com/megaease/easemesh-api v1.3.4 h1:0paB8GGyFofg094Cz4piv9KV/tMVDLNQKbEk0mN3iRI=
+github.com/megaease/easemesh-api v1.3.4/go.mod h1:VJWyuh/airQFJPJ9nfzAjholezslTHYZ70kU4Oq37MU=
 github.com/megaease/grace v1.0.0 h1:b44R3j6e/iaN62F4ZUnru9nzL1VaIcxxUZjSPVtTVzI=
 github.com/megaease/grace v1.0.0/go.mod h1:mOR6MVYQ6zGyuz9Y2or/VJ6QWueTL3erxWfIwyCmiIg=
 github.com/microcosm-cc/bluemonday v1.0.1/go.mod h1:hsXNsILzKxV+sX77C5b8FSuKF00vh2OMYv+xgHpAMF4=
@@ -1452,6 +1457,8 @@ golang.org/x/crypto v0.0.0-20210915214749-c084706c2272/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20210920023735-84f357641f63/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 h1:7I4JAnoQBe7ZtJcBaYHi5UtiO8tQHbUSXxL+pnGRANg=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871 h1:/pEO3GD/ABYAjuakUS6xSEmmlyVS4kxBNkeA9tLJiTI=
+golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -1493,6 +1500,8 @@ golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.5.0 h1:UG21uOlmZabA4fW5i7ZX6bjw1xELEGg/ZLgZq9auk/Q=
+golang.org/x/mod v0.5.0/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1557,8 +1566,10 @@ golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210520170846-37e1c6afe023/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210825183410-e898025ed96a/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210917221730-978cfadd31cf/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211118161319-6a13c67c3ce4 h1:DZshvxDdVoeKIbudAdFEKi+f70l51luSy/7b76ibTY0=
 golang.org/x/net v0.0.0-20211118161319-6a13c67c3ce4/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -1698,6 +1709,7 @@ golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210603125802-9665404d3644/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210816183151-1e6c022a8912/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211030160813-b3129d9d1021 h1:giLT+HuUP/gXYrG2Plg9WTjj4qhfgaW424ZIFog3rlk=
 golang.org/x/sys v0.0.0-20211030160813-b3129d9d1021/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
@@ -1915,6 +1927,8 @@ google.golang.org/genproto v0.0.0-20210608205507-b6d2f5bf0d7d/go.mod h1:UODoCrxH
 google.golang.org/genproto v0.0.0-20210624195500-8bfb893ecb84/go.mod h1:SzzZ/N+nwJDaO1kznhnlzqS8ocJICar6hYhVyhi++24=
 google.golang.org/genproto v0.0.0-20210916144049-3192f974c780 h1:RE6jTVCXBKZ7U9atSg8N3bsjRvvUujhEPspbEhdyy8s=
 google.golang.org/genproto v0.0.0-20210916144049-3192f974c780/go.mod h1:eFjDcFEctNawg4eG61bRv87N7iHBWyVhJu7u1kqDUXY=
+google.golang.org/genproto v0.0.0-20211129164237-f09f9a12af12 h1:DN5b3HU13J4sMd/QjDx34U6afpaexKTDdop+26pdjdk=
+google.golang.org/genproto v0.0.0-20211129164237-f09f9a12af12/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/grpc v0.0.0-20160317175043-d3ddb4469d5a/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.14.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.16.0/go.mod h1:0JHn/cJsOMiMfNA9+DeHDlAU7KAAB5GDlYFpa9MZMio=

--- a/pkg/filter/meshadaptor/meshadaptor.go
+++ b/pkg/filter/meshadaptor/meshadaptor.go
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2017, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package meshadaptor
+
+import (
+	"github.com/megaease/easegress/pkg/context"
+	"github.com/megaease/easegress/pkg/object/httppipeline"
+	"github.com/megaease/easegress/pkg/util/httpfilter"
+	"github.com/megaease/easegress/pkg/util/httpheader"
+	"github.com/megaease/easegress/pkg/util/pathadaptor"
+)
+
+const (
+	// Kind is the kind of MeshAdaptor.
+	Kind = "MeshAdaptor"
+)
+
+var results = []string{}
+
+func init() {
+	httppipeline.Register(&MeshAdaptor{})
+}
+
+type (
+	// MeshAdaptor is filter MeshAdaptor.
+	MeshAdaptor struct {
+		filterSpec *httppipeline.FilterSpec
+		spec       *Spec
+
+		pa *pathadaptor.PathAdaptor
+	}
+
+	// Spec is HTTPAdaptor Spec.
+	Spec struct {
+		ServiceCanaries []*ServiceCanaryAdaptor `yaml:"serviceCanaries" jsonschema:"omitempty"`
+	}
+
+	// ServiceCanaryAdaptor is the service canary adaptor.
+	ServiceCanaryAdaptor struct {
+		Header *httpheader.AdaptSpec `yaml:"header,omitempty" jsonschema:"required"`
+		Filter *httpfilter.Spec      `yaml:"filter" jsonschema:"required"`
+
+		filter *httpfilter.HTTPFilter
+	}
+)
+
+// Kind returns the kind of MeshAdaptor.
+func (ra *MeshAdaptor) Kind() string {
+	return Kind
+}
+
+// DefaultSpec returns default spec of MeshAdaptor.
+func (ra *MeshAdaptor) DefaultSpec() interface{} {
+	return &Spec{}
+}
+
+// Description returns the description of MeshAdaptor.
+func (ra *MeshAdaptor) Description() string {
+	return "MeshAdaptor adapts requests for mesh traffic."
+}
+
+// Results returns the results of MeshAdaptor.
+func (ra *MeshAdaptor) Results() []string {
+	return results
+}
+
+// Init initializes MeshAdaptor.
+func (ra *MeshAdaptor) Init(filterSpec *httppipeline.FilterSpec) {
+	ra.filterSpec, ra.spec = filterSpec, filterSpec.FilterSpec().(*Spec)
+	ra.reload()
+}
+
+// Inherit inherits previous generation of MeshAdaptor.
+func (ra *MeshAdaptor) Inherit(filterSpec *httppipeline.FilterSpec, previousGeneration httppipeline.Filter) {
+	previousGeneration.Close()
+	ra.Init(filterSpec)
+}
+
+func (ra *MeshAdaptor) reload() {
+	for _, serviceCanary := range ra.spec.ServiceCanaries {
+		serviceCanary.filter = httpfilter.New(serviceCanary.Filter)
+	}
+}
+
+// Handle adapts request.
+func (ra *MeshAdaptor) Handle(ctx context.HTTPContext) string {
+	for _, serviceCanary := range ra.spec.ServiceCanaries {
+		if serviceCanary.filter.Filter(ctx) {
+			ctx.Request().Header().Adapt(serviceCanary.Header, ctx.Template())
+		}
+	}
+
+	result := ""
+	return ctx.CallNextHandler(result)
+}
+
+// Status returns status.
+func (ra *MeshAdaptor) Status() interface{} { return nil }
+
+// Close closes MeshAdaptor.
+func (ra *MeshAdaptor) Close() {}

--- a/pkg/object/meshcontroller/api/api.go
+++ b/pkg/object/meshcontroller/api/api.go
@@ -51,8 +51,8 @@ const (
 	// MeshServicePath is the mesh service path.
 	MeshServicePath = "/mesh/services/{serviceName}"
 
-	// MeshServiceCanaryPath is the mesh service canary path.
-	MeshServiceCanaryPath = "/mesh/services/{serviceName}/canary"
+	// OldMeshServiceCanaryPath is the mesh service canary path.
+	OldMeshServiceCanaryPath = "/mesh/services/{serviceName}/canary"
 
 	// MeshServiceMockPath is the mesh service mock path.
 	MeshServiceMockPath = "/mesh/services/{serviceName}/mock"
@@ -107,6 +107,12 @@ const (
 
 	// MeshWatchCustomResource is the path to watch custom resources of a specified kind
 	MeshWatchCustomResource = "/mesh/watchcustomresources/{kind}"
+
+	// MeshServiceCanaryPrefix is the service canary prefix.
+	MeshServiceCanaryPrefix = "/mesh/servicecanaries"
+
+	// MeshServiceCanaryPath is the service canary path.
+	MeshServiceCanaryPath = "/mesh/servicecanaries/{serviceCanaryName}"
 )
 
 type (
@@ -160,10 +166,10 @@ func (a *API) registerAPIs() {
 			{Path: MeshServiceInstancePath, Method: "GET", Handler: a.getServiceInstanceSpec},
 			{Path: MeshServiceInstancePath, Method: "DELETE", Handler: a.offlineServiceInstance},
 
-			{Path: MeshServiceCanaryPath, Method: "POST", Handler: a.createPartOfService(canaryMeta)},
-			{Path: MeshServiceCanaryPath, Method: "GET", Handler: a.getPartOfService(canaryMeta)},
-			{Path: MeshServiceCanaryPath, Method: "PUT", Handler: a.updatePartOfService(canaryMeta)},
-			{Path: MeshServiceCanaryPath, Method: "DELETE", Handler: a.deletePartOfService(canaryMeta)},
+			{Path: OldMeshServiceCanaryPath, Method: "POST", Handler: a.createPartOfService(canaryMeta)},
+			{Path: OldMeshServiceCanaryPath, Method: "GET", Handler: a.getPartOfService(canaryMeta)},
+			{Path: OldMeshServiceCanaryPath, Method: "PUT", Handler: a.updatePartOfService(canaryMeta)},
+			{Path: OldMeshServiceCanaryPath, Method: "DELETE", Handler: a.deletePartOfService(canaryMeta)},
 
 			{Path: MeshServiceMockPath, Method: "POST", Handler: a.createPartOfService(mockMeta)},
 			{Path: MeshServiceMockPath, Method: "GET", Handler: a.getPartOfService(mockMeta)},
@@ -221,6 +227,12 @@ func (a *API) registerAPIs() {
 			{Path: MeshCustomResource, Method: "DELETE", Handler: a.deleteCustomResource},
 
 			{Path: MeshWatchCustomResource, Method: "GET", Handler: a.watchCustomResources},
+
+			{Path: MeshServiceCanaryPrefix, Method: "GET", Handler: a.listServiceCanaries},
+			{Path: MeshServiceCanaryPrefix, Method: "POST", Handler: a.createServiceCanary},
+			{Path: MeshServiceCanaryPath, Method: "GET", Handler: a.getServiceCanary},
+			{Path: MeshServiceCanaryPath, Method: "PUT", Handler: a.updateServiceCanary},
+			{Path: MeshServiceCanaryPath, Method: "DELETE", Handler: a.deleteServiceCanary},
 		},
 	}
 

--- a/pkg/object/meshcontroller/api/api_servicecanary.go
+++ b/pkg/object/meshcontroller/api/api_servicecanary.go
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2017, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"path"
+
+	"github.com/go-chi/chi/v5"
+	v1alpha1 "github.com/megaease/easemesh-api/v1alpha1"
+
+	"github.com/megaease/easegress/pkg/api"
+	"github.com/megaease/easegress/pkg/logger"
+	"github.com/megaease/easegress/pkg/object/meshcontroller/spec"
+)
+
+func (a *API) readServiceCanaryName(r *http.Request) (string, error) {
+	serviceName := chi.URLParam(r, "serviceCanaryName")
+	if serviceName == "" {
+		return "", fmt.Errorf("empty serviceCanary name")
+	}
+
+	return serviceName, nil
+}
+
+func (a *API) listServiceCanaries(w http.ResponseWriter, r *http.Request) {
+	// NOTE: specs has been sorted alread.
+	specs := a.service.ListServiceCanaries()
+
+	var apiSpecs []*v1alpha1.ServiceCanary
+	for _, v := range specs {
+		serviceCanary := &v1alpha1.ServiceCanary{}
+		err := a.convertSpecToPB(v, serviceCanary)
+		if err != nil {
+			logger.Errorf("convert spec %#v to pb spec failed: %v", v, err)
+			continue
+		}
+		apiSpecs = append(apiSpecs, serviceCanary)
+	}
+	buff, err := json.Marshal(apiSpecs)
+	if err != nil {
+		panic(fmt.Errorf("marshal %#v to json failed: %v", specs, err))
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(buff)
+}
+
+func (a *API) createServiceCanary(w http.ResponseWriter, r *http.Request) {
+	pbServiceCanarySpec := &v1alpha1.ServiceCanary{}
+	serviceCanarySpec := &spec.ServiceCanary{}
+
+	err := a.readAPISpec(r, pbServiceCanarySpec, serviceCanarySpec)
+	if err != nil {
+		api.HandleAPIError(w, r, http.StatusBadRequest, err)
+		return
+	}
+
+	if serviceCanarySpec.Priority == 0 {
+		serviceCanarySpec.Priority = 5
+	}
+
+	a.service.Lock()
+	defer a.service.Unlock()
+
+	oldSpec := a.service.GetServiceCanary(serviceCanarySpec.Name)
+	if oldSpec != nil {
+		api.HandleAPIError(w, r, http.StatusConflict, fmt.Errorf("%s existed", serviceCanarySpec.Name))
+		return
+	}
+
+	a.service.PutServiceCanarySpec(serviceCanarySpec)
+
+	w.Header().Set("Location", path.Join(r.URL.Path, serviceCanarySpec.Name))
+	w.WriteHeader(http.StatusCreated)
+}
+
+func (a *API) getServiceCanary(w http.ResponseWriter, r *http.Request) {
+	serviceCanaryName, err := a.readServiceCanaryName(r)
+	if err != nil {
+		api.HandleAPIError(w, r, http.StatusBadRequest, err)
+		return
+	}
+
+	serviceCanarySpec := a.service.GetServiceCanary(serviceCanaryName)
+	if serviceCanarySpec == nil {
+		api.HandleAPIError(w, r, http.StatusNotFound, fmt.Errorf("%s not found", serviceCanaryName))
+		return
+	}
+	pbServiceCanarySpec := &v1alpha1.ServiceCanary{}
+	err = a.convertSpecToPB(serviceCanarySpec, pbServiceCanarySpec)
+	if err != nil {
+		panic(fmt.Errorf("convert spec %#v to pb failed: %v", serviceCanarySpec, err))
+	}
+
+	buff, err := json.Marshal(pbServiceCanarySpec)
+	if err != nil {
+		panic(fmt.Errorf("marshal %#v to json failed: %v", pbServiceCanarySpec, err))
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(buff)
+}
+
+func (a *API) updateServiceCanary(w http.ResponseWriter, r *http.Request) {
+	pbServiceCanarySpec := &v1alpha1.ServiceCanary{}
+	serviceCanarySpec := &spec.ServiceCanary{}
+
+	serviceCanaryName, err := a.readServiceCanaryName(r)
+	if err != nil {
+		api.HandleAPIError(w, r, http.StatusBadRequest, err)
+		return
+	}
+	err = a.readAPISpec(r, pbServiceCanarySpec, serviceCanarySpec)
+	if err != nil {
+		api.HandleAPIError(w, r, http.StatusBadRequest, err)
+		return
+	}
+	if serviceCanaryName != serviceCanarySpec.Name {
+		api.HandleAPIError(w, r, http.StatusBadRequest,
+			fmt.Errorf("name conflict: %s %s", serviceCanaryName, serviceCanarySpec.Name))
+		return
+	}
+
+	if serviceCanarySpec.Priority == 0 {
+		serviceCanarySpec.Priority = 5
+	}
+
+	a.service.Lock()
+	defer a.service.Unlock()
+
+	oldSpec := a.service.GetServiceCanary(serviceCanaryName)
+	if oldSpec == nil {
+		api.HandleAPIError(w, r, http.StatusNotFound, fmt.Errorf("%s not found", serviceCanaryName))
+		return
+	}
+
+	a.service.PutServiceCanarySpec(serviceCanarySpec)
+}
+
+func (a *API) deleteServiceCanary(w http.ResponseWriter, r *http.Request) {
+	serviceCanaryName, err := a.readServiceCanaryName(r)
+	if err != nil {
+		api.HandleAPIError(w, r, http.StatusBadRequest, err)
+		return
+	}
+
+	a.service.Lock()
+	defer a.service.Unlock()
+
+	oldSpec := a.service.GetServiceCanary(serviceCanaryName)
+	if oldSpec == nil {
+		api.HandleAPIError(w, r, http.StatusNotFound, fmt.Errorf("%s not found", serviceCanaryName))
+		return
+	}
+
+	a.service.DeleteServiceCanary(serviceCanaryName)
+}

--- a/pkg/object/meshcontroller/ingresscontroller/ingresscontroller.go
+++ b/pkg/object/meshcontroller/ingresscontroller/ingresscontroller.go
@@ -240,6 +240,7 @@ func (ic *IngressController) _reloadHTTPPipelines() {
 		rootCert = ic.service.GetRootCert()
 	}
 
+	canaries := ic.service.ListServiceCanaries()
 	for _, serviceSpec := range ic.service.ListServiceSpecs() {
 		if _, exists := ic.ingressBackends[serviceSpec.BackendName()]; !exists {
 			continue
@@ -259,8 +260,7 @@ func (ic *IngressController) _reloadHTTPPipelines() {
 			continue
 		}
 
-		// FIXME: What if the instance address is always 127.0.0.1.
-		superSpec, err := serviceSpec.IngressPipelineSpec(instanceSpecs, cert, rootCert)
+		superSpec, err := serviceSpec.IngressControllerPipelineSpec(instanceSpecs, canaries, cert, rootCert)
 		if err != nil {
 			logger.Errorf("get ingress pipeline for %s failed: %v",
 				serviceSpec.Name, err)

--- a/pkg/object/meshcontroller/layout/layout.go
+++ b/pkg/object/meshcontroller/layout/layout.go
@@ -59,6 +59,9 @@ const (
 	customResource           = "/mesh/custom-resources/%s/%s/" // +kind +name
 
 	globalCanaryHeaders = "/mesh/canary-headers"
+
+	serviceCanaryPrefix = "/mesh/service-canary/"
+	serviceCanary       = "/mesh/service-canary/%s"
 )
 
 // ServiceSpecPrefix returns the prefix of service.
@@ -204,4 +207,14 @@ func AllIngressControllerInstanceSpecPrefix() string {
 // AllIngressControllerInstanceCertPrefix returns all instances specs prefix.
 func AllIngressControllerInstanceCertPrefix() string {
 	return allIngressControllerInstanceCertPrefix
+}
+
+// ServiceCanaryPrefix returns the prefix of service canaries.
+func ServiceCanaryPrefix() string {
+	return serviceCanaryPrefix
+}
+
+// ServiceCanaryKey returns the key of service canary.
+func ServiceCanaryKey(serviceCanaryName string) string {
+	return fmt.Sprintf(serviceCanary, serviceCanaryName)
 }

--- a/pkg/object/meshcontroller/master/master.go
+++ b/pkg/object/meshcontroller/master/master.go
@@ -235,7 +235,7 @@ func (m *Master) scanInstances() (failedInstances []*spec.ServiceInstanceSpec,
 		logger.Warnf("dead instances: %s", serviceInstances(deadInstances))
 	}
 	if len(rebornInstances) > 0 {
-		logger.Warnf("reborn instances: %s", serviceInstances(rebornInstances))
+		logger.Infof("reborn instances: %s", serviceInstances(rebornInstances))
 	}
 
 	return

--- a/pkg/object/meshcontroller/service/service.go
+++ b/pkg/object/meshcontroller/service/service.go
@@ -272,7 +272,6 @@ func (s *Service) PutIngressControllerInstanceCert(instaceID string, cert *spec.
 	if err != nil {
 		api.ClusterPanic(err)
 	}
-	return
 }
 
 // DelIngressControllerInstanceCert deletes root cert.
@@ -281,7 +280,6 @@ func (s *Service) DelIngressControllerInstanceCert(instanceID string) {
 	if err != nil {
 		api.ClusterPanic(err)
 	}
-	return
 }
 
 // DelAllIngressControllerInstanceCert deletes all ingress controller certs.
@@ -303,7 +301,6 @@ func (s *Service) PutIngressControllerInstanceSpec(instance *spec.ServiceInstanc
 	if err != nil {
 		api.ClusterPanic(err)
 	}
-	return
 }
 
 // GetRootCert  gets the root cert.
@@ -337,7 +334,6 @@ func (s *Service) PutRootCert(cert *spec.Certificate) {
 	if err != nil {
 		api.ClusterPanic(err)
 	}
-	return
 }
 
 //  DelRootCert deletes root cert.
@@ -959,28 +955,22 @@ func (s *Service) PutServiceCanarySpec(serviceCanarySpec *spec.ServiceCanary) {
 
 // GetServiceCanary gets the service canary.
 func (s *Service) GetServiceCanary(serviceCanaryName string) *spec.ServiceCanary {
-	serviceCanary, _ := s.GetServiceCanaryWithInfo(serviceCanaryName)
-	return serviceCanary
-}
-
-// GetServiceCanaryWithInfo gets the service canary with raw info.
-func (s *Service) GetServiceCanaryWithInfo(serviceCanaryName string) (*spec.ServiceCanary, *mvccpb.KeyValue) {
-	kv, err := s.store.GetRaw(layout.ServiceCanaryKey(serviceCanaryName))
+	value, err := s.store.Get(layout.ServiceCanaryKey(serviceCanaryName))
 	if err != nil {
 		api.ClusterPanic(err)
 	}
 
-	if kv == nil {
-		return nil, nil
+	if value == nil {
+		return nil
 	}
 
 	serviceCanary := &spec.ServiceCanary{}
-	err = yaml.Unmarshal(kv.Value, serviceCanary)
+	err = yaml.Unmarshal([]byte(*value), serviceCanary)
 	if err != nil {
-		panic(fmt.Errorf("BUG: unmarshal %s to yaml failed: %v", string(kv.Value), err))
+		panic(fmt.Errorf("BUG: unmarshal %s to yaml failed: %v", string(*value), err))
 	}
 
-	return serviceCanary, kv
+	return serviceCanary
 }
 
 // DeleteServiceCanary deletes service canary.

--- a/pkg/object/meshcontroller/service/service.go
+++ b/pkg/object/meshcontroller/service/service.go
@@ -20,6 +20,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	"gopkg.in/yaml.v2"
@@ -942,3 +943,90 @@ func (s *Service) PutTrafficTarget(tt *spec.TrafficTarget) {
 		api.ClusterPanic(err)
 	}
 }
+
+// PutServiceCanarySpec updates the service canary spec.
+func (s *Service) PutServiceCanarySpec(serviceCanarySpec *spec.ServiceCanary) {
+	buff, err := yaml.Marshal(serviceCanarySpec)
+	if err != nil {
+		panic(fmt.Errorf("BUG: marshal %#v to yaml failed: %v", serviceCanarySpec, err))
+	}
+
+	err = s.store.Put(layout.ServiceCanaryKey(serviceCanarySpec.Name), string(buff))
+	if err != nil {
+		api.ClusterPanic(err)
+	}
+}
+
+// GetServiceCanary gets the service canary.
+func (s *Service) GetServiceCanary(serviceCanaryName string) *spec.ServiceCanary {
+	serviceCanary, _ := s.GetServiceCanaryWithInfo(serviceCanaryName)
+	return serviceCanary
+}
+
+// GetServiceCanaryWithInfo gets the service canary with raw info.
+func (s *Service) GetServiceCanaryWithInfo(serviceCanaryName string) (*spec.ServiceCanary, *mvccpb.KeyValue) {
+	kv, err := s.store.GetRaw(layout.ServiceCanaryKey(serviceCanaryName))
+	if err != nil {
+		api.ClusterPanic(err)
+	}
+
+	if kv == nil {
+		return nil, nil
+	}
+
+	serviceCanary := &spec.ServiceCanary{}
+	err = yaml.Unmarshal(kv.Value, serviceCanary)
+	if err != nil {
+		panic(fmt.Errorf("BUG: unmarshal %s to yaml failed: %v", string(kv.Value), err))
+	}
+
+	return serviceCanary, kv
+}
+
+// DeleteServiceCanary deletes service canary.
+func (s *Service) DeleteServiceCanary(serviceCanaryName string) {
+	err := s.store.Delete(layout.ServiceCanaryKey(serviceCanaryName))
+	if err != nil {
+		api.ClusterPanic(err)
+	}
+}
+
+// ListServiceCanaries lists service canaries.
+// It sorts service canary in order of priority(primary) and name(secondary).
+func (s *Service) ListServiceCanaries() []*spec.ServiceCanary {
+	serviceCanaries := []*spec.ServiceCanary{}
+	kvs, err := s.store.GetRawPrefix(layout.ServiceCanaryPrefix())
+	if err != nil {
+		api.ClusterPanic(err)
+	}
+
+	for _, v := range kvs {
+		serviceCanary := &spec.ServiceCanary{}
+		err := yaml.Unmarshal(v.Value, serviceCanary)
+		if err != nil {
+			logger.Errorf("BUG: unmarshal %s to yaml failed: %v", v, err)
+			continue
+		}
+		serviceCanaries = append(serviceCanaries, serviceCanary)
+	}
+
+	sort.Sort(serviceCanariesByPriority(serviceCanaries))
+
+	return serviceCanaries
+}
+
+type serviceCanariesByPriority []*spec.ServiceCanary
+
+func (s serviceCanariesByPriority) Less(i, j int) bool {
+	if s[i].Priority < s[j].Priority {
+		return true
+	}
+
+	if s[i].Priority == s[j].Priority && s[i].Name < s[j].Name {
+		return true
+	}
+
+	return false
+}
+func (s serviceCanariesByPriority) Len() int      { return len(s) }
+func (s serviceCanariesByPriority) Swap(i, j int) { s[i], s[j] = s[j], s[i] }

--- a/pkg/object/meshcontroller/spec/selector.go
+++ b/pkg/object/meshcontroller/spec/selector.go
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2017, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package spec
+
+import "github.com/megaease/easegress/pkg/util/stringtool"
+
+type (
+	// ServiceSelector is to select service instances
+	// according to service names and labels.
+	ServiceSelector struct {
+		MatchServices       []string          `yaml:"matchServices" jsonschema:"required,uniqueItems=true"`
+		MatchInstanceLabels map[string]string `yaml:"matchInstanceLabels" jsonschema:"required"`
+	}
+)
+
+// NoopServiceSelector selects none of services or instances.
+var NoopServiceSelector = &ServiceSelector{}
+
+// MatchInstance returns if selecting the service instance.
+func (s *ServiceSelector) MatchInstance(serviceName string, instancelabels map[string]string) bool {
+	if !stringtool.StrInSlice(serviceName, s.MatchServices) {
+		return false
+	}
+
+	for k, v := range s.MatchInstanceLabels {
+		if instancelabels[k] != v {
+			return false
+		}
+	}
+
+	return true
+}
+
+// MatchService returns if selecting the service.
+func (s *ServiceSelector) MatchService(serviceName string) bool {
+	return stringtool.StrInSlice(serviceName, s.MatchServices)
+}

--- a/pkg/object/meshcontroller/spec/selector.go
+++ b/pkg/object/meshcontroller/spec/selector.go
@@ -31,9 +31,9 @@ type (
 // NoopServiceSelector selects none of services or instances.
 var NoopServiceSelector = &ServiceSelector{}
 
-// MatchInstance returns if selecting the service instance.
+// MatchInstance returns whether selecting the service instance by service name and instance labels.
 func (s *ServiceSelector) MatchInstance(serviceName string, instancelabels map[string]string) bool {
-	if !stringtool.StrInSlice(serviceName, s.MatchServices) {
+	if !s.MatchService(serviceName) {
 		return false
 	}
 
@@ -46,7 +46,7 @@ func (s *ServiceSelector) MatchInstance(serviceName string, instancelabels map[s
 	return true
 }
 
-// MatchService returns if selecting the service.
+// MatchService returns whether selecting the given service.
 func (s *ServiceSelector) MatchService(serviceName string) bool {
 	return stringtool.StrInSlice(serviceName, s.MatchServices)
 }

--- a/pkg/object/meshcontroller/spec/selector_test.go
+++ b/pkg/object/meshcontroller/spec/selector_test.go
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2017, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package spec
+
+import "testing"
+
+func TestServiceSelector(t *testing.T) {
+	selector := &ServiceSelector{
+		MatchServices: []string{"order", "delivery"},
+		MatchInstanceLabels: map[string]string{
+			"release": "canary",
+		},
+	}
+
+	if !selector.MatchInstance("order", map[string]string{"release": "canary"}) {
+		t.Fatalf("not match")
+	}
+
+	if selector.MatchInstance("order", map[string]string{"release": "blue"}) {
+		t.Fatalf("not match")
+	}
+
+	if !selector.MatchInstance("delivery", map[string]string{"release": "canary"}) {
+		t.Fatalf("not match")
+	}
+
+	if selector.MatchInstance("xxx", map[string]string{"release": "canary"}) {
+		t.Fatalf("not match")
+	}
+}

--- a/pkg/object/meshcontroller/spec/spec.go
+++ b/pkg/object/meshcontroller/spec/spec.go
@@ -706,14 +706,14 @@ func (b *pipelineSpecBuilder) appendProxyWithCanary(instanceSpecs []*ServiceInst
 	}
 
 	makeServer := func(instance *ServiceInstanceSpec) *proxy.Server {
-		var url string
+		var protocol string
 		if needMTLS {
-			url = fmt.Sprintf("https://%s:%d", instance.IP, instance.Port)
+			protocol = "https"
 		} else {
-			url = fmt.Sprintf("http://%s:%d", instance.IP, instance.Port)
+			protocol = "http"
 		}
 		return &proxy.Server{
-			URL: url,
+			URL: fmt.Sprintf("%s://%s:%d", protocol, instance.IP, instance.Port),
 		}
 	}
 

--- a/pkg/object/meshcontroller/spec/spec.go
+++ b/pkg/object/meshcontroller/spec/spec.go
@@ -25,6 +25,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/megaease/easegress/pkg/filter/circuitbreaker"
+	"github.com/megaease/easegress/pkg/filter/meshadaptor"
 	"github.com/megaease/easegress/pkg/filter/mock"
 	"github.com/megaease/easegress/pkg/filter/proxy"
 	"github.com/megaease/easegress/pkg/filter/ratelimiter"
@@ -34,6 +35,7 @@ import (
 	"github.com/megaease/easegress/pkg/object/httppipeline"
 	"github.com/megaease/easegress/pkg/supervisor"
 	"github.com/megaease/easegress/pkg/util/httpfilter"
+	"github.com/megaease/easegress/pkg/util/httpheader"
 	"github.com/megaease/easegress/pkg/util/urlrule"
 )
 
@@ -86,6 +88,9 @@ const (
 
 	// PodEnvApplicationIP is the IP of the pod in environment variable.
 	PodEnvApplicationIP = "APPLICATION_IP"
+
+	// ServiceCanaryHeaderKey is the http header key of service canary.
+	ServiceCanaryHeaderKey = "X-Mesh-Service-Canary"
 )
 
 var (
@@ -164,6 +169,7 @@ type (
 	}
 
 	// Canary is the spec of service canary.
+	// Deprecated: replaced by ServiceCanary.
 	Canary struct {
 		CanaryRules []*CanaryRule `yaml:"canaryRules" jsonschema:"omitempty"`
 	}
@@ -173,6 +179,22 @@ type (
 		ServiceInstanceLabels map[string]string               `yaml:"serviceInstanceLabels" jsonschema:"required"`
 		Headers               map[string]*urlrule.StringMatch `yaml:"headers" jsonschema:"required"`
 		URLs                  []*urlrule.URLRule              `yaml:"urls" jsonschema:"required"`
+	}
+
+	// ServiceCanary is the service canary entry.
+	ServiceCanary struct {
+		Name string `yaml:"name" jsonschema:"required"`
+		// Priority must be [1, 9], the default is 5 if user does not set it.
+		// The smaller number get higher priority.
+		// The order is sorted by name alphabetically in the same priority.
+		Priority     int              `yaml:"priority" jsonschema:"omitempty"`
+		Selector     *ServiceSelector `yaml:"selector" jsonschema:"required"`
+		TrafficRules *TrafficRules    `yaml:"trafficRules" jsonschema:"required"`
+	}
+
+	// TrafficRules is the rules of traffic.
+	TrafficRules struct {
+		Headers map[string]*urlrule.StringMatch `yaml:"headers" jsonschema:"required"`
 	}
 
 	// GlobalCanaryHeaders is the spec of global service
@@ -414,6 +436,27 @@ type (
 	}
 )
 
+func (sc ServiceCanary) Validate() error {
+	if sc.Priority < 0 || sc.Priority > 9 {
+		return fmt.Errorf("invalid priority (range is [0, 9], the default 0 will be set to 5)")
+	}
+
+	return nil
+}
+
+// Clone clonse TrafficRules.
+func (tr *TrafficRules) Clone() *TrafficRules {
+	headers := map[string]*urlrule.StringMatch{}
+	for k, v := range tr.Headers {
+		stringMatch := *v
+		headers[k] = &stringMatch
+	}
+
+	return &TrafficRules{
+		Headers: headers,
+	}
+}
+
 // UnmarshalYAML implements yaml.Unmarshaler
 // the type of a DynamicObject field could be `map[interface{}]interface{}` if it is
 // unmarshaled from yaml, but some packages, like the standard json package could not
@@ -629,114 +672,144 @@ func (b *pipelineSpecBuilder) appendTimeLimiter(tl *timelimiter.Spec) *pipelineS
 	return b
 }
 
-func (b *pipelineSpecBuilder) appendProxyWithCanary(instanceSpecs []*ServiceInstanceSpec, canary *Canary, lb *proxy.LoadBalance, cert, rootCert *Certificate) *pipelineSpecBuilder {
-	mainServers := []*proxy.Server{}
-	canaryInstances := []*ServiceInstanceSpec{}
+func (b *pipelineSpecBuilder) appendProxyWithCanary(instanceSpecs []*ServiceInstanceSpec,
+	canaries []*ServiceCanary, lb *proxy.LoadBalance, cert, rootCert *Certificate) *pipelineSpecBuilder {
 
-	needMTLS := false
-	if cert != nil && rootCert != nil {
-		needMTLS = true
-	}
-
-	for k, instanceSpec := range instanceSpecs {
-		if instanceSpec.Status == ServiceStatusUp {
-			if len(instanceSpec.Labels) == 0 {
-				if needMTLS {
-					mainServers = append(mainServers, &proxy.Server{
-						URL: fmt.Sprintf("https://%s:%d", instanceSpec.IP, instanceSpec.Port),
-					})
-				} else {
-					mainServers = append(mainServers, &proxy.Server{
-						URL: fmt.Sprintf("http://%s:%d", instanceSpec.IP, instanceSpec.Port),
-					})
-
-				}
-			} else {
-				canaryInstances = append(canaryInstances, instanceSpecs[k])
-			}
-		}
-	}
-	backendName := "backend"
-
+	filterName := "backend"
 	if lb == nil {
 		lb = &proxy.LoadBalance{
 			Policy: proxy.PolicyRoundRobin,
 		}
 	}
 
-	candidatePool := []*proxy.PoolSpec{}
-	if len(canaryInstances) != 0 && canary != nil && len(canary.CanaryRules) != 0 {
-		for _, v := range canary.CanaryRules {
-			servers := []*proxy.Server{}
-			for _, ins := range canaryInstances {
-				for key, label := range v.ServiceInstanceLabels {
-					match := false
-					for insKey, insLabel := range ins.Labels {
-						if key == insKey && label == insLabel {
-							if needMTLS {
-								servers = append(servers, &proxy.Server{
-									URL: fmt.Sprintf("https://%s:%d", ins.IP, ins.Port),
-								})
-							} else {
-								servers = append(servers, &proxy.Server{
-									URL: fmt.Sprintf("http://%s:%d", ins.IP, ins.Port),
-								})
+	needMTLS := false
+	if cert != nil && rootCert != nil {
+		needMTLS = true
+	}
 
-							}
-							match = true
-							break
-						}
-					}
-					if match {
-						break
-					}
-				}
-			}
-			if len(servers) != 0 {
-				candidatePool = append(candidatePool, &proxy.PoolSpec{
-					Filter: &httpfilter.Spec{
-						Headers: v.Headers,
-						URLs:    v.URLs,
-					},
-					ServersTags:     []string{},
-					Servers:         servers,
-					ServiceRegistry: "",
-					ServiceName:     "",
-					LoadBalance:     lb,
-				})
-			}
+	mainPool := &proxy.PoolSpec{
+		LoadBalance: lb,
+	}
+	candidatePools := make([]*proxy.PoolSpec, len(canaries))
+
+	filter := map[string]interface{}{
+		"kind":     proxy.Kind,
+		"name":     filterName,
+		"mainPool": mainPool,
+	}
+	if needMTLS {
+		filter["mtls"] = &proxy.MTLS{
+			CertBase64:     cert.CertBase64,
+			KeyBase64:      cert.KeyBase64,
+			RootCertBase64: rootCert.CertBase64,
 		}
 	}
 
-	b.Flow = append(b.Flow, httppipeline.Flow{Filter: backendName})
-	if needMTLS {
-		b.Filters = append(b.Filters, map[string]interface{}{
-			"kind": proxy.Kind,
-			"name": backendName,
-			"mainPool": &proxy.PoolSpec{
-				Servers:     mainServers,
-				LoadBalance: lb,
-			},
-			"candidatePools": candidatePool,
-			"mtls": &proxy.MTLS{
-				CertBase64:     cert.CertBase64,
-				KeyBase64:      cert.KeyBase64,
-				RootCertBase64: rootCert.CertBase64,
-			},
-		})
+	makeServer := func(instance *ServiceInstanceSpec) *proxy.Server {
+		var url string
+		if needMTLS {
+			url = fmt.Sprintf("https://%s:%d", instance.IP, instance.Port)
+		} else {
+			url = fmt.Sprintf("http://%s:%d", instance.IP, instance.Port)
+		}
+		return &proxy.Server{
+			URL: url,
+		}
+	}
 
+	for _, instance := range instanceSpecs {
+		if instance.Status != ServiceStatusUp {
+			continue
+		}
+
+		server := makeServer(instance)
+
+		isCanary := false
+		for i, canary := range canaries {
+			if !canary.Selector.MatchInstance(instance.ServiceName,
+				instance.Labels) {
+				continue
+			}
+
+			if candidatePools[i] == nil {
+				headers := canary.TrafficRules.Clone().Headers
+				headers[ServiceCanaryHeaderKey] = &urlrule.StringMatch{
+					Exact: canary.Name,
+				}
+				candidatePools[i] = &proxy.PoolSpec{
+					Filter: &httpfilter.Spec{
+						MatchAllHeaders: true,
+						Headers:         headers,
+					},
+					LoadBalance: lb,
+				}
+			}
+
+			candidatePools[i].Servers = append(candidatePools[i].Servers, server)
+
+			isCanary = true
+		}
+
+		if !isCanary {
+			mainPool.Servers = append(mainPool.Servers, server)
+		}
+	}
+
+	candidates := []*proxy.PoolSpec{}
+	for _, candidate := range candidatePools {
+		if candidate == nil || len(candidate.Servers) == 0 {
+			continue
+		}
+
+		candidates = append(candidates, candidate)
+	}
+
+	if len(candidates) != 0 {
+		filter["candidatePools"] = candidates
+	}
+
+	b.Filters = append(b.Filters, filter)
+	b.Flow = append(b.Flow, httppipeline.Flow{Filter: filterName})
+
+	return b
+}
+
+func (b *pipelineSpecBuilder) appendMeshAdaptor(canaries []*ServiceCanary) *pipelineSpecBuilder {
+	if len(canaries) == 0 {
 		return b
 	}
 
-	b.Filters = append(b.Filters, map[string]interface{}{
-		"kind": proxy.Kind,
-		"name": backendName,
-		"mainPool": &proxy.PoolSpec{
-			Servers:     mainServers,
-			LoadBalance: lb,
-		},
-		"candidatePools": candidatePool,
-	})
+	filterName := "meshAdaptor"
+
+	filter := map[string]interface{}{
+		"kind": meshadaptor.Kind,
+		"name": filterName,
+	}
+	adaptors := make([]*meshadaptor.ServiceCanaryAdaptor, len(canaries))
+	for i, canary := range canaries {
+		// NOTE: It means that setting `X-Mesh-Service-Canary: canaryName`
+		// if `X-Mesh-Service-Canary` does not exist and other headers are matching.
+		headers := canary.TrafficRules.Clone().Headers
+		headers[ServiceCanaryHeaderKey] = &urlrule.StringMatch{
+			Empty: true,
+		}
+		adaptors[i] = &meshadaptor.ServiceCanaryAdaptor{
+			Filter: &httpfilter.Spec{
+				MatchAllHeaders: true,
+				Headers:         headers,
+			},
+			Header: &httpheader.AdaptSpec{
+				Set: map[string]string{
+					ServiceCanaryHeaderKey: canary.Name,
+				},
+			},
+		}
+	}
+
+	filter["serviceCanaries"] = adaptors
+
+	b.Filters = append(b.Filters, filter)
+	b.Flow = append(b.Flow, httppipeline.Flow{Filter: filterName})
 
 	return b
 }
@@ -808,12 +881,14 @@ rules:`
 	return spec, nil
 }
 
-// IngressPipelineSpec generates a spec for ingress pipeline spec
-func (s *Service) IngressPipelineSpec(instanceSpecs []*ServiceInstanceSpec, cert, rootCert *Certificate) (*supervisor.Spec, error) {
+// IngressControllerPipelineSpec generates a spec for ingress controller pipeline spec.
+func (s *Service) IngressControllerPipelineSpec(instanceSpecs []*ServiceInstanceSpec,
+	canaries []*ServiceCanary, cert, rootCert *Certificate) (*supervisor.Spec, error) {
+
 	pipelineSpecBuilder := newPipelineSpecBuilder(s.IngressPipelineName())
 
-	// inner pipeline won't need to active tls config for visiting the local app
-	pipelineSpecBuilder.appendProxyWithCanary(instanceSpecs, s.Canary, s.LoadBalance, cert, rootCert)
+	pipelineSpecBuilder.appendMeshAdaptor(canaries)
+	pipelineSpecBuilder.appendProxyWithCanary(instanceSpecs, canaries, s.LoadBalance, cert, rootCert)
 
 	yamlConfig := pipelineSpecBuilder.yamlConfig()
 	superSpec, err := supervisor.NewSpec(yamlConfig)
@@ -825,8 +900,8 @@ func (s *Service) IngressPipelineSpec(instanceSpecs []*ServiceInstanceSpec, cert
 	return superSpec, nil
 }
 
-// SideCarIngressHTTPServerSpec generates a spec for sidecar ingress HTTP server
-func (s *Service) SideCarIngressHTTPServerSpec(cert, rootCert *Certificate) (*supervisor.Spec, error) {
+// SidecarIngressHTTPServerSpec generates a spec for sidecar ingress HTTP server
+func (s *Service) SidecarIngressHTTPServerSpec(cert, rootCert *Certificate) (*supervisor.Spec, error) {
 	ingressHTTPServerFormat := `
 kind: HTTPServer
 name: %s
@@ -918,8 +993,8 @@ func (s *Service) BackendName() string {
 	return s.Name
 }
 
-// SideCarEgressHTTPServerSpec returns a spec for egress HTTP server
-func (s *Service) SideCarEgressHTTPServerSpec() (*supervisor.Spec, error) {
+// SidecarEgressHTTPServerSpec returns a spec for egress HTTP server
+func (s *Service) SidecarEgressHTTPServerSpec() (*supervisor.Spec, error) {
 	egressHTTPServerFormat := `
 kind: HTTPServer
 name: %s
@@ -950,8 +1025,8 @@ func (s *Service) Runnable() bool {
 	return true
 }
 
-// SideCarIngressPipelineSpec returns a spec for sidecar ingress pipeline
-func (s *Service) SideCarIngressPipelineSpec(applicationPort uint32) (*supervisor.Spec, error) {
+// SidecarIngressPipelineSpec returns a spec for sidecar ingress pipeline
+func (s *Service) SidecarIngressPipelineSpec(applicationPort uint32) (*supervisor.Spec, error) {
 	mainServers := []*proxy.Server{
 		{
 			URL: s.ApplicationEndpoint(applicationPort),
@@ -976,13 +1051,17 @@ func (s *Service) SideCarIngressPipelineSpec(applicationPort uint32) (*superviso
 	return superSpec, nil
 }
 
-// SideCarEgressPipelineSpec returns a spec for sidecar egress pipeline
-func (s *Service) SideCarEgressPipelineSpec(instanceSpecs []*ServiceInstanceSpec, appCert, rootCert *Certificate) (*supervisor.Spec, error) {
+// SidecarEgressPipelineSpec returns a spec for sidecar egress pipeline
+func (s *Service) SidecarEgressPipelineSpec(instanceSpecs []*ServiceInstanceSpec,
+	canaries []*ServiceCanary, appCert, rootCert *Certificate) (*supervisor.Spec, error) {
+
 	if len(instanceSpecs) == 0 {
 		return nil, fmt.Errorf("no instance")
 	}
 
 	pipelineSpecBuilder := newPipelineSpecBuilder(s.EgressPipelineName())
+
+	pipelineSpecBuilder.appendMeshAdaptor(canaries)
 
 	if !s.Runnable() {
 		pipelineSpecBuilder.appendMock(s.Mock.Rules)
@@ -993,7 +1072,7 @@ func (s *Service) SideCarEgressPipelineSpec(instanceSpecs []*ServiceInstanceSpec
 			pipelineSpecBuilder.appendCircuitBreaker(s.Resilience.CircuitBreaker)
 		}
 
-		pipelineSpecBuilder.appendProxyWithCanary(instanceSpecs, s.Canary, s.LoadBalance, appCert, rootCert)
+		pipelineSpecBuilder.appendProxyWithCanary(instanceSpecs, canaries, s.LoadBalance, appCert, rootCert)
 	}
 	yamlConfig := pipelineSpecBuilder.yamlConfig()
 	superSpec, err := supervisor.NewSpec(yamlConfig)

--- a/pkg/object/meshcontroller/spec/spec.go
+++ b/pkg/object/meshcontroller/spec/spec.go
@@ -436,6 +436,7 @@ type (
 	}
 )
 
+// Validate validates ServiceCanary.
 func (sc ServiceCanary) Validate() error {
 	if sc.Priority < 0 || sc.Priority > 9 {
 		return fmt.Errorf("invalid priority (range is [0, 9], the default 0 will be set to 5)")

--- a/pkg/object/meshcontroller/spec/spec.go
+++ b/pkg/object/meshcontroller/spec/spec.go
@@ -444,7 +444,7 @@ func (sc ServiceCanary) Validate() error {
 	return nil
 }
 
-// Clone clonse TrafficRules.
+// Clone clones TrafficRules.
 func (tr *TrafficRules) Clone() *TrafficRules {
 	headers := map[string]*urlrule.StringMatch{}
 	for k, v := range tr.Headers {

--- a/pkg/object/meshcontroller/worker/egress.go
+++ b/pkg/object/meshcontroller/worker/egress.go
@@ -202,6 +202,7 @@ func (egs *EgressServer) _ready() bool {
 func (egs *EgressServer) reloadByCert(event informer.Event, value *spec.Certificate) bool {
 	select {
 	case egs.chReloadEvent <- struct{}{}:
+	default:
 	}
 	return true
 }

--- a/pkg/object/meshcontroller/worker/egress.go
+++ b/pkg/object/meshcontroller/worker/egress.go
@@ -210,6 +210,7 @@ func (egs *EgressServer) reloadByCert(event informer.Event, value *spec.Certific
 func (egs *EgressServer) reloadByInstances(value map[string]*spec.ServiceInstanceSpec) bool {
 	select {
 	case egs.chReloadEvent <- struct{}{}:
+	default:
 	}
 	return true
 }
@@ -217,6 +218,7 @@ func (egs *EgressServer) reloadByInstances(value map[string]*spec.ServiceInstanc
 func (egs *EgressServer) reloadBySpecs(value map[string]*spec.Service) bool {
 	select {
 	case egs.chReloadEvent <- struct{}{}:
+	default:
 	}
 	return true
 }
@@ -224,6 +226,7 @@ func (egs *EgressServer) reloadBySpecs(value map[string]*spec.Service) bool {
 func (egs *EgressServer) reloadByHTTPRouteGroups(value map[string]*spec.HTTPRouteGroup) bool {
 	select {
 	case egs.chReloadEvent <- struct{}{}:
+	default:
 	}
 	return true
 }
@@ -231,6 +234,7 @@ func (egs *EgressServer) reloadByHTTPRouteGroups(value map[string]*spec.HTTPRout
 func (egs *EgressServer) reloadByTrafficTargets(value map[string]*spec.TrafficTarget) bool {
 	select {
 	case egs.chReloadEvent <- struct{}{}:
+	default:
 	}
 	return true
 }
@@ -238,6 +242,7 @@ func (egs *EgressServer) reloadByTrafficTargets(value map[string]*spec.TrafficTa
 func (egs *EgressServer) reloadByServiceCanaries(value map[string]*spec.ServiceCanary) bool {
 	select {
 	case egs.chReloadEvent <- struct{}{}:
+	default:
 	}
 	return true
 }

--- a/pkg/object/meshcontroller/worker/ingress.go
+++ b/pkg/object/meshcontroller/worker/ingress.go
@@ -112,7 +112,7 @@ func (ings *IngressServer) InitIngress(service *spec.Service, port uint32) error
 	ings.applicationPort = port
 
 	if _, ok := ings.pipelines[service.IngressPipelineName()]; !ok {
-		superSpec, err := service.SideCarIngressPipelineSpec(port)
+		superSpec, err := service.SidecarIngressPipelineSpec(port)
 		if err != nil {
 			return err
 		}
@@ -132,7 +132,7 @@ func (ings *IngressServer) InitIngress(service *spec.Service, port uint32) error
 			logger.Infof("ingress enable TLS, init httpserver with cert: %#v", cert)
 		}
 
-		superSpec, err := service.SideCarIngressHTTPServerSpec(cert, rootCert)
+		superSpec, err := service.SidecarIngressHTTPServerSpec(cert, rootCert)
 		if err != nil {
 			return err
 		}
@@ -181,7 +181,7 @@ func (ings *IngressServer) reloadHTTPServer(event informer.Event, value *spec.Ce
 	}
 
 	rootCert := ings.service.GetRootCert()
-	superSpec, err := spec.SideCarIngressHTTPServerSpec(value, rootCert)
+	superSpec, err := spec.SidecarIngressHTTPServerSpec(value, rootCert)
 	if err != nil {
 		logger.Errorf("BUG: update ingress pipeline spec: %s new super spec failed: %v",
 			superSpec.YAMLConfig(), err)
@@ -209,7 +209,7 @@ func (ings *IngressServer) reloadPipeline(event informer.Event, serviceSpec *spe
 		return false
 	}
 
-	superSpec, err := serviceSpec.SideCarIngressPipelineSpec(ings.applicationPort)
+	superSpec, err := serviceSpec.SidecarIngressPipelineSpec(ings.applicationPort)
 	if err != nil {
 		logger.Errorf("BUG: update ingress pipeline spec: %s new super spec failed: %v",
 			superSpec.YAMLConfig(), err)

--- a/pkg/object/meshcontroller/worker/worker.go
+++ b/pkg/object/meshcontroller/worker/worker.go
@@ -70,28 +70,24 @@ type (
 	}
 )
 
-func decodeLabels(labels string) map[string]string {
-	mLabels := make(map[string]string)
-	if len(labels) == 0 {
-		return mLabels
-	}
-	strLabel, err := url.QueryUnescape(labels)
-	if err != nil {
-		logger.Errorf("query unescape: %s failed: %v ", labels, err)
-		return mLabels
+func decodeLabels(labelStr string) map[string]string {
+	labelMap := make(map[string]string)
+	if len(labelStr) == 0 {
+		return labelMap
 	}
 
-	arrLabel := strings.Split(strLabel, "&")
+	labelSlice := strings.Split(labelStr, ",")
 
-	for _, v := range arrLabel {
+	for _, v := range labelSlice {
 		kv := strings.Split(v, "=")
 		if len(kv) == 2 {
-			mLabels[kv[0]] = kv[1]
+			labelMap[kv[0]] = kv[1]
 		} else {
-			logger.Errorf("serviceLabel: %s invalid format: %s", strLabel, v)
+			logger.Errorf("%s: invalid label: %s", labelStr, v)
 		}
 	}
-	return mLabels
+
+	return labelMap
 }
 
 // New creates a mesh worker.

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/megaease/easegress/pkg/filter/circuitbreaker"
 	_ "github.com/megaease/easegress/pkg/filter/corsadaptor"
 	_ "github.com/megaease/easegress/pkg/filter/fallback"
+	_ "github.com/megaease/easegress/pkg/filter/meshadaptor"
 	_ "github.com/megaease/easegress/pkg/filter/mock"
 	_ "github.com/megaease/easegress/pkg/filter/proxy"
 	_ "github.com/megaease/easegress/pkg/filter/ratelimiter"

--- a/pkg/util/httpfilter/httpfilter.go
+++ b/pkg/util/httpfilter/httpfilter.go
@@ -116,6 +116,11 @@ func (hf *HTTPFilter) filterHeader(ctx context.HTTPContext) bool {
 	h := ctx.Request().Header()
 	headerMatchNum := 0
 	for key, matchRule := range hf.spec.Headers {
+		// NOTE: Quickly break for performance.
+		if headerMatchNum >= 1 && !hf.spec.MatchAllHeaders {
+			break
+		}
+
 		values := h.GetAll(key)
 
 		if len(values) == 0 && matchRule.Empty {

--- a/pkg/util/httpfilter/httpfilter.go
+++ b/pkg/util/httpfilter/httpfilter.go
@@ -41,9 +41,10 @@ const (
 type (
 	// Spec describes HTTPFilter.
 	Spec struct {
-		Headers     map[string]*urlrule.StringMatch `yaml:"headers" jsonschema:"omitempty"`
-		URLs        []*urlrule.URLRule              `yaml:"urls" jsonschema:"omitempty"`
-		Probability *Probability                    `yaml:"probability,omitempty" jsonschema:"omitempty"`
+		MatchAllHeaders bool                            `yaml:"matchAllHeaders" jsonschema:"omitempty"`
+		Headers         map[string]*urlrule.StringMatch `yaml:"headers" jsonschema:"omitempty"`
+		URLs            []*urlrule.URLRule              `yaml:"urls" jsonschema:"omitempty"`
+		Probability     *Probability                    `yaml:"probability,omitempty" jsonschema:"omitempty"`
 	}
 
 	// HTTPFilter filters HTTP traffic.
@@ -113,23 +114,35 @@ func (hf *HTTPFilter) Filter(ctx context.HTTPContext) bool {
 
 func (hf *HTTPFilter) filterHeader(ctx context.HTTPContext) bool {
 	h := ctx.Request().Header()
-	headerMatch := false
-	for key, vf := range hf.spec.Headers {
-		if headerMatch {
-			break
-		}
-
+	headerMatchNum := 0
+	for key, matchRule := range hf.spec.Headers {
 		values := h.GetAll(key)
 
+		if len(values) == 0 && matchRule.Empty {
+			headerMatchNum++
+			continue
+		}
+
+		// NOTE: So even matchRule.RegEx match empty string,
+		// it won't reach here when len(values) == 0.
 		for _, value := range values {
-			if vf.Match(value) {
-				headerMatch = true
+			if matchRule.Match(value) {
+				headerMatchNum++
 				break
 			}
 		}
 	}
 
-	return headerMatch
+	needHeaderMatchNum := 1
+	if hf.spec.MatchAllHeaders {
+		needHeaderMatchNum = len(hf.spec.Headers)
+	}
+
+	if headerMatchNum >= needHeaderMatchNum {
+		return true
+	}
+
+	return false
 }
 
 func (hf *HTTPFilter) filterURL(ctx context.HTTPContext) bool {

--- a/pkg/util/httpfilter/httpfilter_test.go
+++ b/pkg/util/httpfilter/httpfilter_test.go
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2017, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package httpfilter
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/megaease/easegress/pkg/context"
+	"github.com/megaease/easegress/pkg/tracing"
+	"github.com/megaease/easegress/pkg/util/urlrule"
+)
+
+func TestFilterHeader(t *testing.T) {
+	r := &http.Request{
+		URL: &url.URL{
+			Path: "/",
+		},
+		Header: map[string][]string{
+			"X-Easemesh-Servicecanary": {},
+		},
+	}
+
+	ctx := context.New(httptest.NewRecorder(), r, tracing.NoopTracing, "span")
+
+	filter := New(&Spec{
+		MatchAllHeaders: true,
+		Headers: map[string]*urlrule.StringMatch{
+			"X-Easemesh-Servicecanary": {
+				Empty: true,
+			},
+		},
+	})
+
+	fmt.Println(filter.Filter(ctx))
+}

--- a/pkg/util/httpfilter/httpfilter_test.go
+++ b/pkg/util/httpfilter/httpfilter_test.go
@@ -18,7 +18,6 @@
 package httpfilter
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -36,6 +35,7 @@ func TestFilterHeader(t *testing.T) {
 		},
 		Header: map[string][]string{
 			"X-Easemesh-Servicecanary": {},
+			"Content-Type":             {"application/json"},
 		},
 	}
 
@@ -44,11 +44,21 @@ func TestFilterHeader(t *testing.T) {
 	filter := New(&Spec{
 		MatchAllHeaders: true,
 		Headers: map[string]*urlrule.StringMatch{
+			"Content-Type": {
+				Exact: "application/json",
+			},
 			"X-Easemesh-Servicecanary": {
 				Empty: true,
 			},
 		},
 	})
 
-	fmt.Println(filter.Filter(ctx))
+	if !filter.Filter(ctx) {
+		t.Fatalf("filter failed")
+	}
+
+	filter.spec.MatchAllHeaders = false
+	if !filter.Filter(ctx) {
+		t.Fatalf("filter failed")
+	}
 }

--- a/pkg/util/urlrule/urlrule.go
+++ b/pkg/util/urlrule/urlrule.go
@@ -32,6 +32,7 @@ type (
 		Exact  string `yaml:"exact" jsonschema:"omitempty"`
 		Prefix string `yaml:"prefix" jsonschema:"omitempty"`
 		RegEx  string `yaml:"regex" jsonschema:"omitempty,format=regexp"`
+		Empty  bool   `yaml:"empty" jsonschema:"omitempty"`
 		re     *regexp.Regexp
 	}
 
@@ -46,6 +47,13 @@ type (
 
 // Validate validates the StringMatch object
 func (sm StringMatch) Validate() error {
+	if sm.Empty {
+		if sm.Exact != "" || sm.Prefix != "" || sm.RegEx != "" {
+			return fmt.Errorf("empty is conflict with other patterns")
+		}
+		return nil
+	}
+
 	if sm.Exact != "" {
 		return nil
 	}
@@ -58,7 +66,7 @@ func (sm StringMatch) Validate() error {
 		return nil
 	}
 
-	return fmt.Errorf("at least one pattern must be configured")
+	return fmt.Errorf("all patterns is empty")
 }
 
 // Init initializes an StringMatch
@@ -70,6 +78,10 @@ func (sm *StringMatch) Init() {
 
 // Match matches a string to the pattern
 func (sm *StringMatch) Match(value string) bool {
+	if sm.Empty && value == "" {
+		return true
+	}
+
 	if sm.Exact != "" && value == sm.Exact {
 		return true
 	}


### PR DESCRIPTION
(Will make actions correct after https://github.com/megaease/easemesh-api/pull/16 merged)

- Support multiple canaries (deprecate the first version)
- Change label separator `&` to more idiomatic `,`.