### PR TITLE
Modify github test actions and add release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,23 +1,12 @@
-name: Test
+name: Release
 
 on:
   push:
-    branches:
-      - main
-    paths:
-      - "**/*.go"
-      - "go.mod"
-      - "go.sum"
-      - ".github/workflows/test.yml"
-  pull_request:
-    types: [opened, synchronize, reopened]
-    branches:
-      - main
-    paths:
-      - "**/*.go"
-      - "go.mod"
-      - "go.sum"
-      - ".github/workflows/test.yml"
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
 
 jobs:
   test:
@@ -38,12 +27,7 @@ jobs:
       - name: Test
         shell: bash
         run: |
-          make test TEST_FLAGS="-race -coverprofile=coverage.txt -covermode=atomic"
-
-      - name: Upload coverage to Codecov 
-        uses: codecov/codecov-action@v2.1.0
-        with:
-          file: ./coverage.txt
+          make test TEST_FLAGS="-race -covermode=atomic"
   test-win:
     runs-on: windows-latest
     strategy:
@@ -79,4 +63,23 @@ jobs:
       - name: Test
         run: |
           make httpserver_test
-
+  goreleaser:
+    runs-on: ubuntu-latest
+    needs: integration-test-ubuntu
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+      - uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,7 +23,7 @@ builds:
       - darwin
     ldflags:
       - -s -w
-      - -X github.com/megaease/easegress/pkg/version.RELEASE=v1.4.0
+      - -X github.com/megaease/easegress/pkg/version.RELEASE={{ .Tag }}
       - -X github.com/megaease/easegress/pkg/version.COMMIT={{.Commit}}
       - -X github.com/megaease/easegress/pkg/version.REPO=megaease/easegress
 
@@ -37,7 +37,7 @@ builds:
       - darwin
     ldflags:
       - -s -w
-      - -X github.com/megaease/easegress/pkg/version.RELEASE=v1.4.0
+      - -X github.com/megaease/easegress/pkg/version.RELEASE={{ .Tag }}
       - -X github.com/megaease/easegress/pkg/version.COMMIT={{.Commit}}
       - -X github.com/megaease/easegress/pkg/version.REPO=megaease/easegress
 

--- a/doc/reference/maintain.md
+++ b/doc/reference/maintain.md
@@ -1,0 +1,15 @@
+# Release steps
+
+These are the steps to release new version of Easegress.
+
+### Pre-requisites
+
+Let's suppose that the next version is `X.Y.Z`. Then new *tag* is `vX.Y.Z` (note prefix `v`) and new *release title* is `easegress-vX.Y.Z`. Please collect all Pull Request's that will be mentioned in `CHANGELOG.md` and in the Release Note.
+
+### Steps
+
+1. Create a Pull Request that updates release version `X.Y.Z` in Makefile and adds the new version to `CHANGELOG.md`. Include significant changes, implemented enchantments and fixed bugs to `CHANGELOG.md`. Once the PR is reviewed and approved, merge it to main branch.
+2. Create new release note at https://github.com/megaease/easegress/releases/new with *release title* `easegress-vX.Y.Z` and click `Save draft`. Click *Choose a tag* and add new tag `vX.Y.Z`. Write the Release note. You can use the modifications written to `CHANGELOG.md` in previous step. Follow the same format, as previous Release notes. Once written, click `Publish release`. 
+3. New tag triggers Goreleaser Github action. Follow up that it creates and uploads successfully all binaries and Docker images. 
+4. Ensure that the release note created in step 2 contains the command to pull the new Docker image.
+5. New version of Easegress is now released! Notify everyone to check it out!

--- a/doc/reference/maintain.md
+++ b/doc/reference/maintain.md
@@ -2,11 +2,11 @@
 
 These are the steps to release new version of Easegress.
 
-### Pre-requisites
+## Pre-requisites
 
 Let's suppose that the next version is `X.Y.Z`. Then new *tag* is `vX.Y.Z` (note prefix `v`) and new *release title* is `easegress-vX.Y.Z`. Please collect all Pull Request's that will be mentioned in `CHANGELOG.md` and in the Release Note.
 
-### Steps
+## Steps
 
 1. Create a Pull Request that updates release version `X.Y.Z` in Makefile and adds the new version to `CHANGELOG.md`. Include significant changes, implemented enchantments and fixed bugs to `CHANGELOG.md`. Once the PR is reviewed and approved, merge it to main branch.
 2. Create new release note at https://github.com/megaease/easegress/releases/new with *release title* `easegress-vX.Y.Z` and click `Save draft`. Click *Choose a tag* and add new tag `vX.Y.Z`. Write the Release note. You can use the modifications written to `CHANGELOG.md` in previous step. Follow the same format, as previous Release notes. Once written, click `Publish release`. 


### PR DESCRIPTION
Add Github action that runs .goreleaser.yml when a release tag is created (tag starts with v, for example `v1.4.1` but not `beta-v1.4.1`). Release action also runs tests before creating the release.

### To-do
- test with real release

References:
- https://goreleaser.com/ci/actions/