### PR TITLE
Refactoring httpContext & httpResponse make methods signature as same as interfaces declared.

### DIFF
--- a/pkg/context/contexttest/context.go
+++ b/pkg/context/contexttest/context.go
@@ -143,7 +143,7 @@ func (c *MockedHTTPContext) ClientDisconnected() bool {
 }
 
 // OnFinish mocks the OnFinish function of HTTPContext
-func (c *MockedHTTPContext) OnFinish(fn func()) {
+func (c *MockedHTTPContext) OnFinish(fn context.FinishFunc) {
 	if c.MockedFinish != nil {
 		c.MockedOnFinish(fn)
 	}

--- a/pkg/context/contexttest/response.go
+++ b/pkg/context/contexttest/response.go
@@ -18,6 +18,7 @@
 package contexttest
 
 import (
+	"github.com/megaease/easegress/pkg/context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -33,7 +34,7 @@ type MockedHTTPResponse struct {
 	MockedSetCookie     func(cookie *http.Cookie)
 	MockedSetBody       func(body io.Reader)
 	MockedBody          func() io.Reader
-	MockedOnFlushBody   func(func(body []byte, complete bool) (newBody []byte))
+	MockedOnFlushBody   func(fn context.BodyFlushFunc)
 	MockedStd           func() http.ResponseWriter
 	MockedSize          func() uint64
 }
@@ -84,7 +85,7 @@ func (r *MockedHTTPResponse) Body() io.Reader {
 }
 
 // OnFlushBody registers a callback function on flush body
-func (r *MockedHTTPResponse) OnFlushBody(fn func(body []byte, complete bool) (newBody []byte)) {
+func (r *MockedHTTPResponse) OnFlushBody(fn context.BodyFlushFunc) {
 	if r.MockedOnFlushBody != nil {
 		r.MockedOnFlushBody(fn)
 	}

--- a/pkg/context/httpcontext.go
+++ b/pkg/context/httpcontext.go
@@ -57,8 +57,8 @@ type (
 		Cancelled() bool
 		ClientDisconnected() bool
 
-		OnFinish(func())   // For setting final client statistics, etc.
-		AddTag(tag string) // For debug, log, etc.
+		OnFinish(FinishFunc) // For setting final client statistics, etc.
+		AddTag(tag string)   // For debug, log, etc.
 
 		StatMetric() *httpstat.Metric
 
@@ -116,7 +116,7 @@ type (
 
 		SetBody(body io.Reader)
 		Body() io.Reader
-		OnFlushBody(func(body []byte, complete bool) (newBody []byte))
+		OnFlushBody(BodyFlushFunc)
 
 		Std() http.ResponseWriter
 
@@ -126,6 +126,10 @@ type (
 	// FinishFunc is the type of function to be called back
 	// when HTTPContext is finishing.
 	FinishFunc = func()
+
+	// BodyFlushFunc is the type of function to be called back
+	// when body is flushing.
+	BodyFlushFunc = func(body []byte, complete bool) (newBody []byte)
 
 	httpContext struct {
 		mutex sync.Mutex
@@ -233,7 +237,7 @@ func (ctx *httpContext) Cancel(err error) {
 	}
 }
 
-func (ctx *httpContext) OnFinish(fn func()) {
+func (ctx *httpContext) OnFinish(fn FinishFunc) {
 	ctx.finishFuncs = append(ctx.finishFuncs, fn)
 }
 

--- a/pkg/context/httpcontext.go
+++ b/pkg/context/httpcontext.go
@@ -233,7 +233,7 @@ func (ctx *httpContext) Cancel(err error) {
 	}
 }
 
-func (ctx *httpContext) OnFinish(fn FinishFunc) {
+func (ctx *httpContext) OnFinish(fn func()) {
 	ctx.finishFuncs = append(ctx.finishFuncs, fn)
 }
 

--- a/pkg/context/httpresponse.go
+++ b/pkg/context/httpresponse.go
@@ -31,10 +31,6 @@ import (
 var bodyFlushBuffSize = 8 * int64(os.Getpagesize())
 
 type (
-	// BodyFlushFunc is the type of function to be called back
-	// when body is flushing.
-	BodyFlushFunc = func(body []byte, complete bool) (newBody []byte)
-
 	httpResponse struct {
 		stdr *http.Request
 		std  http.ResponseWriter
@@ -82,7 +78,7 @@ func (w *httpResponse) SetBody(body io.Reader) {
 }
 
 // OnFlushBody adds an HTTP body flushing handler function
-func (w *httpResponse) OnFlushBody(fn func(body []byte, complete bool) (newBody []byte)) {
+func (w *httpResponse) OnFlushBody(fn BodyFlushFunc) {
 	w.bodyFlushFuncs = append(w.bodyFlushFuncs, fn)
 }
 

--- a/pkg/context/httpresponse.go
+++ b/pkg/context/httpresponse.go
@@ -82,7 +82,7 @@ func (w *httpResponse) SetBody(body io.Reader) {
 }
 
 // OnFlushBody adds an HTTP body flushing handler function
-func (w *httpResponse) OnFlushBody(fn BodyFlushFunc) {
+func (w *httpResponse) OnFlushBody(fn func(body []byte, complete bool) (newBody []byte)) {
 	w.bodyFlushFuncs = append(w.bodyFlushFuncs, fn)
 }
 


### PR DESCRIPTION
If the implementation method signature is different from the interface will get an error tip in GoLand.

Refactoring `httpContext` & `httpResponse` make methods signature as same as interfaces declared. 