### PR TITLE
fix empty http request body read panic

### DIFF
--- a/pkg/util/callbackreader/callbackreader.go
+++ b/pkg/util/callbackreader/callbackreader.go
@@ -51,6 +51,10 @@ func New(r io.Reader) *CallbackReader {
 }
 
 func (cr *CallbackReader) Read(p []byte) (int, error) {
+	if cr.reader == nil {
+		return 0, io.EOF
+	}
+
 	cr.num++
 
 	for _, fn := range cr.beforeFuncs {

--- a/pkg/util/callbackreader/callbackreader.go
+++ b/pkg/util/callbackreader/callbackreader.go
@@ -51,17 +51,16 @@ func New(r io.Reader) *CallbackReader {
 }
 
 func (cr *CallbackReader) Read(p []byte) (int, error) {
-	if cr.reader == nil {
-		return 0, io.EOF
-	}
-
 	cr.num++
 
 	for _, fn := range cr.beforeFuncs {
 		p = fn(cr.num, p)
 	}
 
-	n, err := cr.reader.Read(p)
+	n, err := 0, io.EOF
+	if cr.reader != nil {
+		n, err = cr.reader.Read(p)
+	}
 
 	for _, fn := range cr.afterFuncs {
 		p, n, err = fn(cr.num, p, n, err)


### PR DESCRIPTION
During test of my new write filter, i find if we set empty http request body `http.NewRequest(http.MethodPost, "127.0.0.1", nil)` and read body from `HTTPContext`, callbackreader will panic. this pr aims to fix this issue.