### PR TITLE
fix easegress-server keep running on invalid yaml

### DIFF
--- a/pkg/object/mqttproxy/broker.go
+++ b/pkg/object/mqttproxy/broker.go
@@ -552,6 +552,7 @@ func (b *Broker) httpGetAllSessionHandler(w http.ResponseWriter, r *http.Request
 	}
 
 	allSession, err := b.sessMgr.store.getPrefix(sessionStoreKey(""), false)
+	logger.SpanDebugf(span, "httpGetAllSessionHandler current total %v sessions, query %v, topic %v", len(allSession), []int{page, pageSize}, topic)
 	if err != nil {
 		logger.SpanErrorf(span, "get all sessions with prefix %v failed, %v", sessionStoreKey(""), err)
 		api.HandleAPIError(w, r, http.StatusInternalServerError, fmt.Errorf("get all sessions failed, %v", err))

--- a/pkg/object/mqttproxy/mqtt_test.go
+++ b/pkg/object/mqttproxy/mqtt_test.go
@@ -1905,7 +1905,7 @@ func TestHTTPGetAllSession(t *testing.T) {
 			sessions := &HTTPSessions{}
 			json.NewDecoder(resp.Body).Decode(sessions)
 			if len(sessions.Sessions) != test.ansLen {
-				t.Errorf("get wrong session number wanted %v, got %v", test.ansLen, len(sessions.Sessions))
+				t.Errorf("get wrong session number wanted %v, got %v %v", test.ansLen, len(sessions.Sessions), sessions.Sessions)
 				sessions, _ := broker.sessMgr.store.getPrefix(sessionStoreKey(""), true)
 				broker.Lock()
 				t.Errorf("broker clients %v, sessions %v", broker.clients, sessions)

--- a/pkg/object/mqttproxy/mqtt_test.go
+++ b/pkg/object/mqttproxy/mqtt_test.go
@@ -49,7 +49,7 @@ func (t *testMQ) get() *packets.PublishPacket {
 }
 
 func init() {
-	logger.InitMock()
+	logger.InitNop()
 	pipeline.Register(&pipeline.MockMQTTFilter{})
 }
 

--- a/pkg/object/mqttproxy/mqtt_test.go
+++ b/pkg/object/mqttproxy/mqtt_test.go
@@ -177,6 +177,37 @@ func TestSubUnsub(t *testing.T) {
 	broker.close()
 }
 
+func checkSessionStore(broker *Broker, cid, topic string) error {
+	checkFn := func() error {
+		sessStr, err := broker.sessMgr.store.get(sessionStoreKey(cid))
+		if err != nil {
+			return err
+		}
+		if topic == "" {
+			return nil
+		}
+		sess := Session{
+			info: &SessionInfo{},
+		}
+		sess.decode(*sessStr)
+
+		for t := range sess.info.Topics {
+			if topic == t {
+				return nil
+			}
+		}
+		return fmt.Errorf("topic %v not in session %v", topic, cid)
+	}
+
+	for i := 0; i < 20; i++ {
+		if checkFn() == nil {
+			return nil
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return fmt.Errorf("session %v with topic %v not been stored", cid, topic)
+}
+
 func TestCleanSession(t *testing.T) {
 	b64passwd := base64.StdEncoding.EncodeToString([]byte("test"))
 	broker := getBroker("test", "test", b64passwd, 1883)
@@ -184,9 +215,16 @@ func TestCleanSession(t *testing.T) {
 	// client that set cleanSession
 	cid := "cleanSessionClient"
 	client := getMQTTClient(t, cid, "test", "test", true)
+	if err := checkSessionStore(broker, cid, ""); err != nil {
+		t.Fatal(err)
+	}
 	if token := client.Subscribe("test/cleanSession/0", 0, nil); token.Wait() && token.Error() != nil {
 		t.Errorf("subscribe qos0 error %s", token.Error())
 	}
+	if err := checkSessionStore(broker, cid, "test/cleanSession/0"); err != nil {
+		t.Fatal(err)
+	}
+
 	client.Disconnect(200)
 
 	c := broker.getClient(cid)

--- a/pkg/object/mqttproxy/mqtt_test.go
+++ b/pkg/object/mqttproxy/mqtt_test.go
@@ -1883,9 +1883,16 @@ func TestHTTPGetAllSession(t *testing.T) {
 	clients := []paho.Client{}
 	clientNum := 10
 	for i := 0; i < clientNum; i++ {
-		client := getMQTTClient(t, strconv.Itoa(i), "test", "test", true)
+		cid := strconv.Itoa(i)
+		client := getMQTTClient(t, cid, "test", "test", true)
+		if err := checkSessionStore(broker, cid, ""); err != nil {
+			t.Fatal(err)
+		}
 		if token := client.Subscribe("topic", 1, nil); token.Wait() && token.Error() != nil {
 			t.Errorf("subscribe qos0 error %s", token.Error())
+		}
+		if err := checkSessionStore(broker, cid, "topic"); err != nil {
+			t.Fatal(err)
 		}
 		clients = append(clients, client)
 	}
@@ -1943,7 +1950,7 @@ func TestHTTPGetAllSession(t *testing.T) {
 			sessions := &HTTPSessions{}
 			json.NewDecoder(resp.Body).Decode(sessions)
 			if len(sessions.Sessions) != test.ansLen {
-				t.Errorf("get wrong session number wanted %v, got %v %v", test.ansLen, len(sessions.Sessions), sessions.Sessions)
+				t.Errorf("get wrong session number wanted %v, got %v", test.ansLen, len(sessions.Sessions))
 				sessions, _ := broker.sessMgr.store.getPrefix(sessionStoreKey(""), true)
 				broker.Lock()
 				t.Errorf("broker clients %v, sessions %v", broker.clients, sessions)

--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -236,7 +236,7 @@ func (opt *Options) Parse() (string, error) {
 		c.TagName = "yaml"
 	})
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("yaml file unmarshal failed, please make sure you provide valid yaml file, %v", err)
 	}
 
 	opt.renameLegacyClusterRoles()

--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -232,9 +232,12 @@ func (opt *Options) Parse() (string, error) {
 		opt.viper.Set(key, val)
 	}
 
-	opt.viper.Unmarshal(opt, func(c *mapstructure.DecoderConfig) {
+	err = opt.viper.Unmarshal(opt, func(c *mapstructure.DecoderConfig) {
 		c.TagName = "yaml"
 	})
+	if err != nil {
+		return "", err
+	}
 
 	opt.renameLegacyClusterRoles()
 	err = opt.validate()


### PR DESCRIPTION
this pr fix issue #431. if user provide invalid yaml, then `easegress-server` will report error and return. 

ps: here invalid yaml means yaml file provide wrong type for option. For example, `option.cluster.initial-cluster` is a map[string]string, if we provide an array will cause problem. 