### PR TITLE
sync.Pool should be passed by reference

### DIFF
--- a/pkg/filter/proxy/request.go
+++ b/pkg/filter/proxy/request.go
@@ -51,9 +51,9 @@ func (p *pool) newRequest(
 	ctx context.HTTPContext,
 	server *Server,
 	reqBody io.Reader,
-	requestPool sync.Pool,
-	httpstatResultPool sync.Pool) (*request, error) {
-	statResult := httpstatResultPool.Get().(*httpstat.Result)
+	requestPool *sync.Pool,
+	httpStatResultPool *sync.Pool) (*request, error) {
+	statResult := httpStatResultPool.Get().(*httpstat.Result)
 	req := requestPool.Get().(*request)
 	req.createTime = fasttime.Now()
 	req.server = server

--- a/pkg/filter/proxy/request_test.go
+++ b/pkg/filter/proxy/request_test.go
@@ -57,7 +57,7 @@ func TestRequest(t *testing.T) {
 
 	p := pool{}
 	sr := strings.NewReader("this is the raw body")
-	req, _ := p.newRequest(ctx, &server, sr, requestPool, httpstatResultPool)
+	req, _ := p.newRequest(ctx, &server, sr, requestPool, httpStatResultPool)
 	defer requestPool.Put(req) // recycle request
 
 	req.start()
@@ -83,7 +83,7 @@ func TestRequest(t *testing.T) {
 	ctx.MockedRequest.MockedMethod = func() string {
 		return "ééé" // not tokenable, should fail
 	}
-	req, err := p.newRequest(ctx, &server, nil, requestPool, httpstatResultPool)
+	req, err := p.newRequest(ctx, &server, nil, requestPool, httpStatResultPool)
 	assert.Nil(req)
 	assert.NotNil(err)
 }
@@ -102,7 +102,7 @@ func TestResultState(t *testing.T) {
 }
 
 func TestRequestStatus(t *testing.T) {
-	statResult := httpstatResultPool.Get().(*httpstat.Result)
+	statResult := httpStatResultPool.Get().(*httpstat.Result)
 	req := requestPool.Get().(*request)
 	req.createTime = fasttime.Now()
 	req._startTime = time.Time{}
@@ -129,7 +129,7 @@ func TestRequestStatus(t *testing.T) {
 		t.Error("endtime should be _endtime after finish()")
 	}
 
-	httpstatResultPool.Put(req.statResult)
+	httpStatResultPool.Put(req.statResult)
 	requestPool.Put(req)
 }
 
@@ -153,7 +153,7 @@ func TestAddB3PropagationHeaders(t *testing.T) {
 
 	p := pool{}
 	sr := strings.NewReader("this is the raw body")
-	req, _ := p.newRequest(ctx, &server, sr, requestPool, httpstatResultPool)
+	req, _ := p.newRequest(ctx, &server, sr, requestPool, httpStatResultPool)
 	defer requestPool.Put(req) // recycle request
 
 	header := req.std.Header


### PR DESCRIPTION
The sync.Pool used in filter/proxy/pool.go should be passed by reference instead of by value.
use go vet command `go vet pkg/filter/proxy/*.go `, then get the warnings.

note: objects in sync.Pool that are not explicitly cleaned up before call `Put` may cause dirty data to be obtained the next time  call `Get`. I'm guessing `httpStatResultPool` might be the case, but I need experiments to prove it. EG:When the first request succeeds, `httpstat.Result`'s some properties will be set, and when the second request fails (failed to resolve the domain name, failed to establish a tcp link and etc.), some properties (NameLookup\TLSHandshake\serverDone) may use the last one. value，that may be leads to a bias in the statistics