### PR TITLE
valid circuit-breaker filter spec by correlation

### DIFF
--- a/pkg/filter/circuitbreaker/circuitbreaker.go
+++ b/pkg/filter/circuitbreaker/circuitbreaker.go
@@ -111,7 +111,7 @@ URLLoop:
 func (spec Spec) validatePoliciesSpec() error {
 	for _, p := range spec.Policies {
 		if p.FailureRateThreshold != 0 && len(p.FailureStatusCodes) == 0 && !p.CountingNetworkError {
-			return fmt.Errorf("policy '%s' has setted failure threshold and countingNetworkError is false, but not set failure status code", p.Name)
+			return fmt.Errorf("policy '%s' has set failure threshold and countingNetworkError is false, but not set failure status code", p.Name)
 		}
 	}
 	return nil

--- a/pkg/filter/circuitbreaker/circuitbreaker.go
+++ b/pkg/filter/circuitbreaker/circuitbreaker.go
@@ -110,20 +110,8 @@ URLLoop:
 
 func (spec Spec) validatePoliciesSpec() error {
 	for _, p := range spec.Policies {
-		//group of failure
-		if p.FailureRateThreshold == 0 && len(p.FailureStatusCodes) != 0 {
-			return fmt.Errorf("policy '%s' has setted failure status code, but not set failure threshold ", p.Name)
-		}
-		if p.FailureRateThreshold != 0 && len(p.FailureStatusCodes) == 0 {
-			return fmt.Errorf("policy '%s' has setted failure threshold, but not set failure status code ", p.Name)
-		}
-
-		//group of slow
-		if p.SlowCallRateThreshold != 0 && (p.SlowCallDurationThreshold == "" || strings.TrimSpace(p.SlowCallDurationThreshold) == "") {
-			return fmt.Errorf("policy '%s' has setted slow call threshold, but not set slow call duration ", p.Name)
-		}
-		if p.SlowCallRateThreshold == 0 && (p.SlowCallDurationThreshold != "" || strings.TrimSpace(p.SlowCallDurationThreshold) != "") {
-			return fmt.Errorf("policy '%s' has setted slow call duration, but not set slow call threshold ", p.Name)
+		if p.FailureRateThreshold != 0 && len(p.FailureStatusCodes) == 0 && !p.CountingNetworkError {
+			return fmt.Errorf("policy '%s' has setted failure threshold and countingNetworkError is false, but not set failure status code", p.Name)
 		}
 	}
 	return nil

--- a/pkg/filter/circuitbreaker/circuitbreaker_test.go
+++ b/pkg/filter/circuitbreaker/circuitbreaker_test.go
@@ -48,6 +48,7 @@ policies:
   slidingWindowType: COUNT_BASED
   slidingWindowSize: 10
   minimumNumberOfCalls: 5
+  slowCallDurationThreshold: 5s
   failureStatusCodes: [500, 503]
 defaultPolicyRef: default
 urls:
@@ -158,4 +159,110 @@ func TestBuildPolicy(t *testing.T) {
 	if p.WaitDurationInOpen != time.Minute {
 		t.Error("wait duration in open is not 1m")
 	}
+}
+
+func TestValidate(t *testing.T) {
+	t.Run("invalidFailureCode", func(t *testing.T) {
+		const yamlSpec = `
+kind: CircuitBreaker
+name: circuitbreaker
+policies:
+- name: default
+  failureRateThreshold: 50
+  slidingWindowType: COUNT_BASED
+  slidingWindowSize: 10
+defaultPolicyRef: default
+urls:
+- methods: []
+  url:
+    exact: /circuitbreak
+    prefix:
+    regex:
+`
+		rawSpec := make(map[string]interface{})
+		yamltool.Unmarshal([]byte(yamlSpec), &rawSpec)
+
+		_, err := httppipeline.NewFilterSpec(rawSpec, nil)
+		if err == nil {
+			t.Errorf("set failure threshold and not set failure code, that did not fail")
+		}
+	})
+
+	t.Run("invalidFailureThreshold", func(t *testing.T) {
+		const yamlSpec = `
+kind: CircuitBreaker
+name: circuitbreaker
+policies:
+- name: default
+  failureStatusCodes: [500]
+  slidingWindowType: COUNT_BASED
+  slidingWindowSize: 10
+defaultPolicyRef: default
+urls:
+- methods: []
+  url:
+    exact: /circuitbreak
+    prefix:
+    regex:
+`
+		rawSpec := make(map[string]interface{})
+		yamltool.Unmarshal([]byte(yamlSpec), &rawSpec)
+
+		_, err := httppipeline.NewFilterSpec(rawSpec, nil)
+		if err == nil {
+			t.Errorf("set failure code and not set failure rate, that did not fail")
+		}
+	})
+
+	t.Run("invalidSlowDuration", func(t *testing.T) {
+		const yamlSpec = `
+kind: CircuitBreaker
+name: circuitbreaker
+policies:
+- name: default
+  slidingWindowType: COUNT_BASED
+  slidingWindowSize: 10
+  slowCallRateThreshold: 1
+defaultPolicyRef: default
+urls:
+- methods: []
+  url:
+    exact: /circuitbreak
+    prefix:
+    regex:
+`
+		rawSpec := make(map[string]interface{})
+		yamltool.Unmarshal([]byte(yamlSpec), &rawSpec)
+
+		_, err := httppipeline.NewFilterSpec(rawSpec, nil)
+		if err == nil {
+			t.Errorf("set slow call threshold and not set slow call duration, that did not fail")
+		}
+	})
+
+	t.Run("invalidSlowCallThreshold", func(t *testing.T) {
+		const yamlSpec = `
+kind: CircuitBreaker
+name: circuitbreaker
+policies:
+- name: default
+  slidingWindowType: COUNT_BASED
+  slidingWindowSize: 10
+  slowCallDurationThreshold: 1m
+defaultPolicyRef: default
+urls:
+- methods: []
+  url:
+    exact: /circuitbreak
+    prefix:
+    regex:
+`
+		rawSpec := make(map[string]interface{})
+		yamltool.Unmarshal([]byte(yamlSpec), &rawSpec)
+
+		_, err := httppipeline.NewFilterSpec(rawSpec, nil)
+		if err == nil {
+			t.Errorf("set slow call duration and not set slow call threshold, that did not fail")
+		}
+	})
 }


### PR DESCRIPTION
The circuit breaker filter should valid spec according to the parameter correlation: using the strategy of failure statistics, it should ensure that the relevant required parameters have been set(failureRateThreshold,failureStatusCodes). At this time, the relevant parameters of the slow call are not required, and vice versa.