### PR TITLE
update docker image entrypoint.sh

### DIFF
--- a/build/package/entrypoint.sh
+++ b/build/package/entrypoint.sh
@@ -7,7 +7,7 @@
 
 # docker run megaease/easegress
 if [ "$#" -eq 0 ]; then
-  exec /opt/easegress/bin/easegress-server
+  exec /opt/easegress/bin/easegress-server --api-addr 0.0.0.0:2381
 # docker run megaease/easegress -f config.yaml
 elif [ "$1" != "--" ] && [ "$(echo $1 | head -c 1)" == "-" ] ; then
   exec /opt/easegress/bin/easegress-server "$@"


### PR DESCRIPTION
Previous when build docker image, we use api-addr of "localhost:2381". This will cause a problem, when docker run easegress and map api-addr port to host port,
```sh
docker run -p 2381:2381 --name easegress megaease/easegress
```
In this case, we still only can use `egctl` in the container, say run:
```sh 
docker exec -it easegress /opt/easegress/bin/egctl object list
```
And run `egctl` in host not work although we already do port mapping, because we only listen to "localhost:2381", host machine http request will not be handled. 

So, this pr change default api-addr to `0.0.0.0:2381` for easegress when build docker images. 
Then when run
```sh
docker run -p 2381:2381 --name easegress megaease/easegress
```
`egctl` can work both in container or in host.