### PR TITLE
Proxy to send zipkin b3 headers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,8 +36,6 @@ require (
 	github.com/megaease/grace v1.0.0
 	github.com/mitchellh/mapstructure v1.4.3
 	github.com/nacos-group/nacos-sdk-go v1.1.0
-	github.com/opentracing/opentracing-go v1.2.0
-	github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.5
 	github.com/openzipkin/zipkin-go v0.4.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
@@ -176,7 +174,6 @@ require (
 	github.com/nrdcg/dnspod-go v0.4.0 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/onsi/ginkgo v1.16.5 // indirect
-	github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -721,7 +721,6 @@ github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51
 github.com/gorilla/handlers v0.0.0-20150720190736-60c7bfde3e33/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
-github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
@@ -1088,15 +1087,8 @@ github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mo
 github.com/opencontainers/selinux v1.6.0/go.mod h1:VVGKuOLlE7v4PJyT6h7mNWvq1rzqiriPsEqVhc+svHE=
 github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3ogry1nUQF8Evvo=
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
-github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492 h1:lM6RxxfUMrYL/f8bWEUqdXrANWtrL7Nndbm9iFN0DlU=
-github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
-github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
-github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
-github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.5 h1:ZCnq+JUrvXcDVhX/xRolRBZifmabN1HcS1wrPSvxhrU=
-github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.5/go.mod h1:/wsWhb9smxSfWAKL3wpBW7V8scJMt8N8gnaMCS9E/cA=
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
-github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.3.0/go.mod h1:4c3sLeE8xjNqehmF5RpAFLPLJxXscc0R4l6Zg0P1tTQ=
 github.com/openzipkin/zipkin-go v0.4.0 h1:CtfRrOVZtbDj8rt1WXjklw0kqqJQwICrCKmlfUuBUUw=
@@ -2023,7 +2015,6 @@ google.golang.org/grpc v1.20.0/go.mod h1:chYK+tFQF0nDUGJgXMSgLCQk3phJEuONr2DCgLD
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
-google.golang.org/grpc v1.22.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.23.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.24.0/go.mod h1:XDChyiUovWa60DnaeDeZmSW86xtLtjtZbwvSiRnRtcA=

--- a/pkg/context/contexttest/context.go
+++ b/pkg/context/contexttest/context.go
@@ -238,7 +238,7 @@ func (c *MockedHTTPContext) SetHandlerCaller(caller context.HandlerCaller) {
 	}
 }
 
-// SetHandlerCaller mocks the SetHandlerCaller function of HTTPContext
+// Tracing mocks the Tracing function of HTTPContext
 func (c *MockedHTTPContext) Tracing() *tracing.Tracing {
 	if c.MockedTracing != nil {
 		return c.MockedTracing()

--- a/pkg/context/contexttest/context.go
+++ b/pkg/context/contexttest/context.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/megaease/easegress/pkg/context"
+	"github.com/megaease/easegress/pkg/tracing"
 	"github.com/megaease/easegress/pkg/util/httpstat"
 	"github.com/megaease/easegress/pkg/util/texttemplate"
 )
@@ -52,6 +53,7 @@ type MockedHTTPContext struct {
 	MockedSaveRspToTemplate  func(filterName string) error
 	MockedCallNextHandler    func(lastResult string) string
 	MockedSetHandlerCaller   func(caller context.HandlerCaller)
+	MockedTracing            func() *tracing.Tracing
 }
 
 // Protocol return protocol of MockedHTTPContext
@@ -232,6 +234,14 @@ func (c *MockedHTTPContext) CallNextHandler(lastResult string) string {
 // SetHandlerCaller mocks the SetHandlerCaller function of HTTPContext
 func (c *MockedHTTPContext) SetHandlerCaller(caller context.HandlerCaller) {
 	if c.MockedSetHandlerCaller != nil {
-		c.SetHandlerCaller(caller)
+		c.MockedSetHandlerCaller(caller)
 	}
+}
+
+// SetHandlerCaller mocks the SetHandlerCaller function of HTTPContext
+func (c *MockedHTTPContext) Tracing() *tracing.Tracing {
+	if c.MockedTracing != nil {
+		return c.MockedTracing()
+	}
+	return tracing.NoopTracing
 }

--- a/pkg/context/contexttest/context.go
+++ b/pkg/context/contexttest/context.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/megaease/easegress/pkg/context"
-	"github.com/megaease/easegress/pkg/tracing"
 	"github.com/megaease/easegress/pkg/util/httpstat"
 	"github.com/megaease/easegress/pkg/util/texttemplate"
 )
@@ -33,7 +32,6 @@ type MockedHTTPContext struct {
 	finishFuncs              []func()
 	MockedLock               func()
 	MockedUnlock             func()
-	MockedSpan               func() tracing.Span
 	MockedRequest            MockedHTTPRequest
 	MockedResponse           MockedHTTPResponse
 	MockedDeadline           func() (time.Time, bool)
@@ -73,14 +71,6 @@ func (c *MockedHTTPContext) Unlock() {
 	if c.MockedUnlock != nil {
 		c.MockedUnlock()
 	}
-}
-
-// Span mocks the Span function of HTTPContext
-func (c *MockedHTTPContext) Span() tracing.Span {
-	if c.MockedSpan != nil {
-		return c.MockedSpan()
-	}
-	return tracing.NewSpan(tracing.NoopTracing, "mocked")
 }
 
 // Request mocks the Request function of HTTPContext

--- a/pkg/context/httpcontext.go
+++ b/pkg/context/httpcontext.go
@@ -70,6 +70,8 @@ type (
 
 		CallNextHandler(lastResult string) string
 		SetHandlerCaller(caller HandlerCaller)
+
+		Tracing() *tracing.Tracing
 	}
 
 	// HTTPRequest is all operations for HTTP request.
@@ -151,13 +153,13 @@ type (
 		w *httpResponse
 
 		ht             *HTTPTemplate
-		span           tracing.Span
 		originalReqCtx stdcontext.Context
 		stdctx         stdcontext.Context
 		cancelFunc     stdcontext.CancelFunc
 		err            error
 
-		metric httpstat.Metric
+		metric  httpstat.Metric
+		tracing *tracing.Tracing
 	}
 )
 
@@ -183,6 +185,7 @@ func New(stdw http.ResponseWriter, stdr *http.Request,
 		w:              newHTTPResponse(stdw, stdr),
 		lazyTags:       make([]LazyTagFunc, 0, 5),
 		finishFuncs:    make([]FinishFunc, 0, 1),
+		tracing:        tracingInstance,
 	}
 	return ctx
 }
@@ -353,4 +356,9 @@ func (ctx *httpContext) SaveReqToTemplate(filterName string) error {
 // SaveRspToTemplate stores http response related info into HTTP template engine
 func (ctx *httpContext) SaveRspToTemplate(filterName string) error {
 	return ctx.ht.SaveResponse(filterName, ctx)
+}
+
+// Tracing returns tracing object
+func (ctx *httpContext) Tracing() *tracing.Tracing {
+	return ctx.tracing
 }

--- a/pkg/context/httpcontext.go
+++ b/pkg/context/httpcontext.go
@@ -172,7 +172,7 @@ func New(stdw http.ResponseWriter, stdr *http.Request,
 	startTime := fasttime.Now()
 	if !tracingInstance.IsNoopTracer() {
 		// add span to context
-		stdctx = tracing.CreateSpanWithContext(tracingInstance, spanName, startTime, stdctx)
+		stdctx = tracing.CreateSpanWithContext(stdctx, tracingInstance, spanName, startTime)
 	}
 	ctx := &httpContext{
 		startTime:      startTime,

--- a/pkg/filter/proxy/pool.go
+++ b/pkg/filter/proxy/pool.go
@@ -24,20 +24,17 @@ import (
 	"strconv"
 	"sync"
 
-	//"github.com/opentracing/opentracing-go"
 	gohttpstat "github.com/tcnksm/go-httpstat"
 
 	"github.com/megaease/easegress/pkg/context"
 	"github.com/megaease/easegress/pkg/logger"
 	"github.com/megaease/easegress/pkg/supervisor"
-	//"github.com/megaease/easegress/pkg/tracing"
 	"github.com/megaease/easegress/pkg/util/callbackreader"
 	"github.com/megaease/easegress/pkg/util/httpfilter"
 	"github.com/megaease/easegress/pkg/util/httpheader"
 	"github.com/megaease/easegress/pkg/util/httpstat"
 	"github.com/megaease/easegress/pkg/util/memorycache"
 	"github.com/megaease/easegress/pkg/util/stringtool"
-	//zipkinhttp "github.com/openzipkin/zipkin-go/middleware/http"
 )
 
 type (

--- a/pkg/filter/proxy/pool.go
+++ b/pkg/filter/proxy/pool.go
@@ -24,19 +24,20 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/opentracing/opentracing-go"
+	//"github.com/opentracing/opentracing-go"
 	gohttpstat "github.com/tcnksm/go-httpstat"
 
 	"github.com/megaease/easegress/pkg/context"
 	"github.com/megaease/easegress/pkg/logger"
 	"github.com/megaease/easegress/pkg/supervisor"
-	"github.com/megaease/easegress/pkg/tracing"
+	//"github.com/megaease/easegress/pkg/tracing"
 	"github.com/megaease/easegress/pkg/util/callbackreader"
 	"github.com/megaease/easegress/pkg/util/httpfilter"
 	"github.com/megaease/easegress/pkg/util/httpheader"
 	"github.com/megaease/easegress/pkg/util/httpstat"
 	"github.com/megaease/easegress/pkg/util/memorycache"
 	"github.com/megaease/easegress/pkg/util/stringtool"
+	//zipkinhttp "github.com/openzipkin/zipkin-go/middleware/http"
 )
 
 type (
@@ -141,7 +142,7 @@ var httpstatResultPool = sync.Pool{
 	},
 }
 
-func (p *pool) handle(ctx context.HTTPContext, reqBody io.Reader, client *http.Client) string {
+func (p *pool) handle(ctx context.HTTPContext, reqBody io.Reader, client *Client) string {
 	// intMsg is converted to string in AddLazyTag for better performance,
 	// as it is not run when access logs are disabled.
 	addLazyTag := func(subPrefix, msg string, intMsg int) {
@@ -181,7 +182,7 @@ func (p *pool) handle(ctx context.HTTPContext, reqBody io.Reader, client *http.C
 		return resultInternalError
 	}
 
-	resp, span, err := p.doRequest(ctx, req, client)
+	resp, err := p.doRequest(ctx, req, client)
 	if err != nil {
 		// NOTE: May add option to cancel the tracing if failed here.
 		// ctx.Span().Cancel()
@@ -204,13 +205,11 @@ func (p *pool) handle(ctx context.HTTPContext, reqBody io.Reader, client *http.C
 	defer ctx.Unlock()
 	// NOTE: The code below can't use addTag and setStatusCode in case of deadlock.
 
-	respBody := p.statRequestResponse(ctx, req, resp, span)
-
+	respBody := p.statRequestResponse(ctx, req, resp)
 	if p.writeResponse {
 		ctx.Response().SetStatusCode(resp.StatusCode)
 		ctx.Response().Header().AddFromStd(resp.Header)
 		ctx.Response().SetBody(respBody)
-
 		return ""
 	}
 
@@ -235,7 +234,7 @@ func (p *pool) prepareRequest(
 	return p.newRequest(ctx, server, reqBody, requestPool, httpstatResultPool)
 }
 
-func (p *pool) doRequest(ctx context.HTTPContext, req *request, client *http.Client) (*http.Response, tracing.Span, error) {
+func (p *pool) doRequest(ctx context.HTTPContext, req *request, client *Client) (*http.Response, error) {
 	req.start()
 
 	spanName := p.spec.SpanName
@@ -243,14 +242,11 @@ func (p *pool) doRequest(ctx context.HTTPContext, req *request, client *http.Cli
 		spanName = req.server.URL
 	}
 
-	span := ctx.Span().NewChildWithStart(spanName, req.startTime())
-	span.Tracer().Inject(span.Context(), opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(req.std.Header))
-
 	resp, err := fnSendRequest(req.std, client)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	return resp, span, nil
+	return resp, nil
 }
 
 var httpstatMetricPool = sync.Pool{
@@ -260,7 +256,7 @@ var httpstatMetricPool = sync.Pool{
 }
 
 func (p *pool) statRequestResponse(ctx context.HTTPContext,
-	req *request, resp *http.Response, span tracing.Span) io.Reader {
+	req *request, resp *http.Response) io.Reader {
 
 	var count int
 
@@ -269,7 +265,6 @@ func (p *pool) statRequestResponse(ctx context.HTTPContext,
 		count += n
 		if err == io.EOF {
 			req.finish()
-			span.Finish()
 		}
 
 		return p, n, err
@@ -278,7 +273,6 @@ func (p *pool) statRequestResponse(ctx context.HTTPContext,
 	ctx.OnFinish(func() {
 		if !p.writeResponse {
 			req.finish()
-			span.Finish()
 		}
 		duration := req.total()
 		ctx.AddLazyTag(func() string {

--- a/pkg/filter/proxy/proxy.go
+++ b/pkg/filter/proxy/proxy.go
@@ -353,7 +353,7 @@ func (b *Proxy) updateAndGetClient(tracingInstance *tracing.Tracing) *Client {
 	if client.tracing == tracingInstance {
 		return client
 	}
-
+	// tracingInstance is updated so recreate http.Client
 	newClient := NewClient(b.createHTTPClient(), tracingInstance)
 	b.client.Store(newClient)
 	return newClient

--- a/pkg/filter/proxy/proxy_test.go
+++ b/pkg/filter/proxy/proxy_test.go
@@ -339,17 +339,26 @@ mainPool:
 		header := http.Header{}
 		return httpheader.New(header)
 	}
+	ctx.MockedTracing = func() *tracing.Tracing {
+		return tracing.NoopTracing
+	}
 	proxy.handle(ctx)
 	assert.Nil(proxy.client.zipkinClient)
 
 	// HTTPServer updates tracing
 	tracer := createTracing(assert, "")
-	superMock.SetTracing(tracer)
+
+	ctx.MockedTracing = func() *tracing.Tracing {
+		return tracer
+	}
+
 	proxy.handle(ctx)
 	assert.NotNil(proxy.client.zipkinClient)
 
 	// HTTPServer removes tracing
-	superMock.SetTracing(tracing.NoopTracing)
+	ctx.MockedTracing = func() *tracing.Tracing {
+		return tracing.NoopTracing
+	}
 	proxy.handle(ctx)
 	assert.Nil(proxy.client.zipkinClient)
 

--- a/pkg/filter/proxy/proxy_test.go
+++ b/pkg/filter/proxy/proxy_test.go
@@ -343,7 +343,7 @@ mainPool:
 		return tracing.NoopTracing
 	}
 	proxy.handle(ctx)
-	assert.Nil(proxy.client.zipkinClient)
+	assert.Nil(proxy.client.Load().(*Client).zipkinClient)
 
 	// HTTPServer updates tracing
 	tracer := createTracing(assert, "")
@@ -353,14 +353,14 @@ mainPool:
 	}
 
 	proxy.handle(ctx)
-	assert.NotNil(proxy.client.zipkinClient)
+	assert.NotNil(proxy.client.Load().(*Client).zipkinClient)
 
 	// HTTPServer removes tracing
 	ctx.MockedTracing = func() *tracing.Tracing {
 		return tracing.NoopTracing
 	}
 	proxy.handle(ctx)
-	assert.Nil(proxy.client.zipkinClient)
+	assert.Nil(proxy.client.Load().(*Client).zipkinClient)
 
 	tracer.Close() // normally HTTPServer closes this
 }

--- a/pkg/filter/proxy/request_test.go
+++ b/pkg/filter/proxy/request_test.go
@@ -157,7 +157,6 @@ func TestAddB3PropagationHeaders(t *testing.T) {
 	defer requestPool.Put(req) // recycle request
 
 	header := req.std.Header
-	// fmt.Println(header)
 	assert.Equal(1, len(header["X-B3-TraceId"]))
 	assert.Equal(traceID, header["X-B3-TraceId"][0])
 	assert.Equal(1, len(header["X-B3-Sampled"]))

--- a/pkg/object/httpserver/httpserver_test.go
+++ b/pkg/object/httpserver/httpserver_test.go
@@ -372,7 +372,7 @@ func TestStartTwoServerInSamePort(t *testing.T) {
 	superSpecYaml := `
 name: http-server-test
 kind: HTTPServer
-port: 10080
+port: 10082
 cacheSize: 200
 rules:
   - paths:
@@ -391,12 +391,10 @@ rules:
 	httpServer2 := HTTPServer{}
 	httpServer2.Init(superSpec2, mux2)
 
-	_, err1 := http.Get("http://127.0.0.1:10080/api")
 	httpServer1.Close()
 	httpServer2.Close()
-	_, err2 := http.Get("http://127.0.0.1:10080/api")
-	assert.Nil(err1)
-	assert.NotNil(err2)
+	_, err = http.Get("http://127.0.0.1:10082/api")
+	assert.NotNil(err)
 }
 
 func TestMatchPath(t *testing.T) {

--- a/pkg/object/httpserver/mux.go
+++ b/pkg/object/httpserver/mux.go
@@ -349,10 +349,6 @@ func (m *mux) reloadRules(superSpec *supervisor.Spec, muxMapper protocol.MuxMapp
 	} else if oldRules.tracer != nil {
 		tracer = oldRules.tracer
 	}
-	super := superSpec.Super()
-	if super != nil {
-		super.SetTracing(tracer) // share tracing object with proxy filters
-	}
 
 	rules := &muxRules{
 		superSpec:    superSpec,

--- a/pkg/supervisor/supervisor.go
+++ b/pkg/supervisor/supervisor.go
@@ -22,12 +22,10 @@ import (
 	"os"
 	"runtime/debug"
 	"sync"
-	"sync/atomic"
 
 	"github.com/megaease/easegress/pkg/cluster"
 	"github.com/megaease/easegress/pkg/logger"
 	"github.com/megaease/easegress/pkg/option"
-	"github.com/megaease/easegress/pkg/tracing"
 )
 
 const watcherName = "__SUPERVISOR__"
@@ -37,7 +35,6 @@ type (
 	Supervisor struct {
 		options *option.Options
 		cls     cluster.Cluster
-		tracing atomic.Value //*tracing.Tracing
 
 		// The scenario here satisfies the first common case:
 		// When the entry for a given key is only ever written once but read many times.
@@ -115,20 +112,6 @@ func (s *Supervisor) Options() *option.Options {
 // Cluster return the cluster applied to supervisor.
 func (s *Supervisor) Cluster() cluster.Cluster {
 	return s.cls
-}
-
-// Tracing return the tracing instance.
-func (s *Supervisor) Tracing() *tracing.Tracing {
-	tr := s.tracing.Load()
-	if tr == nil {
-		return tracing.NoopTracing
-	}
-	return tr.(*tracing.Tracing)
-}
-
-// SetTracing sets the global tracing instance.
-func (s *Supervisor) SetTracing(tracing *tracing.Tracing) {
-	s.tracing.Store(tracing)
 }
 
 func (s *Supervisor) initSystemControllers() {

--- a/pkg/supervisor/supervisor.go
+++ b/pkg/supervisor/supervisor.go
@@ -26,6 +26,7 @@ import (
 	"github.com/megaease/easegress/pkg/cluster"
 	"github.com/megaease/easegress/pkg/logger"
 	"github.com/megaease/easegress/pkg/option"
+	"github.com/megaease/easegress/pkg/tracing"
 )
 
 const watcherName = "__SUPERVISOR__"
@@ -35,6 +36,7 @@ type (
 	Supervisor struct {
 		options *option.Options
 		cls     cluster.Cluster
+		tracing *tracing.Tracing
 
 		// The scenario here satisfies the first common case:
 		// When the entry for a given key is only ever written once but read many times.
@@ -112,6 +114,19 @@ func (s *Supervisor) Options() *option.Options {
 // Cluster return the cluster applied to supervisor.
 func (s *Supervisor) Cluster() cluster.Cluster {
 	return s.cls
+}
+
+// Tracing return the tracing instance.
+func (s *Supervisor) Tracing() *tracing.Tracing {
+	if s.tracing == nil {
+		return tracing.NoopTracing
+	}
+	return s.tracing
+}
+
+// SetTracing sets the global tracing instance.
+func (s *Supervisor) SetTracing(tracing *tracing.Tracing) {
+	s.tracing = tracing
 }
 
 func (s *Supervisor) initSystemControllers() {

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -81,7 +81,8 @@ func (t *Tracing) Close() error {
 	return nil
 }
 
-func CreateSpanWithContext(tracing *Tracing, spanName string, startTime time.Time, ctx context.Context) context.Context {
+// CreateSpanWithContext creates new span with given name and starttime and adds it to the context.
+func CreateSpanWithContext(ctx context.Context, tracing *Tracing, spanName string, startTime time.Time) context.Context {
 	span := tracing.Tracer.StartSpan(spanName, zipkingo.StartTime(startTime))
 	return zipkingo.NewContext(ctx, span)
 }

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -18,7 +18,9 @@
 package tracing
 
 import (
+	"context"
 	"io"
+	"time"
 
 	"github.com/megaease/easegress/pkg/tracing/zipkin"
 	zipkingo "github.com/openzipkin/zipkin-go"
@@ -77,4 +79,9 @@ func (t *Tracing) Close() error {
 	}
 
 	return nil
+}
+
+func CreateSpanWithContext(tracing *Tracing, spanName string, startTime time.Time, ctx context.Context) context.Context {
+	span := tracing.Tracer.StartSpan(spanName, zipkingo.StartTime(startTime))
+	return zipkingo.NewContext(ctx, span)
 }

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -20,9 +20,8 @@ package tracing
 import (
 	"io"
 
-	opentracing "github.com/opentracing/opentracing-go"
-
 	"github.com/megaease/easegress/pkg/tracing/zipkin"
+	zipkingo "github.com/openzipkin/zipkin-go"
 )
 
 type (
@@ -35,7 +34,7 @@ type (
 
 	// Tracing is the tracing.
 	Tracing struct {
-		opentracing.Tracer
+		Tracer *zipkingo.Tracer
 		tags   map[string]string
 		closer io.Closer
 	}
@@ -45,7 +44,7 @@ type (
 
 // NoopTracing is the tracing doing nothing.
 var NoopTracing = &Tracing{
-	Tracer: opentracing.NoopTracer{},
+	Tracer: zipkin.CreateNoopTracer(),
 	closer: nil,
 }
 
@@ -55,14 +54,13 @@ func New(spec *Spec) (*Tracing, error) {
 		return NoopTracing, nil
 	}
 
-	tracer, closer, err := zipkin.New(spec.ServiceName, spec.Zipkin)
+	tracer, closer, err := zipkin.New(spec.ServiceName, spec.Zipkin, spec.Tags)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Tracing{
 		Tracer: tracer,
-		tags:   spec.Tags,
 		closer: closer,
 	}, nil
 }


### PR DESCRIPTION
Fix #578 

- [opentracing](https://github.com/opentracing/opentracing-go) is deprecated (in favor of open-telemetry) so remove it and use "native" zipkin for tracing
- call zipkin-go SDK and remove explicit creation of spans and `span.Finish()`
- When tracing object is configured in HTTPServer, share the created `tracer` instance to Proxy filter via HTTPContext.
- Use zipkin to inject B3 headers if not present already