### PR TITLE
convert cluster.Mutex to goroutine level

### DIFF
--- a/pkg/object/function/worker/api.go
+++ b/pkg/object/function/worker/api.go
@@ -158,7 +158,11 @@ func (worker *Worker) updateState(w http.ResponseWriter, r *http.Request, event 
 	if !stateUpdated {
 		return
 	}
-	worker.store.Lock()
+	err = worker.store.Lock()
+	if err != nil {
+		api.HandleAPIError(w, r, http.StatusInternalServerError, err)
+		return
+	}
 	defer worker.store.Unlock()
 	err = worker.updateFunctionStatus(function.Status)
 	if err != nil {
@@ -206,7 +210,11 @@ func (worker *Worker) Delete(w http.ResponseWriter, r *http.Request) {
 		api.HandleAPIError(w, r, http.StatusBadRequest, err)
 		return
 	}
-	worker.Lock()
+	err = worker.Lock()
+	if err != nil {
+		api.HandleAPIError(w, r, http.StatusInternalServerError, err)
+		return
+	}
 	defer worker.Unlock()
 
 	// delete function in FaaS Provider

--- a/pkg/object/function/worker/function.go
+++ b/pkg/object/function/worker/function.go
@@ -234,8 +234,8 @@ func (worker *Worker) listFunctionSpecs(all bool, functionName string) ([]*spec.
 }
 
 // Lock locks the cluster store.
-func (worker *Worker) Lock() {
-	worker.store.Lock()
+func (worker *Worker) Lock() error {
+	return worker.store.Lock()
 }
 
 // Unlock unlocks the cluster store.

--- a/pkg/object/meshcontroller/storage/storage.go
+++ b/pkg/object/meshcontroller/storage/storage.go
@@ -66,8 +66,6 @@ func New(name string, cls cluster.Cluster) Storage {
 	err := cs.mutexGoReady()
 	if err != nil {
 		logger.Errorf(err.Error())
-
-		return cs
 	}
 
 	return cs


### PR DESCRIPTION
This PR resolves the 'session expire' issue when the client sends API requests concurrently.
however, API processing becomes slower after the change.