### PR TITLE
sidecar httpserver keepalive config by spec

### DIFF
--- a/pkg/object/meshcontroller/spec/spec.go
+++ b/pkg/object/meshcontroller/spec/spec.go
@@ -93,7 +93,7 @@ const (
 	// ServiceCanaryHeaderKey is the http header key of service canary.
 	ServiceCanaryHeaderKey = "X-Mesh-Service-Canary"
 
-	defaultKeepaliveTimeout = "60s"
+	defaultKeepAliveTimeout = "60s"
 )
 
 var (
@@ -142,8 +142,8 @@ type (
 
 	// WorkerSpec is the spec of worker
 	WorkerSpec struct {
-		IngressServerSpec IngressServerSpec `yaml:"ingressServerSpec" jsonschema:"omitempty"`
-		EgressServerSpec  EgressServerSpec  `yaml:"egressServerSpec" jsonschema:"omitempty"`
+		Ingress IngressServerSpec `yaml:"ingress" jsonschema:"omitempty"`
+		Egress  EgressServerSpec  `yaml:"egress" jsonschema:"omitempty"`
 	}
 
 	// IngressServerSpec is the spec of ingress httpserver in worker
@@ -940,7 +940,7 @@ rules:
 		needHTTPS = "true"
 	}
 	if timeout == "" {
-		timeout = defaultKeepaliveTimeout
+		timeout = defaultKeepAliveTimeout
 	}
 	yamlConfig := fmt.Sprintf(ingressHTTPServerFormat, name,
 		s.Sidecar.IngressPort, keepalive, timeout, needHTTPS, certBase64, keyBase64, rootCertBaser64, pipelineName)
@@ -1026,7 +1026,7 @@ keepAliveTimeout: %s
 https: false
 `
 	if timeout == "" {
-		timeout = defaultKeepaliveTimeout
+		timeout = defaultKeepAliveTimeout
 	}
 	yamlConfig := fmt.Sprintf(egressHTTPServerFormat,
 		s.EgressHTTPServerName(),

--- a/pkg/object/meshcontroller/spec/spec_test.go
+++ b/pkg/object/meshcontroller/spec/spec_test.go
@@ -1045,14 +1045,14 @@ func TestSidecarIngressPipelineSpecCert(t *testing.T) {
 		SignTime:    "2021-10-13 12:33:10",
 	}
 
-	superSpec, err := s.SidecarIngressHTTPServerSpec(false, defaultKeepaliveTimeout, cert, rootCert)
+	superSpec, err := s.SidecarIngressHTTPServerSpec(false, defaultKeepAliveTimeout, cert, rootCert)
 
 	if err != nil {
 		t.Fatalf("ingress http server spec failed: %v", err)
 	}
 	fmt.Println(superSpec.YAMLConfig())
 
-	superSpec, err = s.SidecarEgressHTTPServerSpec(true, defaultKeepaliveTimeout)
+	superSpec, err = s.SidecarEgressHTTPServerSpec(true, defaultKeepAliveTimeout)
 
 	if err != nil {
 		t.Fatalf("egress http server spec failed: %v", err)

--- a/pkg/object/meshcontroller/spec/spec_test.go
+++ b/pkg/object/meshcontroller/spec/spec_test.go
@@ -1045,14 +1045,14 @@ func TestSidecarIngressPipelineSpecCert(t *testing.T) {
 		SignTime:    "2021-10-13 12:33:10",
 	}
 
-	superSpec, err := s.SidecarIngressHTTPServerSpec(cert, rootCert)
+	superSpec, err := s.SidecarIngressHTTPServerSpec(false, defaultKeepaliveTimeout, cert, rootCert)
 
 	if err != nil {
 		t.Fatalf("ingress http server spec failed: %v", err)
 	}
 	fmt.Println(superSpec.YAMLConfig())
 
-	superSpec, err = s.SidecarEgressHTTPServerSpec()
+	superSpec, err = s.SidecarEgressHTTPServerSpec(true, defaultKeepaliveTimeout)
 
 	if err != nil {
 		t.Fatalf("egress http server spec failed: %v", err)
@@ -1075,14 +1075,14 @@ func TestSidecarIngressPipelineSpec(t *testing.T) {
 		},
 	}
 
-	superSpec, err := s.SidecarIngressHTTPServerSpec(nil, nil)
+	superSpec, err := s.SidecarIngressHTTPServerSpec(true, "", nil, nil)
 
 	if err != nil {
 		t.Fatalf("ingress http server spec failed: %v", err)
 	}
 	fmt.Println(superSpec.YAMLConfig())
 
-	superSpec, err = s.SidecarEgressHTTPServerSpec()
+	superSpec, err = s.SidecarEgressHTTPServerSpec(false, "")
 
 	if err != nil {
 		t.Fatalf("egress http server spec failed: %v", err)

--- a/pkg/object/meshcontroller/worker/egress.go
+++ b/pkg/object/meshcontroller/worker/egress.go
@@ -122,7 +122,8 @@ func (egs *EgressServer) InitEgress(service *spec.Service) error {
 	}
 
 	egs.egressServerName = service.EgressHTTPServerName()
-	superSpec, err := service.SidecarEgressHTTPServerSpec()
+	admSpec := egs.superSpec.ObjectSpec().(*spec.Admin)
+	superSpec, err := service.SidecarEgressHTTPServerSpec(admSpec.WorkerSpec.EgressServerSpec.KeepAlive, admSpec.WorkerSpec.EgressServerSpec.KeepAliveTimeout)
 	if err != nil {
 		return err
 	}
@@ -148,7 +149,6 @@ func (egs *EgressServer) InitEgress(service *spec.Service) error {
 		}
 	}
 
-	admSpec := egs.superSpec.ObjectSpec().(*spec.Admin)
 	if admSpec.EnablemTLS() {
 		logger.Infof("egress in mtls mode, start listen ID: %s's cert", egs.instanceID)
 		if err := egs.inf.OnServerCert(egs.serviceName, egs.instanceID, egs.reloadByCert); err != nil {

--- a/pkg/object/meshcontroller/worker/egress.go
+++ b/pkg/object/meshcontroller/worker/egress.go
@@ -123,7 +123,7 @@ func (egs *EgressServer) InitEgress(service *spec.Service) error {
 
 	egs.egressServerName = service.EgressHTTPServerName()
 	admSpec := egs.superSpec.ObjectSpec().(*spec.Admin)
-	superSpec, err := service.SidecarEgressHTTPServerSpec(admSpec.WorkerSpec.EgressServerSpec.KeepAlive, admSpec.WorkerSpec.EgressServerSpec.KeepAliveTimeout)
+	superSpec, err := service.SidecarEgressHTTPServerSpec(admSpec.WorkerSpec.Egress.KeepAlive, admSpec.WorkerSpec.Egress.KeepAliveTimeout)
 	if err != nil {
 		return err
 	}

--- a/pkg/object/meshcontroller/worker/ingress.go
+++ b/pkg/object/meshcontroller/worker/ingress.go
@@ -132,7 +132,7 @@ func (ings *IngressServer) InitIngress(service *spec.Service, port uint32) error
 			logger.Infof("ingress enable TLS, init httpserver with cert: %#v", cert)
 		}
 
-		superSpec, err := service.SidecarIngressHTTPServerSpec(admSpec.WorkerSpec.IngressServerSpec.KeepAlive, admSpec.WorkerSpec.IngressServerSpec.KeepAliveTimeout, cert, rootCert)
+		superSpec, err := service.SidecarIngressHTTPServerSpec(admSpec.WorkerSpec.Ingress.KeepAlive, admSpec.WorkerSpec.Ingress.KeepAliveTimeout, cert, rootCert)
 		if err != nil {
 			return err
 		}
@@ -181,7 +181,7 @@ func (ings *IngressServer) reloadHTTPServer(event informer.Event, value *spec.Ce
 	}
 	admSpec := ings.superSpec.ObjectSpec().(*spec.Admin)
 	rootCert := ings.service.GetRootCert()
-	superSpec, err := serviceSpec.SidecarIngressHTTPServerSpec(admSpec.WorkerSpec.IngressServerSpec.KeepAlive, admSpec.WorkerSpec.IngressServerSpec.KeepAliveTimeout, value, rootCert)
+	superSpec, err := serviceSpec.SidecarIngressHTTPServerSpec(admSpec.WorkerSpec.Ingress.KeepAlive, admSpec.WorkerSpec.Ingress.KeepAliveTimeout, value, rootCert)
 	if err != nil {
 		logger.Errorf("BUG: update ingress pipeline spec: %s new super spec failed: %v",
 			superSpec.YAMLConfig(), err)

--- a/pkg/object/meshcontroller/worker/ingress.go
+++ b/pkg/object/meshcontroller/worker/ingress.go
@@ -132,7 +132,7 @@ func (ings *IngressServer) InitIngress(service *spec.Service, port uint32) error
 			logger.Infof("ingress enable TLS, init httpserver with cert: %#v", cert)
 		}
 
-		superSpec, err := service.SidecarIngressHTTPServerSpec(cert, rootCert)
+		superSpec, err := service.SidecarIngressHTTPServerSpec(admSpec.WorkerSpec.IngressServerSpec.KeepAlive, admSpec.WorkerSpec.IngressServerSpec.KeepAliveTimeout, cert, rootCert)
 		if err != nil {
 			return err
 		}
@@ -174,14 +174,14 @@ func (ings *IngressServer) reloadHTTPServer(event informer.Event, value *spec.Ce
 		return false
 	}
 
-	spec := ings.service.GetServiceSpec(ings.serviceName)
-	if spec == nil {
+	serviceSpec := ings.service.GetServiceSpec(ings.serviceName)
+	if serviceSpec == nil {
 		logger.Infof("ingress can't find its service: %s", ings.serviceName)
 		return false
 	}
-
+	admSpec := ings.superSpec.ObjectSpec().(*spec.Admin)
 	rootCert := ings.service.GetRootCert()
-	superSpec, err := spec.SidecarIngressHTTPServerSpec(value, rootCert)
+	superSpec, err := serviceSpec.SidecarIngressHTTPServerSpec(admSpec.WorkerSpec.IngressServerSpec.KeepAlive, admSpec.WorkerSpec.IngressServerSpec.KeepAliveTimeout, value, rootCert)
 	if err != nil {
 		logger.Errorf("BUG: update ingress pipeline spec: %s new super spec failed: %v",
 			superSpec.YAMLConfig(), err)


### PR DESCRIPTION
In sidecar mode, the httpservers of ingress and egress load keepalive-related configurations according to the mesh-controller spec(it seems that there is no other suitable object to carry this configuration).It seems that there is no other suitable object to carry this configuration. In preliminary consideration, it is not necessary to set different parameters for each worker(if this is done, the ops would be complicated). If there is, use `--label`  would be better.