### PR TITLE
Validate helm-chart values

### DIFF
--- a/helm-charts/easegress/Chart.yaml
+++ b/helm-charts/easegress/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: easegress
 type: application
 version: 1.0.0
-
+icon: https://raw.github.com/megaease/easegress/main/doc/imgs/easegress.svg

--- a/helm-charts/easegress/README.md
+++ b/helm-charts/easegress/README.md
@@ -25,7 +25,7 @@ helm install easegress -n easegress ./helm-charts/easegress
 # install with custom values
 helm install easegress -n easegress ./helm-charts/easegress \
   --set service.nodePort=4080 \
-  --set image.tag=v1.4.0 \
+  --set image.tag=v1.5.0 \
 
 # install cluster of 3 primary and 2 secondary Easegress instances
 helm install easegress -n easegress ./helm-charts/easegress \
@@ -65,7 +65,7 @@ The following table lists the configurable parameters of the MegaEase Easegress 
 | service.nodePort | int | `30780` | nodePort for easegress service. |
 | service.adminPort | int | `31255` | nodePort for egctl access. |
 | cluster.primaryReplicas | int | `1` | number of easegress service that persists cluster data to disk |
-| cluster.volumeType | string | `emptyDir` | `emptyDir`: use pods internal filesystem that is not persisted when pod crashes. `persistentVolume`, create as many persistenVolumes and persistentVolumeClaims as there are nodeHostnames.
+| cluster.volumeType | string | `emptyDir` | `emptyDir`: use pods internal filesystem that is not persisted when pod crashes. Use `emptyDir` only when primaryReplicas is 1. | `persistentVolume`, create as many persistenVolumes and persistentVolumeClaims as there are nodeHostnames.
 | cluster.nodeHostnames | list | `[]` | nodeHostnames are hostnames of VMs/Kubernetes nodes. Only used when `volumeType: persistentVolume`. Note that this require nodes to be static. |
 | secondaryReplicas | int | `0` | number of easegress service that not persists cluster data to disk. |
 

--- a/helm-charts/easegress/templates/StatefulSet.yaml
+++ b/helm-charts/easegress/templates/StatefulSet.yaml
@@ -1,3 +1,8 @@
+{{- if eq .Values.cluster.volumeType "emptyDir" }}
+  {{- if ne (int .Values.cluster.primaryReplicas) 1 }}
+    {{- fail "When .Values.cluster.volumeType is 'emptyDir', .Values.cluster.primaryReplicas should be 1" }}
+  {{- end }}
+{{- end }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/helm-charts/easegress/values.yaml
+++ b/helm-charts/easegress/values.yaml
@@ -11,7 +11,7 @@ image:
 
 # Easegress cluster configurations.
 # When volumeType is
-# - emptyDir: use pods internal filesystem that is not persisted when pod crashes.
+# - emptyDir: use pods internal filesystem that is not persisted when pod crashes. Use `emptyDir` only when primaryReplicas is 1.
 # - persistentVolume, create as many persistenVolumes and persistentVolumeClaims as there are nodeHostnames.
 cluster:
   primaryReplicas: 1 # or 3,5,7


### PR DESCRIPTION
Ensure that value of the volumeType is `emptyDir` only with single replica. This PR aims to avoid users accidentally creating multi-node Easegress in k8s with `emptyDir`, for following reason:

When a pod fails and restarts again, etcd will decide whether bootstrap a new cluster or use existing cluster. In the case of multiple replicas, the restarting pod should use the existing cluster. For joining to the existing cluster, pod needs access to the local etcd's WAL data folder OR a explicit flag (`cluster-state: new/existing`) telling whether to create new cluster. Adding explicit `cluster-state: new/existing` flag is a bit complicated (one way is to use bash commands in StatefulSet spec's to contact the neighbor members and figure out if the cluster exists already).

Simpler approach is to ensure that etcd's WAL data folder is available when restarting pod. This is the case when using volumeType `persistentVolume`, because etcd's data is persisted between pod restarts.

### Reference 
https://github.com/etcd-io/etcd/blob/5fe4d551df1b432137b927992876933c39e57e32/server/etcdserver/bootstrap.go#L275-L276