### PR TITLE
Split Sync statuses to smaller objects in etcd

### DIFF
--- a/pkg/api/cluster.go
+++ b/pkg/api/cluster.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/megaease/easegress/pkg/object/httppipeline"
 	"github.com/megaease/easegress/pkg/object/httpserver"
-	"github.com/megaease/easegress/pkg/object/rawconfigtrafficcontroller"
 	"github.com/megaease/easegress/pkg/object/trafficcontroller"
 	"github.com/megaease/easegress/pkg/supervisor"
 )
@@ -169,52 +168,39 @@ func (s *Server) _listStatusObjects() map[string]map[string]interface{} {
 	return status
 }
 
-func getSubStatusFromTrafficControllerStatus(status *trafficcontroller.Status, spec *supervisor.Spec) string {
-	for _, ns := range status.Specs {
-		if ns.Namespace != rawconfigtrafficcontroller.DefaultNamespace {
-			continue
-		}
-		if spec.Kind() == httpserver.Kind {
-			if val, ok := ns.HTTPServers[spec.Name()]; ok {
-				b, err := yaml.Marshal(val.Status)
-				if err != nil {
-					ClusterPanic(fmt.Errorf("unmarshal %v to yaml failed: %v", val.Status, err))
-				}
-				return string(b)
-			}
-			return ""
-		} else if spec.Kind() == httppipeline.Kind {
-			if val, ok := ns.HTTPPipelines[spec.Name()]; ok {
-				b, err := yaml.Marshal(val.Status)
-				if err != nil {
-					ClusterPanic(fmt.Errorf("unmarshal %v to yaml failed: %v", val.Status, err))
-				}
-				return string(b)
-			}
-			return ""
-		}
-	}
-	return ""
-}
-
 func (s *Server) _getStatusObjectFromTrafficController(name string, spec *supervisor.Spec) map[string]string {
-	prefix := s.cluster.Layout().StatusObjectPrefix(trafficcontroller.Kind)
+	key := s.cluster.Layout().StatusObjectName(trafficcontroller.Kind, name)
+	prefix := s.cluster.Layout().StatusObjectPrefix(key)
 	kvs, err := s.cluster.GetPrefix(prefix)
 	if err != nil {
 		ClusterPanic(err)
 	}
-	status := &trafficcontroller.Status{}
-	ans := make(map[string]string)
-	for k, v := range kvs {
-		// different member
-		memberName := strings.TrimPrefix(k, prefix)
 
-		err = yaml.Unmarshal([]byte(v), status)
-		if err != nil {
-			ClusterPanic(fmt.Errorf("unmarshal %s to yaml failed: %v", v, err))
+	ans := make(map[string]string)
+	for _, v := range kvs {
+		if spec.Kind() == httpserver.Kind {
+			status := &trafficcontroller.HTTPServerStatus{}
+			err = yaml.Unmarshal([]byte(v), status)
+			if err != nil {
+				ClusterPanic(fmt.Errorf("unmarshal %s to yaml failed: %v", v, err))
+			}
+			b, err := yaml.Marshal(status.Status)
+			if err != nil {
+				ClusterPanic(fmt.Errorf("unmarshal %v to yaml failed: %v", status.Status, err))
+			}
+			ans[key] = string(b)
+		} else if spec.Kind() == httppipeline.Kind {
+			status := &trafficcontroller.HTTPPipelineStatus{}
+			err = yaml.Unmarshal([]byte(v), status)
+			if err != nil {
+				ClusterPanic(fmt.Errorf("unmarshal %s to yaml failed: %v", v, err))
+			}
+			b, err := yaml.Marshal(status.Status)
+			if err != nil {
+				ClusterPanic(fmt.Errorf("unmarshal %v to yaml failed: %v", status.Status, err))
+			}
+			ans[key] = string(b)
 		}
-		nsStatus := getSubStatusFromTrafficControllerStatus(status, spec)
-		ans[memberName] = nsStatus
 	}
 	return ans
 }

--- a/pkg/api/object.go
+++ b/pkg/api/object.go
@@ -201,7 +201,6 @@ func (s *Server) updateObject(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) listObjects(w http.ResponseWriter, r *http.Request) {
 	// No need to lock.
-
 	specs := specList(s._listObjects())
 	// NOTE: Keep it consistent.
 	sort.Sort(specs)

--- a/pkg/cluster/layout.go
+++ b/pkg/cluster/layout.go
@@ -27,6 +27,7 @@ const (
 	statusMemberPrefix       = "/status/members/"
 	statusMemberFormat       = "/status/members/%s" // +memberName
 	statusObjectPrefix       = "/status/objects/"
+	statusObjectNameFormat   = "%s-%s"
 	statusObjectPrefixFormat = "/status/objects/%s/"   // +objectName
 	statusObjectFormat       = "/status/objects/%s/%s" // +objectName +memberName
 	configObjectPrefix       = "/config/objects/"
@@ -99,6 +100,11 @@ func (l *Layout) StatusObjectsPrefix() string {
 // StatusObjectPrefix returns the prefix of object status.
 func (l *Layout) StatusObjectPrefix(name string) string {
 	return fmt.Sprintf(statusObjectPrefixFormat, name)
+}
+
+// StatusObjectName returns the name of the status object.
+func (l *Layout) StatusObjectName(kind string, specName string) string {
+	return fmt.Sprintf(statusObjectNameFormat, kind, specName)
 }
 
 // StatusObjectKey returns the key of object status.

--- a/pkg/object/statussynccontroller/statussynccontroller.go
+++ b/pkg/object/statussynccontroller/statussynccontroller.go
@@ -214,11 +214,11 @@ func (ssc *StatusSyncController) handleStatus(unixTimestamp int64) {
 			return splitRawconfigTrafficControllerStatus(name, rawTrafficStatus, statuses, statusesRecord)
 		} else {
 			statusesRecord.Statuses[name] = status
-			mashalledValue, ok := safeMarshal(status)
+			marshalledValue, ok := safeMarshal(status)
 			if !ok {
 				return false
 			}
-			statuses[name] = mashalledValue
+			statuses[name] = marshalledValue
 		}
 		return true
 	}

--- a/pkg/object/statussynccontroller/statussynccontroller.go
+++ b/pkg/object/statussynccontroller/statussynccontroller.go
@@ -20,7 +20,6 @@ package statussynccontroller
 import (
 	"runtime/debug"
 	"sync"
-	"strings"
 
 	"gopkg.in/yaml.v2"
 
@@ -175,8 +174,8 @@ func (ssc *StatusSyncController) handleStatus(unixTimestamp int64) {
 		status := entity.Instance().Status()
 		status.Timestamp = unixTimestamp
 
-		if strings.Contains(entity.Instance().Kind(), "TrafficController") {
-			namespaces := status.ObjectStatus.(trafficcontroller.Status).Specs
+		if trafficStatus, ok := status.ObjectStatus.(*trafficcontroller.Status); ok {
+			namespaces := trafficStatus.Specs
 			for _, namespace := range namespaces {
 				for k, v := range namespace.HTTPPipelines {
 					key := "TrafficController-" + namespace.Namespace + "-" + k

--- a/pkg/object/statussynccontroller/statussynccontroller.go
+++ b/pkg/object/statussynccontroller/statussynccontroller.go
@@ -272,6 +272,13 @@ func (ssc *StatusSyncController) syncStatusToCluster(statuses map[string]string)
 			kvs = make(map[string]*string)
 		}
 	}
+	if len(kvs) > 0 {
+		err := ssc.superSpec.Super().Cluster().PutAndDeleteUnderLease(kvs)
+		if err != nil {
+			logger.Errorf("sync status failed. If the message size is too large, "+
+				"please increase the value of cluster.MaxCallSendMsgSize in configuration: %v", err)
+		}
+	}
 }
 
 func (ssc *StatusSyncController) addStatusesRecord(statusesRecord *StatusesRecord) {

--- a/pkg/object/trafficcontroller/trafficcontroller.go
+++ b/pkg/object/trafficcontroller/trafficcontroller.go
@@ -116,6 +116,27 @@ func (ns *Namespace) GetHandler(name string) (protocol.HTTPHandler, bool) {
 	return handler, true
 }
 
+func (hss *HTTPServerStatus) toSyncStatus() *supervisor.Status {
+	return &supervisor.Status{ObjectStatus: hss}
+}
+
+func (hps *HTTPPipelineStatus) toSyncStatus() *supervisor.Status {
+	return &supervisor.Status{ObjectStatus: hps}
+}
+
+// ToSyncStatus returns http servers and pipelines in a map
+func (sisn *StatusInSameNamespace) ToSyncStatus() map[string]*supervisor.Status {
+	ns := sisn.Namespace
+	objects := make(map[string]*supervisor.Status)
+	for key, server := range sisn.HTTPServers {
+		objects[ns+"-"+key] = server.toSyncStatus()
+	}
+	for key, server := range sisn.HTTPPipelines {
+		objects[ns+"-"+key] = server.toSyncStatus()
+	}
+	return objects
+}
+
 // Category returns the category of TrafficController.
 func (tc *TrafficController) Category() supervisor.ObjectCategory {
 	return Category

--- a/pkg/object/trafficcontroller/trafficcontroller.go
+++ b/pkg/object/trafficcontroller/trafficcontroller.go
@@ -126,13 +126,12 @@ func (hps *HTTPPipelineStatus) toSyncStatus() *supervisor.Status {
 
 // ToSyncStatus returns http servers and pipelines in a map
 func (sisn *StatusInSameNamespace) ToSyncStatus() map[string]*supervisor.Status {
-	ns := sisn.Namespace
 	objects := make(map[string]*supervisor.Status)
 	for key, server := range sisn.HTTPServers {
-		objects[ns+"-"+key] = server.toSyncStatus()
+		objects[key] = server.toSyncStatus()
 	}
 	for key, server := range sisn.HTTPPipelines {
-		objects[ns+"-"+key] = server.toSyncStatus()
+		objects[key] = server.toSyncStatus()
 	}
 	return objects
 }

--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -164,7 +164,7 @@ func New() *Options {
 	opt.flags.StringVar(&opt.CPUProfileFile, "cpu-profile-file", "", "Path to the CPU profile file.")
 	opt.flags.StringVar(&opt.MemoryProfileFile, "memory-profile-file", "", "Path to the memory profile file.")
 
-	opt.flags.IntVar(&opt.StatusUpdateMaxBatchSize, "status-update-max-batch-size", 20, "How many objects statuses to update at maximum in one transaction.")
+	opt.flags.IntVar(&opt.StatusUpdateMaxBatchSize, "status-update-max-batch-size", 20, "Number of object statuses to update at maximum in one transaction.")
 
 	opt.viper.BindPFlags(opt.flags)
 

--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -35,7 +35,7 @@ import (
 	"github.com/megaease/easegress/pkg/version"
 )
 
-// ClusterOptions is the start-up options.
+// ClusterOptions defines the cluster members.
 type ClusterOptions struct {
 	// Primary members define following URLs to form a cluster.
 	ListenPeerURLs           []string          `yaml:"listen-peer-urls"`
@@ -94,6 +94,9 @@ type Options struct {
 	// Profile.
 	CPUProfileFile    string `yaml:"cpu-profile-file"`
 	MemoryProfileFile string `yaml:"memory-profile-file"`
+
+	// Status
+	StatusUpdateMaxBatchSize int `yaml:"status-update-max-batch-size"`
 
 	// Prepare the items below in advance.
 	AbsHomeDir   string `yaml:"-"`
@@ -160,6 +163,8 @@ func New() *Options {
 
 	opt.flags.StringVar(&opt.CPUProfileFile, "cpu-profile-file", "", "Path to the CPU profile file.")
 	opt.flags.StringVar(&opt.MemoryProfileFile, "memory-profile-file", "", "Path to the memory profile file.")
+
+	opt.flags.IntVar(&opt.StatusUpdateMaxBatchSize, "status-update-max-batch-size", 20, "How many objects statuses to update at maximum in one transaction.")
 
 	opt.viper.BindPFlags(opt.flags)
 


### PR DESCRIPTION
Close #541 .

Change periodically (every 5s) called `StatusSyncController.handleStatus`.
- save each status to cluster in individual etcd transaction
- For `TrafficController` and `RawconfigSyncController`, split the large status data structure to smaller items so that each `HTTPServer` object and each `HTTPPipeline` object has unique key "${kind}-${specName}" in etcd.

Adapt pkg/api/cluster.go to these changes:
- `egctl object status list` does not require changes
- `egctl object status get ${httpPipelineName|httpServerName}` uses `_getStatusObjectFromTrafficController` --> adapt this function to read new status data from etcd

