### PR TITLE
support pem in both base64 and plain text

### DIFF
--- a/pkg/object/autocertmanager/autocertmanager.go
+++ b/pkg/object/autocertmanager/autocertmanager.go
@@ -414,7 +414,10 @@ func GetCertificate(chi *tls.ClientHelloInfo, tokenOnly bool) (*tls.Certificate,
 	if acm != nil {
 		return acm.getCertificate(chi, tokenOnly)
 	}
-	return nil, fmt.Errorf("auto certificate manager is not started")
+	// return a nil error in this case, otherwise:
+	// * static certificates configured in an HTTP server are never used, which is a bug
+	// * the Go HTTP package logs a lot of 'TLS handshake error'
+	return nil, nil
 }
 
 // HandleHTTP01Challenge handles HTTP-01 challenge

--- a/pkg/object/autocertmanager/autocertmanager.go
+++ b/pkg/object/autocertmanager/autocertmanager.go
@@ -373,7 +373,10 @@ func (acm *AutoCertManager) getCertificate(chi *tls.ClientHelloInfo, tokenOnly b
 
 	domain := acm.findDomain(name, false)
 	if domain == nil {
-		return nil, fmt.Errorf("host %q is not configured for auto cert", name)
+		// return nil error if the domain is not managed by the AutoCertManager, so that
+		// the Go HTTP package could check the the static certificates configured in the
+		// HTTP server spec.
+		return nil, nil
 	}
 
 	cert := domain.cert()
@@ -414,7 +417,8 @@ func GetCertificate(chi *tls.ClientHelloInfo, tokenOnly bool) (*tls.Certificate,
 	if acm != nil {
 		return acm.getCertificate(chi, tokenOnly)
 	}
-	// return a nil error in this case, otherwise:
+
+	// return a nil error if the AutoCertManager is not started, otherwise:
 	// * static certificates configured in an HTTP server are never used, which is a bug
 	// * the Go HTTP package logs a lot of 'TLS handshake error'
 	return nil, nil


### PR DESCRIPTION
certs in HTTP server spec were in plain text before but were updated to base64 encoding in #391 , this PR auto-detect the encoding, and the certs could be in either plain text or base64.

the PR also fix two issues in the AutoCertManager:
* When AutoCertManager is not started, `autocertmanager.GetCertificate` should return a nil error.
* If a domain is not managed by the AutoCertManager, `autocertmanager.GetCertificate` should return a nil error for that domain.