### PR TITLE
Fix helm charts

### DIFF
--- a/helm-charts/easegress/README.md
+++ b/helm-charts/easegress/README.md
@@ -10,6 +10,15 @@ kubectl create ns easegress
 # update common helm charts
 helm dependency update ./helm-charts/easegress
 ```
+
+### Prepare persistent volume (optional)
+
+If you are going to use persistent volumes, run following shell command on each persistent volume node:
+```bash
+sudo mkdir /opt/easegress
+sudo chmod 700 /opt/easegress
+```
+
 ## Usage
 ```shell
 

--- a/helm-charts/easegress/README.md
+++ b/helm-charts/easegress/README.md
@@ -14,7 +14,7 @@ helm dependency update ./helm-charts/easegress
 ### Prepare persistent volume (optional)
 
 If you are going to use persistent volumes, run following shell command on each persistent volume node:
-```bash
+```shell
 sudo mkdir /opt/easegress
 sudo chmod 700 /opt/easegress
 ```
@@ -48,3 +48,13 @@ Add filters and objects to Easegress:
 egctl --server {NODE_IP}:31255 object create -f pipeline.yaml
 ```
 where NODE_IP is the IP address a node running Easegress pod and `pipeline.yaml` Easegress object definition.
+
+## Uninstall
+
+```shell
+helm uninstall easegress -n easegress
+
+#sometimes helm does not delete pvc and pv. Delete manually each pvc.
+kubectl delete pvc easegress-pv-easegress-0 -n easegress
+# same for easegress-pv-easegress-i...n
+```

--- a/helm-charts/easegress/README.md
+++ b/helm-charts/easegress/README.md
@@ -54,7 +54,7 @@ where NODE_IP is the IP address a node running Easegress pod and `pipeline.yaml`
 ```shell
 helm uninstall easegress -n easegress
 
-#sometimes helm does not delete pvc and pv. Delete manually each pvc.
+# sometimes helm does not delete pvc and pv. Delete manually each pvc.
 kubectl delete pvc easegress-pv-easegress-0 -n easegress
 # same for easegress-pv-easegress-i...n
 ```

--- a/helm-charts/easegress/templates/Deployment.yaml
+++ b/helm-charts/easegress/templates/Deployment.yaml
@@ -57,7 +57,7 @@ spec:
         - mountPath: /opt/eg-config/eg-secondary.yaml
           name: {{ .Release.Name }}
           subPath: eg-secondary.yaml
-        - mountPath: /opt/eg-data/
+        - mountPath: /opt/easegress/data
           name: easegress-data-volume
       restartPolicy: Always
       volumes:

--- a/helm-charts/easegress/templates/PersistentVolume.yaml
+++ b/helm-charts/easegress/templates/PersistentVolume.yaml
@@ -12,7 +12,7 @@ spec:
   - ReadWriteOnce
   persistentVolumeReclaimPolicy: Delete
   storageClassName: easegress-storage
-  hostPath:
+  local:
     path: /opt/easegress
   nodeAffinity:
     required:

--- a/helm-charts/easegress/templates/StatefulSet.yaml
+++ b/helm-charts/easegress/templates/StatefulSet.yaml
@@ -61,6 +61,8 @@ spec:
           subPath: eg-primary.yaml
         - mountPath: /opt/easegress/data
           name: {{ if eq .Values.cluster.volumeType "persistentVolume" }}easegress-pv {{ else }} easegress-data-volume {{ end }}
+        - mountPath: /opt/easegress/log
++         name: {{ if eq .Values.cluster.volumeType "persistentVolume" }}easegress-pv {{ else }} easegress-data-volume {{ end }}
       restartPolicy: Always
       volumes:
       - emptyDir: {}

--- a/helm-charts/easegress/templates/StatefulSet.yaml
+++ b/helm-charts/easegress/templates/StatefulSet.yaml
@@ -62,7 +62,7 @@ spec:
         - mountPath: /opt/easegress/data
           name: {{ if eq .Values.cluster.volumeType "persistentVolume" }}easegress-pv {{ else }} easegress-data-volume {{ end }}
         - mountPath: /opt/easegress/log
-+         name: {{ if eq .Values.cluster.volumeType "persistentVolume" }}easegress-pv {{ else }} easegress-data-volume {{ end }}
+          name: {{ if eq .Values.cluster.volumeType "persistentVolume" }}easegress-pv {{ else }} easegress-data-volume {{ end }}
       restartPolicy: Always
       volumes:
       - emptyDir: {}

--- a/helm-charts/easegress/templates/StatefulSet.yaml
+++ b/helm-charts/easegress/templates/StatefulSet.yaml
@@ -59,7 +59,7 @@ spec:
         - mountPath: /opt/eg-config/eg-primary.yaml
           name: {{ .Release.Name }}
           subPath: eg-primary.yaml
-        - mountPath: /opt/eg-data/
+        - mountPath: /opt/easegress/data
           name: {{ if eq .Values.cluster.volumeType "persistentVolume" }}easegress-pv {{ else }} easegress-data-volume {{ end }}
       restartPolicy: Always
       volumes:

--- a/helm-charts/ingress-controller/README.md
+++ b/helm-charts/ingress-controller/README.md
@@ -44,3 +44,13 @@ helm install ingress-easegress -n ingress-easegress ./helm-charts/ingress-contro
   --set cluster.volumeType=persistentVolume \
   --set 'cluster.nodeHostnames={hostname-xyz}'
 ```
+
+## Uninstall
+
+```shell
+helm uninstall easegress -n easegress
+
+#sometimes helm does not delete pvc and pv. Delete manually each pvc.
+kubectl delete pvc easegress-pv-easegress-0 -n easegress
+# same for easegress-pv-easegress-i...n
+```

--- a/helm-charts/ingress-controller/README.md
+++ b/helm-charts/ingress-controller/README.md
@@ -11,6 +11,15 @@ kubectl create ns ingress-easegress
 # update common helm charts
 helm dependency update ./helm-charts/ingress-controller
 ```
+
+### Prepare persistent volume (optional)
+
+If you are going to use persistent volumes, run following shell command on each persistent volume node:
+```bash
+sudo mkdir /opt/easegress
+sudo chmod 700 /opt/easegress
+```
+
 ## Usage
 ```shell
 # install with default values

--- a/helm-charts/ingress-controller/README.md
+++ b/helm-charts/ingress-controller/README.md
@@ -48,9 +48,9 @@ helm install ingress-easegress -n ingress-easegress ./helm-charts/ingress-contro
 ## Uninstall
 
 ```shell
-helm uninstall easegress -n easegress
+helm uninstall ingress-easegress -n ingress-easegress
 
 #sometimes helm does not delete pvc and pv. Delete manually each pvc.
-kubectl delete pvc easegress-pv-easegress-0 -n easegress
-# same for easegress-pv-easegress-i...n
+kubectl delete pvc easegress-pv-ingress-easegress-0 -n ingress-easegress
+# same for easegress-pv-ingress-easegress-i...n
 ```

--- a/helm-charts/ingress-controller/templates/Deployment.yaml
+++ b/helm-charts/ingress-controller/templates/Deployment.yaml
@@ -62,7 +62,7 @@ spec:
         - mountPath: /opt/eg-config/controller.yaml
           name: {{ .Release.Name }}
           subPath: controller.yaml
-        - mountPath: /opt/eg-data/
+        - mountPath: /opt/easegress/data
           name: ingress-data-volume
       restartPolicy: Always
       volumes:

--- a/helm-charts/ingress-controller/templates/PersistentVolume.yaml
+++ b/helm-charts/ingress-controller/templates/PersistentVolume.yaml
@@ -12,7 +12,7 @@ spec:
   - ReadWriteOnce
   persistentVolumeReclaimPolicy: Delete
   storageClassName: easegress-storage
-  hostPath:
+  local:
     path: /opt/easegress
   nodeAffinity:
     required:

--- a/helm-charts/ingress-controller/templates/StatefulSet.yaml
+++ b/helm-charts/ingress-controller/templates/StatefulSet.yaml
@@ -63,7 +63,7 @@ spec:
         - mountPath: /opt/eg-config/controller.yaml
           name: {{ .Release.Name }}
           subPath: controller.yaml
-        - mountPath: /opt/eg-data/
+        - mountPath: /opt/easegress/data
           name: {{ if eq .Values.cluster.volumeType "persistentVolume" }}easegress-pv {{ else }} ingress-data-volume {{ end }}
       restartPolicy: Always
       volumes:

--- a/helm-charts/ingress-controller/templates/StatefulSet.yaml
+++ b/helm-charts/ingress-controller/templates/StatefulSet.yaml
@@ -66,7 +66,7 @@ spec:
         - mountPath: /opt/easegress/data
           name: {{ if eq .Values.cluster.volumeType "persistentVolume" }}easegress-pv {{ else }} ingress-data-volume {{ end }}
         - mountPath: /opt/easegress/log
-+         name: {{ if eq .Values.cluster.volumeType "persistentVolume" }}easegress-pv {{ else }} easegress-data-volume {{ end }}
+          name: {{ if eq .Values.cluster.volumeType "persistentVolume" }}easegress-pv {{ else }} easegress-data-volume {{ end }}
       restartPolicy: Always
       volumes:
       - emptyDir: {}

--- a/helm-charts/ingress-controller/templates/StatefulSet.yaml
+++ b/helm-charts/ingress-controller/templates/StatefulSet.yaml
@@ -65,6 +65,8 @@ spec:
           subPath: controller.yaml
         - mountPath: /opt/easegress/data
           name: {{ if eq .Values.cluster.volumeType "persistentVolume" }}easegress-pv {{ else }} ingress-data-volume {{ end }}
+        - mountPath: /opt/easegress/log
++         name: {{ if eq .Values.cluster.volumeType "persistentVolume" }}easegress-pv {{ else }} easegress-data-volume {{ end }}
       restartPolicy: Always
       volumes:
       - emptyDir: {}


### PR DESCRIPTION
- Fix mismatch in persistentVolume path: Deployment and StatefulSet has `mountPath: /opt/eg-data/` but ConfigMap points to `/opt/easegress`. Use `/opt/easegress` everywhere.
- Change persistent volume `hostPath` to `local`
- Add instructions to README.md about preparing local persistentVolume (if using persistentVolume) and uninstalling helm installation