### PR TITLE
FaasController: Keep request host field

### DIFF
--- a/doc/reference/faascontroller.md
+++ b/doc/reference/faascontroller.md
@@ -10,7 +10,7 @@
   - [Reference](#reference)
 
 * A FaaSController is a business controller for handling Easegress and FaaS products integration purposes.  It abstracts `FaasFunction`, `FaaSStore` and, `FaasProvider`. Currently, we only support `Knative` type `FaaSProvider`. The `FaaSFunction` describes the name, image URL, the resource, and autoscaling type of this FaaS function instance. The `FaaSStore` is covered by Easegress' embed Etcd already.
-* FaaSController works closely with local `FaaSProvider`. Please make sure they are running in a communicable environment. Follow this [knative doc](https://knative.dev/docs/install/install-serving-with-yaml/) to install `Knative`[1]'s serving component in K8s. It's better to have Easegress run in the same VM instances with K8s for saving communication costs.
+* FaaSController works closely with local `FaaSProvider`. Please make sure they are running in a communicable environment. Follow this [knative doc](https://knative.dev/docs/install/yaml-install/serving/install-serving-with-yaml/) to install `Knative`[1]'s serving component in K8s. It's better to have Easegress run in the same VM instances with K8s for saving communication costs.
 
 
 ## Prerequisites
@@ -163,7 +163,7 @@ The RESTful API path obey this design `http://host/{version}/{namespace}/{scope}
 1. Creating the FaasController in Easegress
 
 ```bash
-$ cd ./easegress/example/writer-001 && ./start.sh
+$ cd ./easegress/example/primary-001 && ./start.sh
 
 $ ./egctl.sh object create -f ./faascontroller.yaml
 
@@ -244,6 +244,6 @@ The function's API is serving in `/tomcat/job/api` path and its logic is display
 
 ## Reference
 1. knative website http://knative.dev
-2. Install knative serving via YAML https://knative.dev/docs/install/install-serving-with-yaml
+2. Install knative serving via YAML https://knative.dev/docs/install/yaml-install/serving/install-serving-with-yaml/
 3. resource quota https://kubernetes.io/docs/concepts/policy/resource-quotas/
 4. AWS Lambda state https://aws.amazon.com/blogs/compute/tracking-the-state-of-lambda-functions/

--- a/doc/reference/faascontroller.md
+++ b/doc/reference/faascontroller.md
@@ -22,7 +22,7 @@
 * One FaaSController will manage one shared HTTP traffic gate and multiple pipelines according to the functions it has.
 * The `httpserver` section in spec is the configuration for the shared HTTP traffic gate.
 * The `Knative` section is for `Knative` type of `FaaSProvider`. Depending your Kubernetes cluster, you can use either Magic DNS or Temporary DNS ([see](https://knative.dev/docs/install/yaml-install/serving/install-serving-with-yaml/#configure-dns)). Here's how you fill the `Knative` section for each one of them:
-  * **Temporary DNS**: The `${knative_kourier_clusterIP}` value can be set by using the command
+  * **Temporary DNS**: The value of `networkLayerURL` can be found using the following command
 
   ``` bash
   $ kubectl get svc -n kourier-system
@@ -30,17 +30,16 @@
   kourier            LoadBalancer   10.109.159.129   <pending>     80:31731/TCP,443:30571/TCP   250dk
   ```
 
-  The `CLUSTER-IP` valued with `10.109.159.129` is your kourier's K8s service's address.
-  * **Note:** Use the `CLUSTER-IP` value above to replace the `{knative_kourier_clusterIP}` in the YAML below.
+  The `CLUSTER-IP` with value `10.109.159.129` is your kourier's K8s service's address. Use it as the value for `networkLayerURL` in the YAML below.
   * `hostSuffix`'s value should be `example.com` [2], like described in `Knative` serving's `Temporary DNS`.
-* **Magic DNS**: Use the `EXTERNAL-IP` of the loadbalancer:
+* **Magic DNS**: For `networkLayerURL`, use the `EXTERNAL-IP` of the loadbalancer:
 
   ```bash
    $ kubectl get svc -n kourier-system
   NAME               TYPE           CLUSTER-IP       EXTERNAL-IP                                                                    PORT(S)                      AGE
   kourier            LoadBalancer   1.2.3.4   some-external-ip-of-my-cloud-provider.com   80:31060/TCP,443:30384/TCP   12m
   ```
-  * For `hostSuffix`, use `kn service list` to see the suffix of your functions: For url `http://demo.default.4.5.6.7.sslip.io` the `hostSuffix` is `4.5.6.7.sslip.io` (`x.x.x.x.sslip.io`). **Note:** If you don't have yet any functions yet deployed, you first use any value for `hostSuffix` (for example `example.com`), then deploy a function and use `kn service list` to find out the value of `hostSuffix`. Update it to your configuration and re-create FaaSController.
+  * For `hostSuffix`, use `kn service list` to see the suffix of your functions: For url `http://demo.default.4.5.6.7.sslip.io` the `hostSuffix` is `4.5.6.7.sslip.io` (basically the IP `x.x.x.x` + `sslip.io`). **Note:** If you don't have yet any functions yet deployed, you first use any value for `hostSuffix` (for example `example.com`), then deploy a function and use `kn service list` to find out the value of `hostSuffix`. Update it to your configuration and re-create FaaSController.
 
 ```yaml
 name: faascontroller
@@ -60,7 +59,7 @@ httpServer:
     maxConnections: 10240      
 
 knative:
-   networkLayerURL: http://{knative_kourier_clusterIP}
+   networkLayerURL: http://{knative_kourier_clusterIP} # or http://{knative_kourier_externalIP}
    hostSuffix: example.com # or x.x.x.x.sslip.com for Magic DNS
 ```
 

--- a/doc/reference/faascontroller.md
+++ b/doc/reference/faascontroller.md
@@ -39,7 +39,7 @@
   NAME               TYPE           CLUSTER-IP       EXTERNAL-IP                                                                    PORT(S)                      AGE
   kourier            LoadBalancer   1.2.3.4   some-external-ip-of-my-cloud-provider.com   80:31060/TCP,443:30384/TCP   12m
   ```
-  * For `hostSuffix`, use `kn service list` to see the suffix of your functions: For url `http://demo.default.4.5.6.7.sslip.io` the `hostSuffix` is `4.5.6.7.sslip.io` (basically the IP `x.x.x.x` + `sslip.io`). **Note:** If you don't have yet any functions yet deployed, you first use any value for `hostSuffix` (for example `example.com`), then deploy a function and use `kn service list` to find out the value of `hostSuffix`. Update it to your configuration and re-create FaaSController.
+  * For `hostSuffix`, use `kn service list` to see the suffix of your functions: For url `http://demo.default.4.5.6.7.sslip.io` the `hostSuffix` is `4.5.6.7.sslip.io` (basically the IP `x.x.x.x` + `sslip.io`). **Note:** If you don't have any functions yet deployed, you first use any value for `hostSuffix` (for example `example.com`), then deploy a function and use `kn service list` to find out the value of `hostSuffix`. Update it to your configuration and re-create FaaSController.
 
 ```yaml
 name: faascontroller

--- a/doc/reference/filters.md
+++ b/doc/reference/filters.md
@@ -50,7 +50,7 @@
     - [Configuration](#configuration-15)
     - [Results](#results-15)
   - [CertExtractor](#certextractor)
-    - [Configuration](#configuration-16))
+    - [Configuration](#configuration-16)
   - [Common Types](#common-types)
     - [apiaggregator.Pipeline](#apiaggregatorpipeline)
     - [pathadaptor.Spec](#pathadaptorspec)
@@ -811,9 +811,10 @@ Rules to revise request header. Note that both header name and value can be a te
 
 | Name   | Type     | Description                                                                                                  | Required |
 | ------ | -------- | ------------------------------------------------------------------------------------------------------------ | -------- |
-| url    | string   | Address of the server. The address should start with `http://` or `https://`, followed by the hostname or IP address of the server, and then optionally followed by `:{port number}`, for example: `https://www.megaease.com`, `http://10.10.10.10:8080`. When host name is used, the `Host` of a request sent to this server is always the hostname of the server, and therefore using a [RequestAdaptor](#requestadaptor) in the pipeline to modify it will not be possible; when IP address is used, the `Host` is the same as the original request, that can be modified by a [RequestAdaptor](#requestadaptor).        | Yes      |
+| url    | string   | Address of the server. The address should start with `http://` or `https://`, followed by the hostname or IP address of the server, and then optionally followed by `:{port number}`, for example: `https://www.megaease.com`, `http://10.10.10.10:8080`. When host name is used, the `Host` of a request sent to this server is always the hostname of the server, and therefore using a [RequestAdaptor](#requestadaptor) in the pipeline to modify it will not be possible; when IP address is used, the `Host` is the same as the original request, that can be modified by a [RequestAdaptor](#requestadaptor). See also `KeepHost`.         | Yes      |
 | tags   | []string | Tags of this server, refer `serverTags` in [proxy.PoolSpec](#proxyPoolSpec)                                  | No       |
 | weight | int      | When load balance policy is `weightedRandom`, this value is used to calculate the possibility of this server | No       |
+| KeepHost | bool      | If true, the `Host` is the same as the original request, no matter what is the value of `url`. Default value is `false`. | No       |
 
 ### proxy.LoadBalance
 

--- a/example/backend-service/echo/echo.go
+++ b/example/backend-service/echo/echo.go
@@ -44,6 +44,7 @@ func main() {
 		fmt.Fprintln(tw, "Your Request")
 		fmt.Fprintln(tw, "==============")
 		fmt.Fprintln(tw, "Method:", req.Method)
+		fmt.Fprintln(tw, "Host:", req.Host)
 		fmt.Fprintln(tw, "URL   :", url)
 
 		fmt.Fprintln(tw, "Header:")

--- a/pkg/filter/proxy/request.go
+++ b/pkg/filter/proxy/request.go
@@ -76,9 +76,11 @@ func (p *pool) newRequest(
 
 	stdr.Header = r.Header().Std()
 	// only set host when server address is not host name.
-	if !server.addrIsHostName {
-		stdr.Host = r.Host()
-	}
+	//if !server.addrIsHostName {
+	stdr.Host = r.Host()
+	//} else {
+	//	fmt.Println("NOT SETTING Host")
+	//}
 
 	req.std = stdr
 

--- a/pkg/filter/proxy/request.go
+++ b/pkg/filter/proxy/request.go
@@ -75,12 +75,10 @@ func (p *pool) newRequest(
 	}
 
 	stdr.Header = r.Header().Std()
-	// only set host when server address is not host name.
-	//if !server.addrIsHostName {
-	stdr.Host = r.Host()
-	//} else {
-	//	fmt.Println("NOT SETTING Host")
-	//}
+	// only set host when server address is not host name OR server is explicitly told to keep the host of the request.
+	if !server.addrIsHostName || server.KeepHost {
+		stdr.Host = r.Host()
+	}
 
 	req.std = stdr
 

--- a/pkg/filter/proxy/server.go
+++ b/pkg/filter/proxy/server.go
@@ -74,6 +74,7 @@ type (
 		URL            string   `yaml:"url" jsonschema:"required,format=url"`
 		Tags           []string `yaml:"tags" jsonschema:"omitempty,uniqueItems=true"`
 		Weight         int      `yaml:"weight" jsonschema:"omitempty,minimum=0,maximum=100"`
+		KeepHost       bool     `yaml:"keepHost" jsonschema:"omitempty,default=false`
 		addrIsHostName bool
 	}
 

--- a/pkg/filter/proxy/server_test.go
+++ b/pkg/filter/proxy/server_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/megaease/easegress/pkg/object/serviceregistry"
 	"github.com/megaease/easegress/pkg/util/hashtool"
 	"github.com/megaease/easegress/pkg/util/httpheader"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPickservers(t *testing.T) {
@@ -409,42 +410,36 @@ func TestDynamicService(t *testing.T) {
 }
 
 func TestCheckAddrPattern(t *testing.T) {
+	assert := assert.New(t)
+
 	server := Server{}
 
 	// regard invalid url as IP:port
 	server.URL = "@@+=%^httpsidfssjflsdkjfsjf"
 	server.checkAddrPattern()
-	if server.addrIsHostName {
-		t.Error("address should be IP:port")
-	}
+	assert.False(server.addrIsHostName, "address should be IP:port")
 
 	server.URL = "http://127.0.0.1:1111"
 	server.checkAddrPattern()
-	if server.addrIsHostName {
-		t.Error("address should be IP:port")
-	}
+	assert.False(server.addrIsHostName, "address should be IP:port")
 
 	server.URL = "https://127.0.0.1:1111"
 	server.checkAddrPattern()
-	if server.addrIsHostName {
-		t.Error("address should be IP:port")
-	}
+	assert.False(server.addrIsHostName, "address should be IP:port")
 
 	server.URL = "https://[FE80:CD00:0000:0CDE:1257:0000:211E:729C]:1111"
 	server.checkAddrPattern()
-	if server.addrIsHostName {
-		t.Error("address should be IP:port")
-	}
+	assert.False(server.addrIsHostName, "address should be IP:port")
 
 	server.URL = "https://www.megaease.com:1111"
 	server.checkAddrPattern()
-	if !server.addrIsHostName {
-		t.Error("address should be host name")
-	}
+	assert.True(server.addrIsHostName, "address should be host name")
 
 	server.URL = "https://www.megaease.com"
 	server.checkAddrPattern()
-	if !server.addrIsHostName {
-		t.Error("address should be host name")
-	}
+	assert.True(server.addrIsHostName, "address should be host name")
+
+	server.URL = "faas-func-name.default.example.com"
+	server.checkAddrPattern()
+	assert.True(server.addrIsHostName, "address should not be IP:port")
 }

--- a/pkg/object/function/worker/ingress.go
+++ b/pkg/object/function/worker/ingress.go
@@ -153,7 +153,8 @@ func (b *pipelineSpecBuilder) appendReqAdaptor(funcSpec *spec.Spec, faasNamespac
 func (b *pipelineSpecBuilder) appendProxy(faasNetworkLayerURL string) *pipelineSpecBuilder {
 	mainServers := []*proxy.Server{
 		{
-			URL: faasNetworkLayerURL,
+			URL:      faasNetworkLayerURL,
+			KeepHost: true, // Keep the host of the requests as they route to functions.
 		},
 	}
 


### PR DESCRIPTION
Fix https://github.com/megaease/easegress/issues/554.

- Add new flag `KeepHost` to proxy.Server that overrides logic of https://github.com/megaease/easegress/issues/447 when true (by default false). This fixes  FaasController that uses `Host` to route request to FaaS functions.
- Update and simplify `doc/reference/faascontroller.md` and `doc/cookboook/faas.md`.
- Describe in `doc/reference/faascontroller.md` another way (Magic DNS instead of Temporary DNS) to configure Knative FaasProvider.