### PR TITLE
avoid endless loop between body and primaryReader

### DIFF
--- a/pkg/filter/proxy/primarysecondaryreader.go
+++ b/pkg/filter/proxy/primarysecondaryreader.go
@@ -20,6 +20,8 @@ package proxy
 import (
 	"bytes"
 	"io"
+
+	"github.com/megaease/easegress/pkg/util/callbackreader"
 )
 
 type (
@@ -38,9 +40,15 @@ type (
 )
 
 func newPrimarySecondaryReader(r io.Reader) (io.ReadCloser, io.Reader) {
+	var realReader io.Reader
+	if cbReader, ok := r.(*callbackreader.CallbackReader); ok {
+		realReader = cbReader.GetReader()
+	} else {
+		realReader = r
+	}
 	buffChan := make(chan []byte, 10)
 	mr := &primaryReader{
-		r:        r,
+		r:        realReader,
 		buffChan: buffChan,
 		sawEOF:   false,
 	}

--- a/pkg/util/callbackreader/callbackreader.go
+++ b/pkg/util/callbackreader/callbackreader.go
@@ -89,6 +89,10 @@ func (cr *CallbackReader) Close() error {
 	return nil
 }
 
+func (cr *CallbackReader) GetReader() io.Reader {
+	return cr.reader
+}
+
 // SetReader replace previous reader with new reader. If closePreviousReader set to true, it will close
 // previous reader.
 func (cr *CallbackReader) SetReader(reader io.Reader, closePreviousReader bool) {


### PR DESCRIPTION
avoid endless loop between body and primaryReader, when mirrorPool is used