### PR TITLE
Update goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -58,6 +58,8 @@ dockers:
   - image_templates:
     - megaease/easegress:latest
     - megaease/easegress:{{ .Tag }}
+    - megaease/easegress:easemesh
+    - megaease/easegress:server-sidecar
 
     goos: linux
     goarch: amd64


### PR DESCRIPTION
Add `easemesh` and `server-sidecar` docker tags. Goreleaser ([doc](https://goreleaser.com/customization/docker/#keeping-docker-images-updated-for-current-major)) updates all tags when new release is published.