### PR TITLE
Reduce etcd server memory usage

### DIFF
--- a/pkg/cluster/config.go
+++ b/pkg/cluster/config.go
@@ -40,6 +40,10 @@ const (
 
 	maxTxnOps       = 10240
 	maxRequestBytes = 10 * 1024 * 1024 // 10MB
+
+	// Should help to decrease memory usage.
+	// Reference: https://etcd.io/docs/v3.5/tuning/#snapshot-tuning
+	snapshotCount = 5000
 )
 
 var (
@@ -90,6 +94,7 @@ func CreateStaticClusterEtcdConfig(opt *option.Options) (*embed.Config, error) {
 	ec.QuotaBackendBytes = quotaBackendBytes
 	ec.MaxTxnOps = maxTxnOps
 	ec.MaxRequestBytes = maxRequestBytes
+	ec.SnapshotCount = snapshotCount
 	ec.Logger = "zap"
 	ec.LogOutputs = []string{common.NormalizeZapLogPath(filepath.Join(opt.AbsLogDir, logFilename))}
 
@@ -147,6 +152,7 @@ func CreateEtcdConfig(opt *option.Options, members *members) (*embed.Config, err
 	ec.QuotaBackendBytes = quotaBackendBytes
 	ec.MaxTxnOps = maxTxnOps
 	ec.MaxRequestBytes = maxRequestBytes
+	ec.SnapshotCount = snapshotCount
 	ec.Logger = "zap"
 	ec.LogOutputs = []string{common.NormalizeZapLogPath(filepath.Join(opt.AbsLogDir, logFilename))}
 

--- a/pkg/cluster/config.go
+++ b/pkg/cluster/config.go
@@ -41,7 +41,7 @@ const (
 	maxTxnOps       = 10240
 	maxRequestBytes = 10 * 1024 * 1024 // 10MB
 
-	// Should help to decrease memory usage.
+	// Threshold for number of changes etcd stores in memory before creating a new snapshot.
 	// Reference: https://etcd.io/docs/v3.5/tuning/#snapshot-tuning
 	snapshotCount = 5000
 )

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -92,7 +92,11 @@ func EtcdClientLoggerConfig(opt *option.Options, filename string) *zap.Config {
 	encoderConfig := defaultEncoderConfig()
 
 	level := zap.NewAtomicLevel()
-	level.SetLevel(zapcore.DebugLevel)
+	if opt.Debug {
+		level.SetLevel(zapcore.DebugLevel)
+	} else {
+		level.SetLevel(zapcore.InfoLevel)
+	}
 
 	outputPaths := []string{common.NormalizeZapLogPath(filepath.Join(opt.AbsLogDir, filename))}
 

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -24,7 +24,6 @@ import (
 	"runtime/debug"
 	"runtime/pprof"
 	"sync"
-	"time"
 
 	"github.com/megaease/easegress/pkg/logger"
 	"github.com/megaease/easegress/pkg/option"
@@ -50,7 +49,6 @@ func New(opt *option.Options) (Profile, error) {
 	if err != nil {
 		return nil, err
 	}
-	p.startMemoryProfiling()
 
 	return p, nil
 }
@@ -102,16 +100,6 @@ func (p *profile) memoryProfile() {
 		logger.Errorf("close memory file failed: %v", err)
 		return
 	}
-}
-
-func (p *profile) startMemoryProfiling() {
-	go func() {
-		for {
-			fmt.Println("Running memory profiling.")
-			time.Sleep(10 * time.Minute)
-			p.memoryProfile()
-		}
-	}()
 }
 
 func (p *profile) Close(wg *sync.WaitGroup) {

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -24,6 +24,7 @@ import (
 	"runtime/debug"
 	"runtime/pprof"
 	"sync"
+	"time"
 
 	"github.com/megaease/easegress/pkg/logger"
 	"github.com/megaease/easegress/pkg/option"
@@ -49,6 +50,7 @@ func New(opt *option.Options) (Profile, error) {
 	if err != nil {
 		return nil, err
 	}
+	p.startMemoryProfiling()
 
 	return p, nil
 }
@@ -100,6 +102,16 @@ func (p *profile) memoryProfile() {
 		logger.Errorf("close memory file failed: %v", err)
 		return
 	}
+}
+
+func (p *profile) startMemoryProfiling() {
+	go func() {
+		for {
+			fmt.Println("Running memory profiling.")
+			time.Sleep(10 * time.Minute)
+			p.memoryProfile()
+		}
+	}()
 }
 
 func (p *profile) Close(wg *sync.WaitGroup) {


### PR DESCRIPTION
- set snapshot count to lower value to reduce etcd ram usage https://etcd.io/docs/v3.5/tuning/#snapshot-tuning
- fix https://github.com/megaease/easegress/issues/420 ; do not print debug client logs if `--debug` flag is not provided for server