### PR TITLE
fix(proxy): fallback not working

### DIFF
--- a/pkg/filter/proxy/proxy.go
+++ b/pkg/filter/proxy/proxy.go
@@ -352,9 +352,8 @@ func (b *Proxy) handle(ctx context.HTTPContext) (result string) {
 	if result != "" {
 		if b.fallbackForCodes(ctx) {
 			return resultFallback
-		} else {
-			return result
 		}
+		return result
 	}
 
 	// compression and memoryCache only work for

--- a/pkg/filter/proxy/proxy.go
+++ b/pkg/filter/proxy/proxy.go
@@ -350,11 +350,11 @@ func (b *Proxy) handle(ctx context.HTTPContext) (result string) {
 
 	result = p.handle(ctx, ctx.Request().Body(), b.client)
 	if result != "" {
-		return result
-	}
-
-	if b.fallbackForCodes(ctx) {
-		return resultFallback
+		if b.fallbackForCodes(ctx) {
+			return resultFallback
+		} else {
+			return result
+		}
 	}
 
 	// compression and memoryCache only work for

--- a/pkg/filter/proxy/proxy_test.go
+++ b/pkg/filter/proxy/proxy_test.go
@@ -144,7 +144,6 @@ failureCodes: [503, 504]
 	}
 
 	// test fallback
-
 	ctx.MockedResponse.MockedStatusCode = func() int {
 		return http.StatusServiceUnavailable
 	}
@@ -153,7 +152,6 @@ failureCodes: [503, 504]
 	if result != "fallback" {
 		t.Error("proxy.Handle should fallback")
 	}
-
 
 	time.Sleep(10 * time.Millisecond)
 	proxy.Close()

--- a/pkg/filter/proxy/proxy_test.go
+++ b/pkg/filter/proxy/proxy_test.go
@@ -143,6 +143,18 @@ failureCodes: [503, 504]
 		t.Error("proxy.Handle should fail")
 	}
 
+	// test fallback
+
+	ctx.MockedResponse.MockedStatusCode = func() int {
+		return http.StatusServiceUnavailable
+	}
+
+	result = proxy.Handle(ctx)
+	if result != "fallback" {
+		t.Error("proxy.Handle should fallback")
+	}
+
+
 	time.Sleep(10 * time.Millisecond)
 	proxy.Close()
 	time.Sleep(10 * time.Millisecond)


### PR DESCRIPTION
https://github.com/megaease/easegress/blob/36480f34946b464820360ea1a535880fd7e7751f/pkg/filter/proxy/proxy.go#L351-L360

As shown above, handle processing results equal to `""` on behalf of the request is normal, `not ""` on behalf of the occurrence of errors, fallback mechanism is said to occur after the error processing mechanism, so it should be `result ! = ""` in the case of fallback processing