### PR TITLE
AppendPath parameter

### DIFF
--- a/pkg/filter/headerlookup/headerlookup.go
+++ b/pkg/filter/headerlookup/headerlookup.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 
@@ -55,6 +56,7 @@ type (
 		spec       *Spec
 		etcdPrefix string
 		headerKey  string
+		pathRegExp *regexp.Regexp
 
 		cache   *lru.Cache
 		cluster cluster.Cluster
@@ -71,13 +73,15 @@ type (
 	// Spec defines header key and etcd prefix that form etcd key like /custom-data/{etcdPrefix}/{headerKey's value}.
 	// This /custom-data/{etcdPrefix}/{headerKey's value} is retrieved from etcd and HeaderSetters extract keys from the
 	// from the retrieved etcd item.
-	// When AppendPath is true, the path (without leading slash) is appended to the etcd key in following format:
-	// /custom-data/{etcdPrefix}/{headerKey's value}-{path} . For example, for path "/bananas", the etcd key is
+	// When PathRegExp is defined, PathRegExp is used with `regexp.FindStringSubmatch` to identify a group from path.
+	// The first captured group is appended to the etcd key in following format:
+	// /custom-data/{etcdPrefix}/{headerKey's value}-{regex group} . For example, for path
+	// "/api/bananas/33" and pathRegExp: "^/api/([a-z]+)/[0-9]*", the group "bananas" is extracted and etcd key is
 	// /custom-data/{etcdPrefix}/{headerKey's value}-bananas.
 	Spec struct {
 		HeaderKey     string              `yaml:"headerKey" jsonschema:"required"`
 		EtcdPrefix    string              `yaml:"etcdPrefix" jsonschema:"required"`
-		AppendPath    bool                `yaml:"appendPath" jsonschema:"omitempty"`
+		PathRegExp    string              `yaml:"pathRegExp" jsonschema:"omitempty"`
 		HeaderSetters []*HeaderSetterSpec `yaml:"headerSetters" jsonschema:"required"`
 	}
 )
@@ -100,6 +104,10 @@ func (spec Spec) Validate() error {
 		if hs.HeaderKey == "" {
 			return fmt.Errorf("headerSetters[i].headerKey is required")
 		}
+	}
+
+	if _, err := regexp.Compile(spec.PathRegExp); err != nil {
+		return err
 	}
 	return nil
 }
@@ -134,6 +142,7 @@ func (hl *HeaderLookup) Init(filterSpec *httppipeline.FilterSpec) {
 	hl.headerKey = http.CanonicalHeaderKey(hl.spec.HeaderKey)
 	hl.cache, _ = lru.New(cacheSize)
 	hl.stopCtx, hl.cancel = context.WithCancel(context.Background())
+	hl.pathRegExp = regexp.MustCompile(hl.spec.PathRegExp)
 	hl.watchChanges()
 }
 
@@ -253,8 +262,11 @@ func (hl *HeaderLookup) handle(ctx httpcontext.HTTPContext) string {
 		logger.Warnf("request does not have header '%s'", hl.spec.HeaderKey)
 		return ""
 	}
-	if hl.spec.AppendPath {
-		headerVal = headerVal + "-" + strings.TrimPrefix(ctx.Request().Path(), "/")
+	if hl.spec.PathRegExp != "" {
+		path := ctx.Request().Path()
+		if match := hl.pathRegExp.FindStringSubmatch(path); match != nil && len(match) > 1 {
+			headerVal = headerVal + "-" + match[1]
+		}
 	}
 	headersToAdd, err := hl.lookup(headerVal)
 	if err != nil {

--- a/pkg/filter/headerlookup/headerlookup_test.go
+++ b/pkg/filter/headerlookup/headerlookup_test.go
@@ -107,7 +107,7 @@ etcdPrefix: "/credentials/"
 headerSetters:
   - etcdKey: "ext-id"
 `,
-`
+		`
 name: headerLookup
 kind: HeaderLookup
 headerKey: "X-AUTH-USER"
@@ -282,8 +282,8 @@ headerSetters:
 ext-id: 333
 extra-entry: "extra"
 `)
-clusterInstance.Put("/custom-data/credentials/bob-pearls",
-`
+	clusterInstance.Put("/custom-data/credentials/bob-pearls",
+		`
 ext-id: 4444
 extra-entry: "extra"
 `)


### PR DESCRIPTION
As consequence of https://github.com/megaease/easegress/pull/472, it's now possible to have following custom-data:

```yaml
rebuild: true
list:
 - key: bob-bananas
   username: bob
   extra-field: ...

 - key: bob-pearls
   username: bob
   extra-field: ...
```

and following configuration for HeaderLookup:

```yaml
name: headerLookup
kind: HeaderLookup
headerKey: "X-AUTH-USER"
etcdPrefix: "credentials/"
headerSetters:
  - etcdKey: "extra-field"
    headerKey: "user-extra-field"
```

that aims to retrieve the `extra-field` of the authenticated user. However if the authenticated user is `bob` (= value of `X-AUTH-USER` header is `bob`), bob cannot retrieve data entries bob-bananas and bob-pearls.

This PR aims to solve this by introducing `pathRegExp` parameter that extracts specified part of the path and appends it to the custom-data key, when retrieving data. Let's change the configuration of the HeaderLookup to 

```yaml
name: headerLookup
kind: HeaderLookup
headerKey: "X-AUTH-USER"
etcdPrefix: "credentials/"
pathRegExp: "^/(.+)" # add this line
headerSetters:
  - etcdKey: "extra-field"
    headerKey: "user-extra-field"
```

Now when `header("X-AUTH-USER") = "bob"` and request `path = /bananas`, the HeaderLookup retrieves the custom-data entry `bob-bananas`.