### PR TITLE
fix issue 555 about request header context-length missing

### DIFF
--- a/pkg/filter/proxy/proxy.go
+++ b/pkg/filter/proxy/proxy.go
@@ -352,13 +352,13 @@ func (b *Proxy) fallbackForCodes(ctx context.HTTPContext) bool {
 // redirects can replay the body), and Body is set to NoBody if the
 // ContentLength is 0.
 //
-// So in this way, http.Request.ContextLength will be 0, and when http.Client send this request, it will delete
-// "Context-Length" key in header. We solve this problem by set http.Request.ContextLength equal to
-// http.Request.Header["Context-Length"] (if it is presented).
+// So in this way, http.Request.ContentLength will be 0, and when http.Client send this request, it will delete
+// "Content-Length" key in header. We solve this problem by set http.Request.ContentLength equal to
+// http.Request.Header["Content-Length"] (if it is presented).
 // Reading all context.Request().Body() and create new request with bytes.NewReader is another way, but it may cause performance loss.
 //
-// It is important "Context-Length" in Header is equal to length of Body. In easegress, when a filter change Request.Body,
-// it will delete the header of "Context-Length". So, you should not worry about this when using our filters.
+// It is important that "Content-Length" in the Header is equal to the length of the Body. In easegress, when a filter change Request.Body,
+// it will delete the header of "Content-Length". So, you should not worry about this when using our filters.
 // But for customer filters, developer should make sure to delete or set "Context-Length" value in header when change Request.Body.
 func (b *Proxy) Handle(ctx context.HTTPContext) (result string) {
 	result = b.handle(ctx)

--- a/pkg/filter/proxy/request.go
+++ b/pkg/filter/proxy/request.go
@@ -82,10 +82,15 @@ func (p *pool) newRequest(
 		stdr.Host = r.Host()
 	}
 
-	// golang http.NewRequestWithContext will set ContentLength when body is bytes.Buffer,
-	// bytes.Reader or strings.Reader.
-	// If stdr.ContentLength is not send, golang std lib will delete Header of
-	// Context-Length when sending request.
+	// Based on Golang std lib comment:
+	// https://github.com/golang/go/blob/master/src/net/http/request.go#L857
+	// If body is of type *bytes.Buffer, *bytes.Reader, or
+	// *strings.Reader, the returned request's ContentLength is set to its
+	// exact value (instead of -1), GetBody is populated (so 307 and 308
+	// redirects can replay the body), and Body is set to NoBody if the
+	// ContentLength is 0.
+	//
+	// Here we set ContextLength when "Context-Length" header is not empty.
 	if val := stdr.Header.Get(httpheader.KeyContentLength); val != "" {
 		l, err := strconv.Atoi(val)
 		if err == nil {

--- a/pkg/filter/proxy/request.go
+++ b/pkg/filter/proxy/request.go
@@ -82,15 +82,7 @@ func (p *pool) newRequest(
 		stdr.Host = r.Host()
 	}
 
-	// Based on Golang std lib comment:
-	// https://github.com/golang/go/blob/master/src/net/http/request.go#L857
-	// If body is of type *bytes.Buffer, *bytes.Reader, or
-	// *strings.Reader, the returned request's ContentLength is set to its
-	// exact value (instead of -1), GetBody is populated (so 307 and 308
-	// redirects can replay the body), and Body is set to NoBody if the
-	// ContentLength is 0.
-	//
-	// Here we set ContextLength when "Context-Length" header is not empty.
+	// Based on comments in proxy.Handle, we update stdr.ContentLength here.
 	if val := stdr.Header.Get(httpheader.KeyContentLength); val != "" {
 		l, err := strconv.Atoi(val)
 		if err == nil {

--- a/pkg/filter/proxy/request.go
+++ b/pkg/filter/proxy/request.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
@@ -30,6 +31,7 @@ import (
 	"github.com/megaease/easegress/pkg/context"
 	"github.com/megaease/easegress/pkg/logger"
 	"github.com/megaease/easegress/pkg/util/fasttime"
+	"github.com/megaease/easegress/pkg/util/httpheader"
 )
 
 type (
@@ -78,6 +80,17 @@ func (p *pool) newRequest(
 	// only set host when server address is not host name OR server is explicitly told to keep the host of the request.
 	if !server.addrIsHostName || server.KeepHost {
 		stdr.Host = r.Host()
+	}
+
+	// golang http.NewRequestWithContext will set ContentLength when body is bytes.Buffer,
+	// bytes.Reader or strings.Reader.
+	// If stdr.ContentLength is not send, golang std lib will delete Header of
+	// Context-Length when sending request.
+	if val := stdr.Header.Get(httpheader.KeyContentLength); val != "" {
+		l, err := strconv.Atoi(val)
+		if err == nil {
+			stdr.ContentLength = int64(l)
+		}
 	}
 
 	req.std = stdr

--- a/pkg/filter/proxy/request_test.go
+++ b/pkg/filter/proxy/request_test.go
@@ -20,6 +20,7 @@ package proxy
 import (
 	"bytes"
 	"net/http"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -57,8 +58,10 @@ func TestRequest(t *testing.T) {
 
 	p := pool{}
 	sr := strings.NewReader("this is the raw body")
+	ctx.Request().Header().Add(httpheader.KeyContentLength, strconv.Itoa(sr.Len()))
 	req, _ := p.newRequest(ctx, &server, sr, requestPool, httpStatResultPool)
 	defer requestPool.Put(req) // recycle request
+	assert.Equal(int64(sr.Len()), req.std.ContentLength)
 
 	req.start()
 	tm := req.startTime()


### PR DESCRIPTION
Golang `http.NewRequestWithContext` will set `http.Request.ContentLength` when body is `bytes.Buffer`, `bytes.Reader` or `strings.Reader`. If `http.Request.ContentLength` is not send, Golang std lib will delete Header of `Context-Length` when sending request. Fix #555 