### PR TITLE
feat(helm): log support custom path and use emptyDir volume 

### DIFF
--- a/helm-charts/easegress/README.md
+++ b/helm-charts/easegress/README.md
@@ -68,5 +68,6 @@ The following table lists the configurable parameters of the MegaEase Easegress 
 | cluster.volumeType | string | `emptyDir` | `emptyDir`: use pods internal filesystem that is not persisted when pod crashes. Use `emptyDir` only when primaryReplicas is 1. | `persistentVolume`, create as many persistenVolumes and persistentVolumeClaims as there are nodeHostnames.
 | cluster.nodeHostnames | list | `[]` | nodeHostnames are hostnames of VMs/Kubernetes nodes. Only used when `volumeType: persistentVolume`. Note that this require nodes to be static. |
 | secondaryReplicas | int | `0` | number of easegress service that not persists cluster data to disk. |
+| log.path | string | `/opt/easegress/log` | log path inside container |
 
 > By default, k8s use range 30000-32767 for NodePort. Make sure you choose right port number.

--- a/helm-charts/easegress/templates/ConfigMap.yaml
+++ b/helm-charts/easegress/templates/ConfigMap.yaml
@@ -19,7 +19,7 @@ data:
     wal-dir: ""
     cpu-profile-file: ""
     memory-profile-file: ""
-    log-dir: /opt/easegress/log
+    log-dir: {{ .Values.log.path }}
     debug: false
   eg-secondary.yaml: |
     cluster-name: easegress
@@ -32,7 +32,7 @@ data:
     wal-dir: ""
     cpu-profile-file: ""
     memory-profile-file: ""
-    log-dir: /opt/easegress/log
+    log-dir: {{ .Values.log.path }}
     debug: false
 kind: ConfigMap
 metadata:

--- a/helm-charts/easegress/templates/StatefulSet.yaml
+++ b/helm-charts/easegress/templates/StatefulSet.yaml
@@ -27,7 +27,7 @@ spec:
         - -c
         - |-
           echo name: $EG_NAME > /opt/eg-config/config.yaml &&
-          cat /opt/eg-config/eg-primary.yaml >> /opt/eg-config/config.yaml && 
+          cat /opt/eg-config/eg-primary.yaml >> /opt/eg-config/config.yaml &&
           /opt/easegress/bin/easegress-server \
             -f /opt/eg-config/config.yaml \
             --advertise-client-urls http://$(EG_NAME).easegress-hs.{{ .Release.Namespace }}:2379 \
@@ -67,7 +67,7 @@ spec:
         - mountPath: /opt/easegress/data
           name: {{ if eq .Values.cluster.volumeType "persistentVolume" }}easegress-pv {{ else }} easegress-data-volume {{ end }}
         - mountPath: /opt/easegress/log
-          name: {{ if eq .Values.cluster.volumeType "persistentVolume" }}easegress-pv {{ else }} easegress-data-volume {{ end }}
+          name: easegress-data-volume
       restartPolicy: Always
       volumes:
       - emptyDir: {}

--- a/helm-charts/easegress/templates/StatefulSet.yaml
+++ b/helm-charts/easegress/templates/StatefulSet.yaml
@@ -66,7 +66,7 @@ spec:
           subPath: eg-primary.yaml
         - mountPath: /opt/easegress/data
           name: {{ if eq .Values.cluster.volumeType "persistentVolume" }}easegress-pv {{ else }} easegress-data-volume {{ end }}
-        - mountPath: /opt/easegress/log
+        - mountPath: {{ .Values.log.path }}
           name: easegress-data-volume
       restartPolicy: Always
       volumes:

--- a/helm-charts/easegress/values.yaml
+++ b/helm-charts/easegress/values.yaml
@@ -25,5 +25,6 @@ cluster:
 
   secondaryReplicas: 0
 
+# log path inside container
 log:
   path: /opt/easegress/log

--- a/helm-charts/easegress/values.yaml
+++ b/helm-charts/easegress/values.yaml
@@ -24,3 +24,6 @@ cluster:
   # - hostname-3
 
   secondaryReplicas: 0
+
+log:
+  path: /opt/easegress/log

--- a/helm-charts/ingress-controller/README.md
+++ b/helm-charts/ingress-controller/README.md
@@ -39,5 +39,7 @@ The following table lists the configurable parameters of the Ingress Controller 
 |-----|------|---------|-------------|
 | service.nodePort | int | `30080` | nodePort for Easegress Ingress Controller. |
 | replicas | int | `1` | number of Easegress Ingress Controllers |
+| log.path | string | `/opt/easegress/log` | log path inside container |
+
 
 > By default, k8s use range 30000-32767 for NodePort. Make sure you choose right port number.

--- a/helm-charts/ingress-controller/templates/ConfigMap.yaml
+++ b/helm-charts/ingress-controller/templates/ConfigMap.yaml
@@ -6,7 +6,7 @@ data:
     cluster-role: primary
     api-addr: 0.0.0.0:2381
     data-dir: /opt/easegress/data
-    log-dir: /opt/easegress/log
+    log-dir: {{ .Values.log.path }}
     debug: false
   controller.yaml: |
     kind: IngressController

--- a/helm-charts/ingress-controller/values.yaml
+++ b/helm-charts/ingress-controller/values.yaml
@@ -19,3 +19,6 @@ controller:
 
 # number of Easegress IngressController replicas
 replicas: 1
+
+log:
+  path: /opt/easegress/log

--- a/helm-charts/ingress-controller/values.yaml
+++ b/helm-charts/ingress-controller/values.yaml
@@ -20,5 +20,6 @@ controller:
 # number of Easegress IngressController replicas
 replicas: 1
 
+# log path inside container
 log:
   path: /opt/easegress/log


### PR DESCRIPTION
1. log  support custom path
2. use emptyDir volume, consistent with secondary