### PR TITLE
Http basic auth

### DIFF
--- a/doc/cookbook/security.md
+++ b/doc/cookbook/security.md
@@ -156,6 +156,7 @@ filters:
   - kind: Validator
     name: oauth-validator
     basicAuth:
+      mode: "FILE"
       userFile: '/etc/apache2/.htpasswd'
   - name: proxy
     kind: Proxy
@@ -282,6 +283,7 @@ filters:
   - kind: Validator
     name: basic-auth-validator
     basicAuth:
+      mode: "FILE"
       userFile: '/etc/apache2/.htpasswd'
   - name: proxy
     kind: Proxy

--- a/doc/cookbook/security.md
+++ b/doc/cookbook/security.md
@@ -7,11 +7,13 @@
     - [JWT](#jwt)
     - [Signature](#signature)
     - [OAuth2](#oauth2)
+    - [Basic Auth](#basic-auth)
   - [References](#references)
     - [Header](#header-1)
     - [JWT](#jwt-1)
     - [Signature](#signature-1)
     - [OAuth2](#oauth2-1)
+    - [Basic Auth](#basic-auth-1)
     - [Concepts](#concepts)
 
 As a production-ready cloud-native traffic orchestrator, Easegress cares about security and provides several features to ensure that.
@@ -134,12 +136,34 @@ filters:
       insecureTls: false
   - name: proxy
     kind: Proxy
-
 ```
 
 * The example above uses a token introspection server, which is provided by `endpoint` filed for validation. It also supports `Self-Encoded Access Tokens mode` which will require a JWT related configuration included. Check it out in the Easegress filter doc if needed. [5]
 
 * For the full YAML, see [here](#oauth-1)
+
+### Basic Auth
+
+* Using Basic Auth validation in Easegress. Basic access authentication is the simplest technique for enforcing access control to web resources [6]. You can create .htpasswd file using *apache2-util* `htpasswd` [7] for storing encrypted user credentials. Please note that Basic Auth is not the most secure access control technique and it is not recommended to depend solely to Basic Auth when designing the security features of your environment.
+
+``` yaml
+name: pipeline-reverse-proxy
+kind: HTTPPipeline
+flow:
+  - filter: oauth-validator
+  - filter: proxy
+filters:
+  - kind: Validator
+    name: oauth-validator
+    basicAuth:
+      userFile: '/etc/apache2/.htpasswd'
+  - name: proxy
+    kind: Proxy
+```
+
+* The example above uses credentials defined in `/etc/apache2/.htpasswd` to restrict access. Please check out apache2-utils documentation [7] for more details.
+
+* For the full YAML, see [here](#basic-auth-1)
 
 ## References
 
@@ -167,7 +191,6 @@ filters:
       - url: http://127.0.0.1:9097
       loadBalance:
         policy: roundRobin
-
 ```
 
 ### JWT
@@ -247,6 +270,29 @@ filters:
         policy: roundRobin
 ```
 
+### Basic Auth
+
+``` yaml
+name: pipeline-reverse-proxy
+kind: HTTPPipeline
+flow:
+  - filter: header-validator
+  - filter: proxy
+filters:
+  - kind: Validator
+    name: basic-auth-validator
+    basicAuth:
+      userFile: '/etc/apache2/.htpasswd'
+  - name: proxy
+    kind: Proxy
+    mainPool:
+      servers:
+      - url: http://127.0.0.1:9095
+      - url: http://127.0.0.1:9096
+      - url: http://127.0.0.1:9097
+      loadBalance:
+        policy: roundRobin
+```
 
 ### Concepts
 
@@ -255,3 +301,5 @@ filters:
 3. https://github.com/megaease/easegress/blob/main/doc/filters.md#signerliteral
 4. https://oauth.net/2/
 5. https://github.com/megaease/easegress/blob/main/doc/filters.md#validatorOAuth2JWT
+6. https://en.wikipedia.org/wiki/Basic_access_authentication
+7. https://manpages.debian.org/testing/apache2-utils/htpasswd.1.en.html

--- a/doc/reference/filters.md
+++ b/doc/reference/filters.md
@@ -597,6 +597,7 @@ Here's an example for `basicAuth` validation method which uses [Apache2 htpasswd
 kind: Validator
 name: basicAuth-validator-example
 basicAuth:
+  mode: "FILE"
   userFile: /etc/apache2/.htpasswd
 ```
 
@@ -608,6 +609,7 @@ basicAuth:
 | jwt       | [validator.JWTValidatorSpec](#validatorJWTValidatorSpec)          | JWT validation rule, validates JWT token string from the `Authorization` header or cookies                                                                                                                    | No       |
 | signature | [signer.Spec](#signerSpec)                                        | Signature validation rule, implements an [Amazon Signature V4](https://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html) compatible signature validation validator, with customizable literal strings | No       |
 | oauth2    | [validator.OAuth2ValidatorSpec](#validatorOAuth2ValidatorSpec)    | The `OAuth/2` method support `Token Introspection` mode and `Self-Encoded Access Tokens` mode, only one mode can be configured at a time                                                                      | No       |
+| basicAuth    | [basicauth.BasicAuthValidatorSpec](#basicauthBasicAuthValidatorSpec)    | The `BasicAuth` method support `FILE` mode and `ETCD` mode, only one mode can be configured at a time.                                                                  | No       |
 
 ### Results
 

--- a/doc/reference/filters.md
+++ b/doc/reference/filters.md
@@ -545,7 +545,7 @@ The filter always returns an empty result.
 
 ## Validator
 
-The Validator filter validates requests, forwards valid ones, and rejects invalid ones. Four validation methods (`headers`, `jwt`, `signature`, and `oauth2`) are supported up to now, and these methods can either be used together or alone. When two or more methods are used together, a request needs to pass all of them to be forwarded.
+The Validator filter validates requests, forwards valid ones, and rejects invalid ones. Four validation methods (`headers`, `jwt`, `signature`, `oauth2` and `basicAuth`) are supported up to now, and these methods can either be used together or alone. When two or more methods are used together, a request needs to pass all of them to be forwarded.
 
 Below is an example configuration for the `headers` validation method. Requests which has a header named `Is-Valid` with value `abc` or `goodplan` or matches regular expression `^ok-.+$` are considered to be valid.
 
@@ -590,6 +590,14 @@ oauth2:
     clientId: easegress
     clientSecret: 42620d18-871d-465f-912a-ebcef17ecb82
     insecureTls: false
+```
+
+Here's an example for `basicAuth` validation method which uses [Apache2 htpasswd](https://manpages.debian.org/testing/apache2-utils/htpasswd.1.en.html) formatted encrypted password file for validation.
+```yaml
+kind: Validator
+name: basicAuth-validator-example
+basicAuth:
+  userFile: /etc/apache2/.htpasswd
 ```
 
 ### Configuration

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 // indirect
 	github.com/facebookgo/subset v0.0.0-20200203212716-c811ad88dec4 // indirect
 	github.com/fatih/color v1.12.0
-	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/fsnotify/fsnotify v1.4.9
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-chi/chi/v5 v5.0.3
 	github.com/go-zookeeper/zk v1.0.2

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 // indirect
 	github.com/facebookgo/subset v0.0.0-20200203212716-c811ad88dec4 // indirect
 	github.com/fatih/color v1.12.0
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-chi/chi/v5 v5.0.3
 	github.com/go-zookeeper/zk v1.0.2

--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/spf13/viper v1.8.1
 	github.com/stretchr/testify v1.7.0
 	github.com/tcnksm/go-httpstat v0.2.1-0.20191008022543-e866bb274419
+	github.com/tg123/go-htpasswd v1.2.0
 	github.com/tidwall/gjson v1.11.0
 	github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce
 	github.com/valyala/fasttemplate v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -107,6 +107,8 @@ github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBp
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962 h1:KeNholpO2xKjgaaSyd+DyQRrsQjhbSeS7qe4nEw8aQw=
+github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962/go.mod h1:kC29dT1vFpj7py2OvG1khBdQpo3kInWP+6QipLbdngo=
 github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317/go.mod h1:DF8FZRxMHMGv/vP2lQP6h+dYzzjpuRn24VeRiYn3qjQ=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
@@ -1266,6 +1268,8 @@ github.com/tcnksm/go-httpstat v0.2.1-0.20191008022543-e866bb274419 h1:elOIj31UL4
 github.com/tcnksm/go-httpstat v0.2.1-0.20191008022543-e866bb274419/go.mod h1:s3JVJFtQxtBEBC9dwcdTTXS9xFnM3SXAZwPG41aurT8=
 github.com/tebeka/strftime v0.1.3 h1:5HQXOqWKYRFfNyBMNVc9z5+QzuBtIXy03psIhtdJYto=
 github.com/tebeka/strftime v0.1.3/go.mod h1:7wJm3dZlpr4l/oVK0t1HYIc4rMzQ2XJlOMIUJUJH6XQ=
+github.com/tg123/go-htpasswd v1.2.0 h1:UKp34m9H467/xklxUxU15wKRru7fwXoTojtxg25ITF0=
+github.com/tg123/go-htpasswd v1.2.0/go.mod h1:h7IzlfpvIWnVJhNZ0nQ9HaFxHb7pn5uFJYLlEUJa2sM=
 github.com/tidwall/gjson v1.11.0 h1:C16pk7tQNiH6VlCrtIXL1w8GaOsi1X3W8KDkE1BuYd4=
 github.com/tidwall/gjson v1.11.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
@@ -1426,6 +1430,7 @@ golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20181030102418-4d3f4d9ffa16/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/crypto v0.0.0-20190228161510-8dd112bcdc25/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190313024323-a1f597ede03a/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190320223903-b7391e95e576/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/pkg/cluster/test_util.go
+++ b/pkg/cluster/test_util.go
@@ -1,0 +1,64 @@
+/*
+* Copyright (c) 2017, MegaEase
+* All rights reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package cluster
+
+import (
+	"fmt"
+
+	"github.com/phayes/freeport"
+
+	"github.com/megaease/easegress/pkg/env"
+	"github.com/megaease/easegress/pkg/option"
+)
+
+func check(e error) {
+	if e != nil {
+		panic(e)
+	}
+}
+
+// CreateClusterForTest creates a cluster for testing purposes.
+func CreateClusterForTest(tempDir string) Cluster {
+	ports, err := freeport.GetFreePorts(3)
+	check(err)
+	name := fmt.Sprintf("test-member-x")
+	opt := option.New()
+	opt.Name = name
+	opt.ClusterName = "test-cluster"
+	opt.ClusterRole = "primary"
+	opt.ClusterRequestTimeout = "10s"
+	opt.Cluster.ListenClientURLs = []string{fmt.Sprintf("http://localhost:%d", ports[0])}
+	opt.Cluster.AdvertiseClientURLs = opt.Cluster.ListenClientURLs
+	opt.Cluster.ListenPeerURLs = []string{fmt.Sprintf("http://localhost:%d", ports[1])}
+	opt.Cluster.InitialAdvertisePeerURLs = opt.Cluster.ListenPeerURLs
+	opt.Cluster.InitialCluster = make(map[string]string)
+	opt.Cluster.InitialCluster[name] = opt.Cluster.InitialAdvertisePeerURLs[0]
+	opt.APIAddr = fmt.Sprintf("localhost:%d", ports[2])
+	opt.DataDir = fmt.Sprintf("%s/data", tempDir)
+	opt.LogDir = fmt.Sprintf("%s/log", tempDir)
+	opt.MemberDir = fmt.Sprintf("%s/member", tempDir)
+
+	_, err = opt.Parse()
+	check(err)
+
+	env.InitServerDir(opt)
+
+	clusterInstance, err := New(opt)
+	check(err)
+	return clusterInstance
+}

--- a/pkg/cluster/test_util.go
+++ b/pkg/cluster/test_util.go
@@ -13,7 +13,7 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*/
+ */
 
 package cluster
 

--- a/pkg/filter/headerlookup/headerlookup.go
+++ b/pkg/filter/headerlookup/headerlookup.go
@@ -20,6 +20,7 @@ package headerlookup
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/megaease/easegress/pkg/cluster"
 	"github.com/megaease/easegress/pkg/context"
@@ -31,6 +32,8 @@ import (
 const (
 	// Kind is the kind of HeaderLookup.
 	Kind = "HeaderLookup"
+	// customDataPrefix is prefix for lookup data.
+	customDataPrefix = "/custom-data/"
 )
 
 var results = []string{}
@@ -54,8 +57,8 @@ type (
 		HeaderKey string `yaml:"headerKey,omitempty" jsonschema:"omitempty"`
 	}
 
-	// Spec defines header key and etcd prefix that form etcd key like {etcdPrefix}/{headerKey's value}.
-	// This {etcdPrefix}/{headerKey's value} is retrieved from etcd and HeaderSetters extract keys from the
+	// Spec defines header key and etcd prefix that form etcd key like /custom-data/{etcdPrefix}/{headerKey's value}.
+	// This /custom-data/{etcdPrefix}/{headerKey's value} is retrieved from etcd and HeaderSetters extract keys from the
 	// from the retrieved etcd item.
 	Spec struct {
 		HeaderKey     string              `yaml:"headerKey" jsonschema:"required"`
@@ -133,8 +136,7 @@ func parseYamlCreds(entry string) (map[string]string, error) {
 }
 
 func (hl *HeaderLookup) lookup(headerVal string) (map[string]string, error) {
-	etcdKey := hl.spec.EtcdPrefix + headerVal
-	fmt.Println(etcdKey)
+	etcdKey := customDataPrefix + strings.TrimPrefix(hl.spec.EtcdPrefix, "/") + headerVal
 	etcdVal, err := hl.cluster.Get(etcdKey)
 	if err != nil {
 		return nil, err

--- a/pkg/filter/headerlookup/headerlookup.go
+++ b/pkg/filter/headerlookup/headerlookup.go
@@ -19,6 +19,7 @@ package headerlookup
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/megaease/easegress/pkg/cluster"
 	"github.com/megaease/easegress/pkg/context"
@@ -162,7 +163,7 @@ func (hl *HeaderLookup) Handle(ctx context.HTTPContext) string {
 
 func (hl *HeaderLookup) handle(ctx context.HTTPContext) string {
 	header := ctx.Request().Header()
-	headerVal := header.Get(hl.spec.HeaderKey)
+	headerVal := header.Get(http.CanonicalHeaderKey(hl.spec.HeaderKey))
 	if headerVal == "" {
 		logger.Warnf("request does not have header '%s'", hl.spec.HeaderKey)
 		return ""
@@ -173,7 +174,7 @@ func (hl *HeaderLookup) handle(ctx context.HTTPContext) string {
 		return ""
 	}
 	for hk, hv := range headersToAdd {
-		header.Set(hk, hv)
+		header.Set(http.CanonicalHeaderKey(hk), hv)
 	}
 	return ""
 }

--- a/pkg/filter/headerlookup/headerlookup.go
+++ b/pkg/filter/headerlookup/headerlookup.go
@@ -1,0 +1,179 @@
+/*
+* Copyright (c) 2017, MegaEase
+* All rights reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package headerlookup
+
+import (
+	"fmt"
+
+	"github.com/megaease/easegress/pkg/cluster"
+	"github.com/megaease/easegress/pkg/context"
+	"github.com/megaease/easegress/pkg/logger"
+	"github.com/megaease/easegress/pkg/object/httppipeline"
+	"github.com/megaease/easegress/pkg/util/yamltool"
+)
+
+const (
+	// Kind is the kind of HeaderLookup.
+	Kind = "HeaderLookup"
+)
+
+var results = []string{}
+
+func init() {
+	httppipeline.Register(&HeaderLookup{})
+}
+
+type (
+	// HeaderLookup retrieves values from etcd to headers.
+	HeaderLookup struct {
+		filterSpec *httppipeline.FilterSpec
+		spec       *Spec
+
+		cluster cluster.Cluster
+	}
+
+	// HeaderSetterSpec defines etcd source key and request destination header.
+	HeaderSetterSpec struct {
+		EtcdKey   string `yaml:"etcdKey,omitempty" jsonschema:"omitempty"`
+		HeaderKey string `yaml:"headerKey,omitempty" jsonschema:"omitempty"`
+	}
+
+	// Spec defines header key and etcd prefix that form etcd key like {etcdPrefix}/{headerKey's value}.
+	// This {etcdPrefix}/{headerKey's value} is retrieved from etcd and HeaderSetters extract keys from the
+	// from the retrieved etcd item.
+	Spec struct {
+		HeaderKey     string              `yaml:"headerKey" jsonschema:"required"`
+		EtcdPrefix    string              `yaml:"etcdPrefix" jsonschema:"required"`
+		HeaderSetters []*HeaderSetterSpec `yaml:"headerSetters" jsonschema:"required"`
+	}
+)
+
+// Validate validates spec.
+func (spec Spec) Validate() error {
+	if spec.HeaderKey == "" {
+		return fmt.Errorf("headerKey is required")
+	}
+	if spec.EtcdPrefix == "" {
+		return fmt.Errorf("etcdPrefix is required")
+	}
+	if len(spec.HeaderSetters) < 1 {
+		return fmt.Errorf("at least one headerSetter is required")
+	}
+	for _, hs := range spec.HeaderSetters {
+		if hs.EtcdKey == "" {
+			return fmt.Errorf("headerSetters[i].etcdKey is required")
+		}
+		if hs.HeaderKey == "" {
+			return fmt.Errorf("headerSetters[i].headerKey is required")
+		}
+	}
+	return nil
+}
+
+// Kind returns the kind of HeaderLookup.
+func (hl *HeaderLookup) Kind() string {
+	return Kind
+}
+
+// DefaultSpec returns the default spec of HeaderLookup.
+func (hl *HeaderLookup) DefaultSpec() interface{} {
+	return &Spec{}
+}
+
+// Description returns the description of HeaderLookup.
+func (hl *HeaderLookup) Description() string {
+	return "HeaderLookup enriches request headers per request, looking up values from etcd."
+}
+
+// Results returns the results of HeaderLookup.
+func (hl *HeaderLookup) Results() []string {
+	return results
+}
+
+// Init initializes HeaderLookup.
+func (hl *HeaderLookup) Init(filterSpec *httppipeline.FilterSpec) {
+	hl.filterSpec, hl.spec = filterSpec, filterSpec.FilterSpec().(*Spec)
+	hl.cluster = filterSpec.Super().Cluster()
+}
+
+// Inherit inherits previous generation of HeaderLookup.
+func (hl *HeaderLookup) Inherit(filterSpec *httppipeline.FilterSpec, previousGeneration httppipeline.Filter) {
+	previousGeneration.Close()
+	hl.Init(filterSpec)
+}
+
+func parseYamlCreds(entry string) (map[string]string, error) {
+	var err error
+	defer func() {
+		if err := recover(); err != nil {
+			err = fmt.Errorf("could not marshal custom-data, ensure that it's valid yaml")
+		}
+	}()
+	yamlMap := make(map[string]string)
+	yamltool.Unmarshal([]byte(entry), &yamlMap)
+	return yamlMap, err
+}
+
+func (hl *HeaderLookup) lookup(headerVal string) (map[string]string, error) {
+	etcdKey := hl.spec.EtcdPrefix + headerVal
+	fmt.Println(etcdKey)
+	etcdVal, err := hl.cluster.Get(etcdKey)
+	if err != nil {
+		return nil, err
+	}
+	if etcdVal == nil {
+		return nil, fmt.Errorf("no data found")
+	}
+	result := make(map[string]string, len(hl.spec.HeaderSetters))
+	etcdValues, err := parseYamlCreds(*etcdVal)
+	if err != nil {
+		return nil, err
+	}
+	for _, setter := range hl.spec.HeaderSetters {
+		if val, ok := etcdValues[setter.EtcdKey]; ok {
+			result[setter.HeaderKey] = val
+		}
+	}
+	return result, nil
+}
+
+// Handle retrieves header values and sets request headers.
+func (hl *HeaderLookup) Handle(ctx context.HTTPContext) string {
+	header := ctx.Request().Header()
+	headerVal := header.Get(hl.spec.HeaderKey)
+	if headerVal == "" {
+		logger.Warnf("request does not have header '%s'", hl.spec.HeaderKey)
+		return ""
+	}
+	headersToAdd, err := hl.lookup(headerVal)
+	if err != nil {
+		logger.Errorf(err.Error())
+		return ""
+	}
+	fmt.Println(len(headersToAdd))
+	for hk, hv := range headersToAdd {
+		header.Set(hk, hv)
+	}
+	return ""
+}
+
+// Status returns status.
+func (hl *HeaderLookup) Status() interface{} { return nil }
+
+// Close closes RequestAdaptor.
+func (hl *HeaderLookup) Close() {}

--- a/pkg/filter/headerlookup/headerlookup_test.go
+++ b/pkg/filter/headerlookup/headerlookup_test.go
@@ -1,0 +1,172 @@
+/*
+* Copyright (c) 2017, MegaEase
+* All rights reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package headerlookup
+
+import (
+	"io/ioutil"
+	"net/http"
+	"os"
+	"sync"
+	"testing"
+
+	cluster "github.com/megaease/easegress/pkg/cluster"
+	"github.com/megaease/easegress/pkg/context/contexttest"
+	"github.com/megaease/easegress/pkg/logger"
+	"github.com/megaease/easegress/pkg/object/httppipeline"
+	"github.com/megaease/easegress/pkg/supervisor"
+	"github.com/megaease/easegress/pkg/util/httpheader"
+	"github.com/megaease/easegress/pkg/util/yamltool"
+)
+
+func TestMain(m *testing.M) {
+	logger.InitNop()
+	code := m.Run()
+	os.Exit(code)
+}
+
+func createHeaderLookup(yamlSpec string, supervisor *supervisor.Supervisor) (*HeaderLookup, error) {
+	rawSpec := make(map[string]interface{})
+	yamltool.Unmarshal([]byte(yamlSpec), &rawSpec)
+	spec, err := httppipeline.NewFilterSpec(rawSpec, supervisor)
+	if err != nil {
+		return nil, err
+	}
+	hl := &HeaderLookup{}
+	hl.Init(spec)
+	hl.Inherit(spec, hl)
+	return hl, nil
+}
+
+func check(e error) {
+	if e != nil {
+		panic(e)
+	}
+}
+
+func TestValidate(t *testing.T) {
+	etcdDirName, err := ioutil.TempDir("", "etcd-headerlookup-test")
+	check(err)
+	defer os.RemoveAll(etcdDirName)
+	clusterInstance := cluster.CreateClusterForTest(etcdDirName)
+	var mockMap sync.Map
+	supervisor := supervisor.NewMock(
+		nil, clusterInstance, mockMap, mockMap, nil, nil, false, nil, nil)
+
+	const validYaml = `
+name: headerLookup
+kind: HeaderLookup
+headerKey: "X-AUTH-USER"
+etcdPrefix: "/credentials/"
+headerSetters:
+  - etcdKey: "ext-id"
+    headerKey: "user-ext-id"
+`
+	unvalidYamls := []string{
+		`
+name: headerLookup
+kind: HeaderLookup
+`,
+		`
+name: headerLookup
+kind: HeaderLookup
+headerKey: "X-AUTH-USER"
+`,
+		`
+name: headerLookup
+kind: HeaderLookup
+headerKey: "X-AUTH-USER"
+etcdPrefix: "/credentials/"
+`,
+		`
+name: headerLookup
+kind: HeaderLookup
+headerKey: "X-AUTH-USER"
+etcdPrefix: "/credentials/"
+headerSetters:
+  - etcdKey: "ext-id"
+`,
+	}
+
+	for _, unvalidYaml := range unvalidYamls {
+		if _, err := createHeaderLookup(unvalidYaml, supervisor); err == nil {
+			t.Errorf("validate should return error")
+		}
+	}
+
+	if _, err := createHeaderLookup(validYaml, supervisor); err != nil {
+		t.Errorf("validate should not return error: %s", err.Error())
+	}
+}
+
+func TestHandle(t *testing.T) {
+	etcdDirName, err := ioutil.TempDir("", "etcd-headerlookup-test")
+	check(err)
+	defer os.RemoveAll(etcdDirName)
+	clusterInstance := cluster.CreateClusterForTest(etcdDirName)
+	var mockMap sync.Map
+	supervisor := supervisor.NewMock(
+		nil, clusterInstance, mockMap, mockMap, nil, nil, false, nil, nil)
+
+	// let's put data to 'foobar'
+	clusterInstance.Put("/credentials/foobar",
+		`
+ext-id: 123456789
+extra-entry: "extra"
+`)
+
+	const config = `
+name: headerLookup
+kind: HeaderLookup
+headerKey: "X-AUTH-USER"
+etcdPrefix: "/credentials/"
+headerSetters:
+  - etcdKey: "ext-id"
+    headerKey: "user-ext-id"
+`
+	hl, err := createHeaderLookup(config, supervisor)
+	check(err)
+
+	// 'foobar' is the id
+	ctx := &contexttest.MockedHTTPContext{}
+	header := httpheader.New(http.Header{})
+	ctx.MockedRequest.MockedHeader = func() *httpheader.HTTPHeader {
+		return header
+	}
+
+	hl.Handle(ctx) // does nothing as header missing
+
+	if header.Get("user-ext-id") != "" {
+		t.Errorf("header should not be set")
+	}
+
+	header.Set("X-AUTH-USER", "unknown-user")
+
+	hl.Handle(ctx) // does nothing as user is missing
+
+	if header.Get("user-ext-id") != "" {
+		t.Errorf("header should be set")
+	}
+
+	header.Set("X-AUTH-USER", "foobar")
+
+	hl.Handle(ctx) // now updates header
+
+	if header.Get("user-ext-id") != "123456789" {
+		t.Errorf("header should be set")
+	}
+}

--- a/pkg/filter/headerlookup/headerlookup_test.go
+++ b/pkg/filter/headerlookup/headerlookup_test.go
@@ -71,7 +71,7 @@ func TestValidate(t *testing.T) {
 name: headerLookup
 kind: HeaderLookup
 headerKey: "X-AUTH-USER"
-etcdPrefix: "/credentials/"
+etcdPrefix: "credentials/"
 headerSetters:
   - etcdKey: "ext-id"
     headerKey: "user-ext-id"
@@ -123,7 +123,7 @@ func TestHandle(t *testing.T) {
 		nil, clusterInstance, mockMap, mockMap, nil, nil, false, nil, nil)
 
 	// let's put data to 'foobar'
-	clusterInstance.Put("/credentials/foobar",
+	clusterInstance.Put("/custom-data/credentials/foobar",
 		`
 ext-id: 123456789
 extra-entry: "extra"
@@ -133,7 +133,7 @@ extra-entry: "extra"
 name: headerLookup
 kind: HeaderLookup
 headerKey: "X-AUTH-USER"
-etcdPrefix: "/credentials/"
+etcdPrefix: "credentials/"
 headerSetters:
   - etcdKey: "ext-id"
     headerKey: "user-ext-id"

--- a/pkg/filter/validator/basicauth.go
+++ b/pkg/filter/validator/basicauth.go
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2017, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package validator
+
+import (
+	"os"
+	"bufio"
+	"fmt"
+	"encoding/base64"
+	"strings"
+
+	"github.com/megaease/easegress/pkg/context"
+)
+
+// BasicAuthValidatorSpec defines the configuration of Basic Auth validator.
+// Only one of UserFile or UseEtcd should be defined.
+type BasicAuthValidatorSpec struct {
+	// UserFile is path to file containing encrypted user credentials in apache2-utils/htpasswd format.
+	// To add user `userY`, use `sudo htpasswd /etc/apache2/.htpasswd userY`
+	// Reference: https://manpages.debian.org/testing/apache2-utils/htpasswd.1.en.html#EXAMPLES
+	UserFile string `yaml:"userFile" jsonschema:"omitempty"`
+	// When UseEtcd is true, verify user credentials from etcd.
+	// TODO add some details about this.
+	UseEtcd bool `yaml:"useEtcd" jsonschema:"omitempty"`
+}
+
+type AuthorizedUsers struct {
+	nameToToken	map[string]string
+}
+
+func NewAuthorizedUsers() *AuthorizedUsers {
+	return &AuthorizedUsers{
+		nameToToken: make(map[string]string),
+	}
+}
+
+func (au *AuthorizedUsers) Validate(user string, token string) error {
+	if expectedToken, ok := au.nameToToken[user]; ok && expectedToken == token {
+		return nil
+	}
+	return fmt.Errorf("unauthorized")
+}
+
+func parseCredentials(creds string) (string, string, error) {
+	parts := strings.Split(creds, ":")
+	if len(parts) < 2 {
+		return "", "", fmt.Errorf("bad format")
+	}
+	return parts[0], parts[1], nil
+}
+
+func (au *AuthorizedUsers) UpdateFromUserFile(fileName string) error {
+	file, err := os.OpenFile(fileName, os.O_RDONLY, os.ModePerm)
+    if err != nil {
+        return fmt.Errorf("open file error: %v", err)
+    }
+    defer file.Close()
+	sc := bufio.NewScanner(file)
+    for sc.Scan() {
+        line := sc.Text()
+		name, token, err := parseCredentials(line)
+		if err != nil {
+			return err
+		}
+		au.nameToToken[name] = token
+    }
+	return nil
+}
+
+// NewBasicAuthValidator creates a new Basic Auth validator
+func NewBasicAuthValidator(spec *BasicAuthValidatorSpec) *BasicAuthValidator {
+	au := NewAuthorizedUsers()
+	if spec.UserFile != "" {
+		au.UpdateFromUserFile(spec.UserFile)
+	}
+	return &BasicAuthValidator{
+		spec:        spec,
+		authorizedUsers: au,
+	}
+}
+
+// BasicAuthValidator defines the Basic Auth validator
+type BasicAuthValidator struct {
+	spec        *BasicAuthValidatorSpec
+	authorizedUsers		*AuthorizedUsers
+}
+
+// Validate validates the Authorization header of a http request
+func (bav *BasicAuthValidator) Validate(req context.HTTPRequest) error {
+	hdr := req.Header()
+	base64credentials, err := parseAuthorizationHeader(hdr)
+	if err != nil {
+		return err
+	}
+	credentialBytes, err := base64.StdEncoding.DecodeString(base64credentials)
+	if err != nil {
+		return fmt.Errorf("error occured during base64 decode: %s", err.Error())
+	}
+	credentials := string(credentialBytes)
+	name, token, err := parseCredentials(credentials)
+	if err != nil {
+		return fmt.Errorf("unauthorized")
+	}
+	return bav.authorizedUsers.Validate(name, token)
+}

--- a/pkg/filter/validator/basicauth.go
+++ b/pkg/filter/validator/basicauth.go
@@ -54,7 +54,6 @@ type (
 		GetUser(string) (string, bool)
 		WatchChanges() error
 		Close()
-		SetSyncInterval(time.Duration)
 	}
 
 	htpasswdUserCache struct {
@@ -118,7 +117,7 @@ func newHtpasswdUserCache(userFile string, syncInterval time.Duration) *htpasswd
 	return &htpasswdUserCache{
 		cache:    cache,
 		userFile: userFile,
-		// Removed authorization or updated passwords are updated according syncInterval.
+		// Removed access or updated passwords are updated according syncInterval.
 		syncInterval: syncInterval,
 	}
 }
@@ -181,10 +180,6 @@ func (huc *htpasswdUserCache) Close() {
 	if huc.cancel != nil {
 		huc.cancel()
 	}
-}
-
-func (huc *htpasswdUserCache) SetSyncInterval(interval time.Duration) {
-	huc.syncInterval = interval
 }
 
 func newEtcdUserCache(cluster cluster.Cluster) *etcdUserCache {
@@ -283,10 +278,6 @@ func (euc *etcdUserCache) Close() {
 	if euc.cancel != nil {
 		euc.cancel()
 	}
-}
-
-func (euc *etcdUserCache) SetSyncInterval(interval time.Duration) {
-	euc.syncInterval = interval
 }
 
 // NewBasicAuthValidator creates a new Basic Auth validator

--- a/pkg/filter/validator/basicauth.go
+++ b/pkg/filter/validator/basicauth.go
@@ -360,6 +360,7 @@ func (bav *BasicAuthValidator) Validate(req httpcontext.HTTPRequest) error {
 	}
 
 	if bav.authorizedUsersCache.Match(userID, password) {
+		req.Header().Set("X-AUTH-USER", userID)
 		return nil
 	}
 	return fmt.Errorf("unauthorized")

--- a/pkg/filter/validator/basicauth.go
+++ b/pkg/filter/validator/basicauth.go
@@ -30,6 +30,7 @@ import (
 	"github.com/megaease/easegress/pkg/context"
 	"github.com/megaease/easegress/pkg/logger"
 	"github.com/megaease/easegress/pkg/supervisor"
+	"github.com/megaease/easegress/pkg/util/httpheader"
 )
 
 // BasicAuthValidatorSpec defines the configuration of Basic Auth validator.
@@ -133,10 +134,20 @@ func (bav *BasicAuthValidator) getUserFromCache(userID string) (string, bool) {
 	return password, true
 }
 
+func parseBasicAuthorizationHeader(hdr *httpheader.HTTPHeader) (string, error) {
+	const prefix = "Basic "
+
+	tokenStr := hdr.Get("Authorization")
+	if !strings.HasPrefix(tokenStr, prefix) {
+		return "", fmt.Errorf("unexpected authorization header: %s", tokenStr)
+	}
+	return tokenStr[len(prefix):], nil
+}
+
 // Validate validates the Authorization header of a http request
 func (bav *BasicAuthValidator) Validate(req context.HTTPRequest) error {
 	hdr := req.Header()
-	base64credentials, err := parseAuthorizationHeader(hdr)
+	base64credentials, err := parseBasicAuthorizationHeader(hdr)
 	if err != nil {
 		return err
 	}

--- a/pkg/filter/validator/basicauth.go
+++ b/pkg/filter/validator/basicauth.go
@@ -18,10 +18,10 @@
 package validator
 
 import (
-	"os"
 	"bufio"
-	"fmt"
 	"encoding/base64"
+	"fmt"
+	"os"
 	"strings"
 
 	"github.com/megaease/easegress/pkg/context"
@@ -40,7 +40,7 @@ type BasicAuthValidatorSpec struct {
 }
 
 type AuthorizedUsers struct {
-	nameToToken	map[string]string
+	nameToToken map[string]string
 }
 
 func NewAuthorizedUsers() *AuthorizedUsers {
@@ -66,19 +66,19 @@ func parseCredentials(creds string) (string, string, error) {
 
 func (au *AuthorizedUsers) UpdateFromUserFile(fileName string) error {
 	file, err := os.OpenFile(fileName, os.O_RDONLY, os.ModePerm)
-    if err != nil {
-        return fmt.Errorf("open file error: %v", err)
-    }
-    defer file.Close()
+	if err != nil {
+		return fmt.Errorf("open file error: %v", err)
+	}
+	defer file.Close()
 	sc := bufio.NewScanner(file)
-    for sc.Scan() {
-        line := sc.Text()
+	for sc.Scan() {
+		line := sc.Text()
 		name, token, err := parseCredentials(line)
 		if err != nil {
 			return err
 		}
 		au.nameToToken[name] = token
-    }
+	}
 	return nil
 }
 
@@ -89,15 +89,15 @@ func NewBasicAuthValidator(spec *BasicAuthValidatorSpec) *BasicAuthValidator {
 		au.UpdateFromUserFile(spec.UserFile)
 	}
 	return &BasicAuthValidator{
-		spec:        spec,
+		spec:            spec,
 		authorizedUsers: au,
 	}
 }
 
 // BasicAuthValidator defines the Basic Auth validator
 type BasicAuthValidator struct {
-	spec        *BasicAuthValidatorSpec
-	authorizedUsers		*AuthorizedUsers
+	spec            *BasicAuthValidatorSpec
+	authorizedUsers *AuthorizedUsers
 }
 
 // Validate validates the Authorization header of a http request

--- a/pkg/filter/validator/basicauth.go
+++ b/pkg/filter/validator/basicauth.go
@@ -24,7 +24,12 @@ import (
 	"os"
 	"strings"
 
+	lru "github.com/hashicorp/golang-lru"
+
+	"github.com/megaease/easegress/pkg/cluster"
 	"github.com/megaease/easegress/pkg/context"
+	"github.com/megaease/easegress/pkg/logger"
+	"github.com/megaease/easegress/pkg/supervisor"
 )
 
 // BasicAuthValidatorSpec defines the configuration of Basic Auth validator.
@@ -34,26 +39,17 @@ type BasicAuthValidatorSpec struct {
 	// To add user `userY`, use `sudo htpasswd /etc/apache2/.htpasswd userY`
 	// Reference: https://manpages.debian.org/testing/apache2-utils/htpasswd.1.en.html#EXAMPLES
 	UserFile string `yaml:"userFile" jsonschema:"omitempty"`
-	// When UseEtcd is true, verify user credentials from etcd.
-	// TODO add some details about this.
+	// When UseEtcd is true, verify user credentials from etcd. Etcd stores them:
+	// key: /credentials/{user id}
+	// value: {encrypted password}
 	UseEtcd bool `yaml:"useEtcd" jsonschema:"omitempty"`
 }
 
-type AuthorizedUsers struct {
-	nameToToken map[string]string
-}
-
-func NewAuthorizedUsers() *AuthorizedUsers {
-	return &AuthorizedUsers{
-		nameToToken: make(map[string]string),
-	}
-}
-
-func (au *AuthorizedUsers) Validate(user string, token string) error {
-	if expectedToken, ok := au.nameToToken[user]; ok && expectedToken == token {
-		return nil
-	}
-	return fmt.Errorf("unauthorized")
+// BasicAuthValidator defines the Basic Auth validator
+type BasicAuthValidator struct {
+	spec                 *BasicAuthValidatorSpec
+	authorizedUsersCache *lru.Cache
+	cluster              cluster.Cluster
 }
 
 func parseCredentials(creds string) (string, string, error) {
@@ -64,40 +60,77 @@ func parseCredentials(creds string) (string, string, error) {
 	return parts[0], parts[1], nil
 }
 
-func (au *AuthorizedUsers) UpdateFromUserFile(fileName string) error {
-	file, err := os.OpenFile(fileName, os.O_RDONLY, os.ModePerm)
+func (bav *BasicAuthValidator) getFromFile(targetUserID string) (string, error) {
+	file, err := os.OpenFile(bav.spec.UserFile, os.O_RDONLY, os.ModePerm)
 	if err != nil {
-		return fmt.Errorf("open file error: %v", err)
+		return "", fmt.Errorf("open file error: %v", err)
 	}
 	defer file.Close()
 	sc := bufio.NewScanner(file)
 	for sc.Scan() {
 		line := sc.Text()
-		name, token, err := parseCredentials(line)
+		userID, password, err := parseCredentials(line)
 		if err != nil {
-			return err
+			return "", err
 		}
-		au.nameToToken[name] = token
+		if userID == targetUserID {
+			return password, nil
+		}
 	}
-	return nil
+	return "", fmt.Errorf("unauthorized")
+}
+
+func (bav *BasicAuthValidator) getFromEtcd(targetUserID string) (string, error) {
+	const prefix = "/credentials/"
+	password, err := bav.cluster.Get(prefix + targetUserID)
+	if err != nil {
+		return "", err
+	}
+	if password == nil {
+		return "", fmt.Errorf("unauthorized")
+	}
+	return *password, nil
 }
 
 // NewBasicAuthValidator creates a new Basic Auth validator
-func NewBasicAuthValidator(spec *BasicAuthValidatorSpec) *BasicAuthValidator {
-	au := NewAuthorizedUsers()
-	if spec.UserFile != "" {
-		au.UpdateFromUserFile(spec.UserFile)
+func NewBasicAuthValidator(spec *BasicAuthValidatorSpec, supervisor *supervisor.Supervisor) *BasicAuthValidator {
+	var cluster cluster.Cluster
+	if spec.UseEtcd {
+		if supervisor == nil || supervisor.Cluster() == nil {
+			logger.Errorf("BasicAuth validator : failed to read data from etcd")
+		} else {
+			cluster = supervisor.Cluster()
+		}
 	}
-	return &BasicAuthValidator{
-		spec:            spec,
-		authorizedUsers: au,
+	cache, err := lru.New(256)
+	if err != nil {
+		panic(err)
 	}
+	bav := &BasicAuthValidator{
+		spec:                 spec,
+		authorizedUsersCache: cache,
+		cluster:              cluster,
+	}
+	return bav
 }
 
-// BasicAuthValidator defines the Basic Auth validator
-type BasicAuthValidator struct {
-	spec            *BasicAuthValidatorSpec
-	authorizedUsers *AuthorizedUsers
+func (bav *BasicAuthValidator) getUserFromCache(userID string) (string, bool) {
+	if val, ok := bav.authorizedUsersCache.Get(userID); ok {
+		return val.(string), true
+	}
+	var password string
+	var err error
+	if bav.spec.UserFile != "" {
+		password, err = bav.getFromFile(userID)
+	}
+	if bav.spec.UseEtcd == true {
+		password, err = bav.getFromEtcd(userID)
+	}
+	if err != nil {
+		return "", false
+	}
+	bav.authorizedUsersCache.Add(userID, password)
+	return password, true
 }
 
 // Validate validates the Authorization header of a http request
@@ -112,9 +145,13 @@ func (bav *BasicAuthValidator) Validate(req context.HTTPRequest) error {
 		return fmt.Errorf("error occured during base64 decode: %s", err.Error())
 	}
 	credentials := string(credentialBytes)
-	name, token, err := parseCredentials(credentials)
+	userID, token, err := parseCredentials(credentials)
 	if err != nil {
 		return fmt.Errorf("unauthorized")
 	}
-	return bav.authorizedUsers.Validate(name, token)
+
+	if expectedToken, ok := bav.getUserFromCache(userID); ok && expectedToken == token {
+		return nil
+	}
+	return fmt.Errorf("unauthorized")
 }

--- a/pkg/filter/validator/oauth2.go
+++ b/pkg/filter/validator/oauth2.go
@@ -29,7 +29,6 @@ import (
 	"github.com/golang-jwt/jwt"
 
 	"github.com/megaease/easegress/pkg/context"
-	"github.com/megaease/easegress/pkg/util/httpheader"
 )
 
 type (
@@ -138,23 +137,16 @@ func (v *OAuth2Validator) introspectToken(tokenStr string) (*tokenInfo, error) {
 	return &ti.tokenInfo, nil
 }
 
-func parseAuthorizationHeader(hdr *httpheader.HTTPHeader) (string, error) {
-	const prefix = "Bearer "
-
-	tokenStr := hdr.Get("Authorization")
-	if !strings.HasPrefix(tokenStr, prefix) {
-		return "", fmt.Errorf("unexpected authorization header: %s", tokenStr)
-	}
-	return tokenStr[len(prefix):], nil
-}
-
 // Validate validates the access token of a http request
 func (v *OAuth2Validator) Validate(req context.HTTPRequest) error {
+	const prefix = "Bearer "
+
 	hdr := req.Header()
-	tokenStr, err := parseAuthorizationHeader(hdr)
-	if err != nil {
-		return err
+	tokenStr := hdr.Get("Authorization")
+	if !strings.HasPrefix(tokenStr, prefix) {
+		return fmt.Errorf("unexpected authorization header: %s", tokenStr)
 	}
+	tokenStr = tokenStr[len(prefix):]
 
 	var subject, scope string
 	if v.spec.TokenIntrospect != nil {

--- a/pkg/filter/validator/validator.go
+++ b/pkg/filter/validator/validator.go
@@ -174,5 +174,9 @@ func (v *Validator) handle(ctx context.HTTPContext) string {
 // Status returns status.
 func (v *Validator) Status() interface{} { return nil }
 
-// Close closes Validator.
-func (v *Validator) Close() {}
+// Close closes validations.
+func (v *Validator) Close() {
+	if v.basicAuth != nil {
+		v.basicAuth.Close()
+	}
+}

--- a/pkg/filter/validator/validator.go
+++ b/pkg/filter/validator/validator.go
@@ -48,10 +48,10 @@ type (
 		filterSpec *httppipeline.FilterSpec
 		spec       *Spec
 
-		headers *httpheader.Validator
-		jwt     *JWTValidator
-		signer  *signer.Signer
-		oauth2  *OAuth2Validator
+		headers   *httpheader.Validator
+		jwt       *JWTValidator
+		signer    *signer.Signer
+		oauth2    *OAuth2Validator
 		basicAuth *BasicAuthValidator
 	}
 
@@ -61,7 +61,7 @@ type (
 		JWT       *JWTValidatorSpec         `yaml:"jwt,omitempty" jsonschema:"omitempty"`
 		Signature *signer.Spec              `yaml:"signature,omitempty" jsonschema:"omitempty"`
 		OAuth2    *OAuth2ValidatorSpec      `yaml:"oauth2,omitempty" jsonschema:"omitempty"`
-		BasicAuth    *BasicAuthValidatorSpec      `yaml:"basicAuth,omitempty" jsonschema:"omitempty"`
+		BasicAuth *BasicAuthValidatorSpec   `yaml:"basicAuth,omitempty" jsonschema:"omitempty"`
 	}
 )
 

--- a/pkg/filter/validator/validator.go
+++ b/pkg/filter/validator/validator.go
@@ -119,7 +119,7 @@ func (v *Validator) reload() {
 		v.oauth2 = NewOAuth2Validator(v.spec.OAuth2)
 	}
 	if v.spec.BasicAuth != nil {
-		v.basicAuth = NewBasicAuthValidator(v.spec.BasicAuth)
+		v.basicAuth = NewBasicAuthValidator(v.spec.BasicAuth, v.filterSpec.Super())
 	}
 }
 

--- a/pkg/filter/validator/validator_test.go
+++ b/pkg/filter/validator/validator_test.go
@@ -455,6 +455,14 @@ basicAuth:
 		}
 
 		clusterInstance.Delete("/credentials/" + userIds[0]) // first user is not authorized anymore
+		clusterInstance.Put("/credentials/doge",
+			`
+randomEntry1: 21
+nestedEntry:
+  key1: val1
+password: doge
+lastEntry: "byebye"
+`)
 
 		tryCount := 5
 		for i := 0; i <= tryCount; i++ {
@@ -469,6 +477,14 @@ basicAuth:
 			if i == tryCount && result != resultInvalid {
 				t.Errorf("should be unauthorized")
 			}
+		}
+
+		ctx, header := prepareCtxAndHeader()
+		b64creds := base64.StdEncoding.EncodeToString([]byte("doge:doge"))
+		header.Set("Authorization", "Basic "+b64creds)
+		result := v.Handle(ctx)
+		if result == resultInvalid {
+			t.Errorf("should be authorized")
 		}
 
 		v.Close()

--- a/pkg/filter/validator/validator_test.go
+++ b/pkg/filter/validator/validator_test.go
@@ -18,8 +18,8 @@
 package validator
 
 import (
-	"fmt"
 	"encoding/base64"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -295,14 +295,14 @@ signature:
 }
 
 func check(e error) {
-    if e != nil {
-        panic(e)
-    }
+	if e != nil {
+		panic(e)
+	}
 }
 
 func TestHTTPBasicAuth(t *testing.T) {
 	userFile, err := os.CreateTemp("/tmp/", "apache2-htpasswd")
-    check(err)
+	check(err)
 
 	defer os.Remove(userFile.Name())
 

--- a/pkg/filter/validator/validator_test.go
+++ b/pkg/filter/validator/validator_test.go
@@ -407,6 +407,7 @@ basicAuth:
 
 		v := createValidator(yamlSpec, nil, nil)
 		// set shorted syncInterval for test
+		v.basicAuth.authorizedUsersCache.Close()
 		v.basicAuth.authorizedUsersCache = newHtpasswdUserCache(v.basicAuth.spec.UserFile, 150*time.Millisecond)
 		go v.basicAuth.authorizedUsersCache.WatchChanges()
 
@@ -426,11 +427,13 @@ basicAuth:
 			}
 		}
 
+		v.basicAuth.authorizedUsersCache.Lock()
 		err = userFile.Truncate(0)
 		check(err)
 		_, err = userFile.Seek(0, 0)
 		check(err)
 		userFile.Write([]byte("")) // no more authorized users
+		v.basicAuth.authorizedUsersCache.Unlock()
 
 		tryCount := 5
 		for i := 0; i <= tryCount; i++ {

--- a/pkg/filter/validator/validator_test.go
+++ b/pkg/filter/validator/validator_test.go
@@ -368,7 +368,7 @@ basicAuth:
 				return httpheader.New(header)
 			}
 			b64creds := base64.StdEncoding.EncodeToString([]byte(userIds[i] + ":" + passwords[i]))
-			header.Set("Authorization", "Bearer "+b64creds)
+			header.Set("Authorization", "Basic "+b64creds)
 			result := v.Handle(ctx)
 			if expectedValid[i] {
 				if result == resultInvalid {
@@ -411,7 +411,7 @@ basicAuth:
 				return httpheader.New(header)
 			}
 			b64creds := base64.StdEncoding.EncodeToString([]byte(userIds[i] + ":" + passwords[i]))
-			header.Set("Authorization", "Bearer "+b64creds)
+			header.Set("Authorization", "Basic "+b64creds)
 			result := v.Handle(ctx)
 			if expectedValid[i] {
 				if result == resultInvalid {

--- a/pkg/filter/validator/validator_test.go
+++ b/pkg/filter/validator/validator_test.go
@@ -489,6 +489,9 @@ lastEntry: "byebye"
 		if result == resultInvalid {
 			t.Errorf("should be authorized")
 		}
+		if header.Get("X-AUTH-USER") != "doge" {
+			t.Errorf("x-auth-user header not set")
+		}
 
 		v.Close()
 		wg := &sync.WaitGroup{}

--- a/pkg/filter/validator/validator_test.go
+++ b/pkg/filter/validator/validator_test.go
@@ -346,7 +346,7 @@ func TestBasicAuthUser(t *testing.T) {
 		"md5-encrypted-pw-1", "md5-encrypted-pw-2", "md5-encrypted-pw3",
 	}
 	t.Run("credentials from userFile", func(t *testing.T) {
-		userFile, err := os.CreateTemp("/tmp/", "apache2-htpasswd")
+		userFile, err := os.CreateTemp("", "apache2-htpasswd")
 		check(err)
 
 		defer os.Remove(userFile.Name())

--- a/pkg/filter/validator/validator_test.go
+++ b/pkg/filter/validator/validator_test.go
@@ -419,11 +419,11 @@ basicAuth:
 		defer os.RemoveAll(etcdDirName)
 		clusterInstance := createCluster(etcdDirName)
 
-		pwToYaml := func(pw string) string {
-			return fmt.Sprintf("password: %s", pw)
+		pwToYaml := func(user string, pw string) string {
+			return fmt.Sprintf("username: %s\npassword: %s", user, pw)
 		}
-		clusterInstance.Put("/credentials/"+userIds[0], pwToYaml(encryptedPasswords[0]))
-		clusterInstance.Put("/credentials/"+userIds[2], pwToYaml(encryptedPasswords[2]))
+		clusterInstance.Put("/credentials/1", pwToYaml(userIds[0], encryptedPasswords[0]))
+		clusterInstance.Put("/credentials/2", pwToYaml(userIds[2], encryptedPasswords[2]))
 
 		var mockMap sync.Map
 		supervisor := supervisor.NewMock(
@@ -435,6 +435,7 @@ name: validator
 basicAuth:
   etcd:
     prefix: /credentials/
+    usernameKey: "username"
     passwordKey: "password"`
 
 		expectedValid := []bool{true, false, true}
@@ -455,13 +456,14 @@ basicAuth:
 			}
 		}
 
-		clusterInstance.Delete("/credentials/" + userIds[0]) // first user is not authorized anymore
+		clusterInstance.Delete("/credentials/1") // first user is not authorized anymore
 		clusterInstance.Put("/credentials/doge",
 			`
 randomEntry1: 21
 nestedEntry:
   key1: val1
 password: doge
+username: doge
 lastEntry: "byebye"
 `)
 

--- a/pkg/filter/validator/validator_test.go
+++ b/pkg/filter/validator/validator_test.go
@@ -433,7 +433,8 @@ basicAuth:
 kind: Validator
 name: validator
 basicAuth:
-  etcdYamlFormat:
+  etcd:
+    prefix: /credentials/
     passwordKey: "password"`
 
 		expectedValid := []bool{true, false, true}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -26,6 +26,7 @@ import (
 	_ "github.com/megaease/easegress/pkg/filter/connectcontrol"
 	_ "github.com/megaease/easegress/pkg/filter/corsadaptor"
 	_ "github.com/megaease/easegress/pkg/filter/fallback"
+	_ "github.com/megaease/easegress/pkg/filter/headerlookup"
 	_ "github.com/megaease/easegress/pkg/filter/kafka"
 	_ "github.com/megaease/easegress/pkg/filter/meshadaptor"
 	_ "github.com/megaease/easegress/pkg/filter/mock"


### PR DESCRIPTION
Fix https://github.com/megaease/easegress/issues/404

#### Table of Contents  
[Test case with userFile](#test-case-with-userfile)  
[Test case with etcd](#test-case-with-etcd)
[User Header Lookup](#UserHeaderLookup-filter) 
[BasicAuth and UserHeaderLookup filter combined](#BasicAuth-and-UserHeaderLookup-filter-combined) 
<a name="headers"/>

### Test case with userFile

Create `.htpasswd` file: 
```bash
sudo htpasswd -c /etc/apache2/.htpasswd doge # password doge
cat /etc/apache2/.htpasswd
# doge:$apr1$0f...
```

Create HTML Server:

```yaml
kind: HTTPServer
name: server-demo
port: 10081
globalFilter: basicAuthFilter
keepAlive: true
https: false
rules:
    - paths:
      - pathPrefix: /pipeline
        backend: pipeline-demo
```

and pipeline:

```yaml
name: pipeline-demo
kind: HTTPPipeline
flow:
  - filter: basicAuth
  - filter: proxy
filters:
  - name: basicAuth
    kind: Validator
    basicAuth:
      mode: "FILE"
      userFile: '/etc/apache2/.htpasswd'
  - name: proxy
    kind: Proxy
    mainPool:
      servers:
      - url: http://127.0.0.1:9095
      loadBalance:
        policy: roundRobin
```
Start also backend for proxy, for example `go run example/backend-service/echo/echo.go` for testing.
Send authorized request:
`curl -u doge:doge -v localhost:10081/pipeline` and observe status code 200.

Unauthorized one:
`curl -u doge:foo -v localhost:10081/pipeline` and see 401.

Remove *doge*'s line from `/etc/apache2/.htpasswd`. Wait 1 minute and execute:
`curl -u doge:doge -v localhost:10081/pipeline` and notice status code 401 as *doge* has no more access.

### Test case with etcd
Use same setup as previously, except change first filter to 
```yaml
  - name: basicAuth
    kind: Validator
    basicAuth:
      mode: "ETCD"
```
Send authorized request with doge's credentials:
`curl -u doge:doge -v localhost:10081/pipeline` ==> 401.

Add password to Easegress using  `egctl` _custom-data_ command: 
```bash
echo '                                       
rebuild: true
list:
  - key: 'doge'
    password: 'doge'
' | ./bin/egctl custom-data update credentials
```
Now `curl -u doge:doge -v localhost:10081/pipeline` ==> 200. 

Add apache2 mod5 encrypted password to etcd: 
```bash
echo '                                       
rebuild: true
list:
  - key: 'doge'
    password: "$apr1$7q/O2y6n$1zNd5r5bJH2hn20x.V2To1"
' | ./bin/egctl custom-data update credentials
```
Again `curl -u doge:doge -v localhost:10081/pipeline` ==> 200. 

Add bryct encrypted password to etcd:
```bash
echo '                                       
rebuild: true
list:
  - key: 'doge'
    password: "$2a$10$ZdnoaOVLm5Ug5URVNG5fiepEM8KJlL9p.5Ao5t5fuasNOIUD.wkmC"
' | ./bin/egctl custom-data update credentials
```
 Curling `curl -u doge:doge -v localhost:10081/pipeline` ==> 200.

### UserHeaderLookup filter
Create a filter called `UserHeaderLookup` with following configuration
```yaml
name: authUserHeaders
kind: HeaderLookup
headerKey: "X-AUTH-USER" # header field to use for looking up the user in etcd
etcdPrefix: "/credentials/" # looking for user info at /custom-data/credentials/{user} in etcd
headerSetter:
  - etcdKey: "ext-id" # looking up 'ext-id' value in etcd
    headerKey: "user-ext-id" # set value to 'user-ext-id' 
  - etcdKey: "other-user-entry" # looking up 'other-user-entry' value in etcd
    headerKey: "other-user-entry" # set value to 'other-user-entry' 
```
HeaderLookup filter modifies request header: it looks up user information stored in etcd, identified by `etcdPrefix` and `headerKey`.  HeaderLookup then extracts the `etcdKey`s defined in `headerSetter` and sets them to headers, using `headerKey` as key.

### BasicAuth and UserHeaderLookup filter combined

To use BasicAuth and UserHeaderLookup together, add following filters to pipeline

```yaml
  - name: basicAuth
    kind: Validator
    basicAuth:
      mode: "ETCD"
  - name: headerLookup
    kind: HeaderLookup
    headerKey: "X-AUTH-USER"
    etcdPrefix: "credentials/"
    headerSetters:
    - etcdKey: "service-X-ID"
      headerKey: "service-X-ID"
```

Update Easegress custom-data:

```bash
echo '                                       
rebuild: true
list:
  - key: 'doge'
    password: 'doge'
    service-X-ID: 123456789
' | ./bin/egctl custom-data update credentials
```

Then execute `curl -u doge:doge -v localhost:10081/pipeline` and the header `Service-X-Id: [12345678]` has been included to the request.