### PR TITLE
add GZipCompressReader & ByteCountReader

### DIFF
--- a/pkg/filters/proxy/compression_test.go
+++ b/pkg/filters/proxy/compression_test.go
@@ -69,26 +69,6 @@ func TestAlreadyGziped(t *testing.T) {
 	}
 }
 
-func TestParseContentLength(t *testing.T) {
-	c := newCompression(&CompressionSpec{MinLength: 100})
-
-	resp := &http.Response{Header: http.Header{}}
-
-	if c.parseContentLength(resp) != -1 {
-		t.Error("content length should be -1")
-	}
-
-	resp.Header.Set(keyContentLength, "abc")
-	if c.parseContentLength(resp) != -1 {
-		t.Error("content length should be -1")
-	}
-
-	resp.Header.Set(keyContentLength, "100")
-	if c.parseContentLength(resp) != 100 {
-		t.Error("content length should be 100")
-	}
-}
-
 func TestCompress(t *testing.T) {
 	c := newCompression(&CompressionSpec{MinLength: 100})
 

--- a/pkg/util/readers/bytecountreader.go
+++ b/pkg/util/readers/bytecountreader.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2017, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package readers
+
+import (
+	"io"
+)
+
+// ByteCountReader wraps an io.Reader and counts the bytes read from it.
+type ByteCountReader struct {
+	r         io.Reader
+	bytesRead int
+}
+
+// NewByteCountReader wraps an io.Reader to ByteCountReader and returns it.
+func NewByteCountReader(r io.Reader) *ByteCountReader {
+	return &ByteCountReader{r: r}
+}
+
+// Read implements io.Reader.
+func (r *ByteCountReader) Read(p []byte) (int, error) {
+	n, err := r.r.Read(p)
+	r.bytesRead += n
+	return n, err
+}
+
+// BytesRead returns the count of bytes has been read from the underlying
+// io.Reader.
+func (r *ByteCountReader) BytesRead() int {
+	return r.bytesRead
+}
+
+// Close implements io.Closer and closes the underlying io.Reader if
+// it is an io.Closer.
+func (r *ByteCountReader) Close() error {
+	if c, ok := r.r.(io.Closer); ok {
+		return c.Close()
+	}
+	return nil
+}

--- a/pkg/util/readers/gzipcompressreader.go
+++ b/pkg/util/readers/gzipcompressreader.go
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2017, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package readers
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"os"
+)
+
+var bodyFlushSize = 8 * int64(os.Getpagesize())
+
+// GZipCompressReader wraps an io.Reader to a new io.Reader, whose data
+// is the gzip compression result of the original io.Reader.
+type GZipCompressReader struct {
+	r    io.Reader
+	buff *bytes.Buffer
+	gw   *gzip.Writer
+	err  error
+}
+
+// NewGZipCompressReader creates a new GZipCompressReader from r.
+func NewGZipCompressReader(r io.Reader) *GZipCompressReader {
+	buff := bytes.NewBuffer(nil)
+	return &GZipCompressReader{
+		r:    r,
+		buff: buff,
+		gw:   gzip.NewWriter(buff),
+	}
+}
+
+// Read implements io.Reader.
+func (r *GZipCompressReader) Read(p []byte) (n int, err error) {
+	for {
+		// The error could only be io.EOF, which need to be ignored.
+		m, _ := r.buff.Read(p)
+		n += m
+		if m == len(p) {
+			break
+		}
+
+		if r.err != nil {
+			err = r.err
+			break
+		}
+
+		r.pull()
+		p = p[m:]
+	}
+	return
+}
+
+func (r *GZipCompressReader) pull() {
+	// reset the buffer to avoid it becomes too large.
+	r.buff.Reset()
+
+	_, r.err = io.CopyN(r.gw, r.r, bodyFlushSize)
+	if r.err == io.EOF {
+		if err := r.gw.Close(); err != nil {
+			r.err = err
+		}
+	}
+}
+
+// Close implements io.Closer and closes the underlying io.Reader if
+// it is an io.Closer.
+func (r *GZipCompressReader) Close() error {
+	if c, ok := r.r.(io.Closer); ok {
+		return c.Close()
+	}
+	return nil
+}


### PR DESCRIPTION
The buffer of the original gzipBody could become very large and consume too much memory, and the new ByteCountReader is added for later use.