### PR TITLE
Basic Auth etcd mode to use username by default

### DIFF
--- a/pkg/filter/validator/basicauth.go
+++ b/pkg/filter/validator/basicauth.go
@@ -94,9 +94,9 @@ type (
 
 	// etcdCredentials defines the format for credentials in etcd
 	etcdCredentials struct {
-		Key      string `yaml:"key" jsonschema:"omitempty"`
-		Username string `yaml:"username" jsonschema:"omitempty"`
-		Password string `yaml:"password" jsonschema:"required"`
+		Key  string `yaml:"key" jsonschema:"omitempty"`
+		User string `yaml:"username" jsonschema:"omitempty"`
+		Pass string `yaml:"password" jsonschema:"required"`
 	}
 )
 
@@ -104,12 +104,17 @@ const (
 	customDataPrefix = "/custom-data/"
 )
 
-// DefaultUsername uses Username if present, otherwise Key
-func (cred *etcdCredentials) DefaultUsername() string {
-	if cred.Username != "" {
-		return cred.Username
+// Username uses username if present, otherwise key
+func (cred *etcdCredentials) Username() string {
+	if cred.User != "" {
+		return cred.User
 	}
 	return cred.Key
+}
+
+// Password returns password.
+func (cred *etcdCredentials) Password() string {
+	return cred.Pass
 }
 
 func parseCredentials(creds string) (string, string, error) {
@@ -232,14 +237,14 @@ func kvsToReader(kvs map[string]string) io.Reader {
 			logger.Errorf(err.Error())
 			continue
 		}
-		if creds.DefaultUsername() == "" || creds.Password == "" {
+		if creds.Username() == "" || creds.Password() == "" {
 			logger.Errorf(
 				"Parsing credential updates failed. " +
 					"Make sure that credentials contains 'key' or 'password' entry for password and 'password' entries.",
 			)
 			continue
 		}
-		pwStrSlice = append(pwStrSlice, creds.DefaultUsername()+":"+creds.Password)
+		pwStrSlice = append(pwStrSlice, creds.Username()+":"+creds.Password())
 	}
 	if len(pwStrSlice) == 0 {
 		// no credentials found, let's return empty reader

--- a/pkg/filter/validator/basicauth.go
+++ b/pkg/filter/validator/basicauth.go
@@ -54,7 +54,10 @@ type (
 		// key: /custom-data/{etcdPrefix}/{$key}
 		// value:
 		//   key: "$key"
+		//   username: "$username" # optional
 		//   password: "$password"
+		// Username and password are used for Basic Authentication. If "username" is empty, the value of "key"
+		// entry is used as username for Basic Auth.
 		EtcdPrefix string `yaml:"etcdPrefix" jsonschema:"omitempty"`
 	}
 
@@ -89,15 +92,25 @@ type (
 		authorizedUsersCache AuthorizedUsersCache
 	}
 
-	credentials struct {
+	// etcdCredentials defines the format for credentials in etcd
+	etcdCredentials struct {
 		Key      string `yaml:"key" jsonschema:"omitempty"`
-		Password string `yaml:"password" jsonschema:"omitempty"`
+		Username string `yaml:"username" jsonschema:"omitempty"`
+		Password string `yaml:"password" jsonschema:"required"`
 	}
 )
 
 const (
 	customDataPrefix = "/custom-data/"
 )
+
+// DefaultUsername uses Username if present, otherwise Key
+func (cred *etcdCredentials) DefaultUsername() string {
+	if cred.Username != "" {
+		return cred.Username
+	}
+	return cred.Key
+}
 
 func parseCredentials(creds string) (string, string, error) {
 	parts := strings.Split(creds, ":")
@@ -213,19 +226,20 @@ func newEtcdUserCache(cluster cluster.Cluster, etcdPrefix string) *etcdUserCache
 func kvsToReader(kvs map[string]string) io.Reader {
 	pwStrSlice := make([]string, 0, len(kvs))
 	for _, item := range kvs {
-		creds := &credentials{}
+		creds := &etcdCredentials{}
 		err := yaml.Unmarshal([]byte(item), creds)
 		if err != nil {
 			logger.Errorf(err.Error())
 			continue
 		}
-		if creds.Key == "" || creds.Password == "" {
+		if creds.DefaultUsername() == "" || creds.Password == "" {
 			logger.Errorf(
-				"Parsing credential updates failed. Make sure that credentials contains 'key' and 'password' entries.",
+				"Parsing credential updates failed. " +
+					"Make sure that credentials contains 'key' or 'password' entry for password and 'password' entries.",
 			)
 			continue
 		}
-		pwStrSlice = append(pwStrSlice, creds.Key+":"+creds.Password)
+		pwStrSlice = append(pwStrSlice, creds.DefaultUsername()+":"+creds.Password)
 	}
 	if len(pwStrSlice) == 0 {
 		// no credentials found, let's return empty reader


### PR DESCRIPTION
When configuring Basic Auth using Easegress `custom-data` store, the `key` value is used as unique identifier of the data entry and username. Sometimes two `custom-data` entries might share the same user identity: for example we could have `bob-pearls` and `bob-bananas` data entries but only one identity `bob`.

After this PR, the `custom-data` entries can share same identity by adding `username` in `custom-data`:

```yaml
rebuild: true
list:
 - key: bob-bananas
   username: bob
   password: ...

 - key: bob-pearls
   username: bob
   password: ...
```
Now `key` field is still unique identifier of the entries but username can be shared.