### PR TITLE
create mocked service

### DIFF
--- a/pkg/object/meshcontroller/spec/spec.go
+++ b/pkg/object/meshcontroller/spec/spec.go
@@ -1028,15 +1028,6 @@ https: false
 	return superSpec, nil
 }
 
-// Runnable indicates this service is runnable inside mesh or not.
-//   e.g., If this is a mock service, there is not need to be deployed and run.
-func (s *Service) Runnable() bool {
-	if s.Mock != nil && s.Mock.Enabled {
-		return false
-	}
-	return true
-}
-
 // SidecarIngressPipelineSpec returns a spec for sidecar ingress pipeline
 func (s *Service) SidecarIngressPipelineSpec(applicationPort uint32) (*supervisor.Spec, error) {
 	mainServers := []*proxy.Server{
@@ -1075,7 +1066,7 @@ func (s *Service) SidecarEgressPipelineSpec(instanceSpecs []*ServiceInstanceSpec
 
 	pipelineSpecBuilder.appendMeshAdaptor(canaries)
 
-	if !s.Runnable() {
+	if s.Mock != nil && s.Mock.Enabled {
 		pipelineSpecBuilder.appendMock(s.Mock.Rules)
 	}
 

--- a/pkg/object/meshcontroller/spec/spec_test.go
+++ b/pkg/object/meshcontroller/spec/spec_test.go
@@ -363,16 +363,11 @@ func TestSidecarEgressPipelineSpecWithMock(t *testing.T) {
 		},
 	}
 
-	if s.Runnable() != false {
-		t.Fatalf("service spec %+v should be not runnable", s)
-	}
-
 	instanceSpecs := []*ServiceInstanceSpec{}
 	_, err := s.SidecarEgressPipelineSpec(instanceSpecs, nil, nil, nil)
 	if err == nil {
 		t.Fatalf("mocking service should failed: %v", err)
 	}
-	//fmt.Println(superSpec.YAMLConfig())
 }
 
 func TestMockPBConvert(t *testing.T) {

--- a/pkg/object/meshcontroller/worker/worker.go
+++ b/pkg/object/meshcontroller/worker/worker.go
@@ -205,7 +205,7 @@ func (worker *Worker) run() {
 		}()
 
 		serviceSpec, info := worker.service.GetServiceSpecWithInfo(worker.serviceName)
-		if serviceSpec == nil || !serviceSpec.Runnable() {
+		if serviceSpec == nil {
 			return false
 		}
 
@@ -225,7 +225,7 @@ func (worker *Worker) run() {
 	}
 
 	if runnable := startUpRoutine(); !runnable {
-		logger.Errorf("service: %s is not runnable, check the service spec or ignore if mock is enable", worker.superSpec.Name())
+		logger.Errorf("service: %s is not runnable, please check the service spec", worker.superSpec.Name())
 		return
 	}
 	go worker.heartbeat()


### PR DESCRIPTION
Service instances should be still created even it is mocked.
Because:
* the mock can be disabled
* the mock may only be applied on parts of the APIs of the service