### PR TITLE
Add Tracing DisableReport config item

### DIFF
--- a/doc/reference/controllers.md
+++ b/doc/reference/controllers.md
@@ -461,13 +461,14 @@ domains:
 
 ### zipkin.Spec
 
-| Name       | Type    | Description                                                                                        | Required |
-| ---------- | ------- | -------------------------------------------------------------------------------------------------- | -------- |
-| hostPort   | string  | The host:port of the service                                                                       | No       |
-| serverURL  | string  | The zipkin server URL                                                                              | Yes      |
-| sampleRate | float64 | The sample rate for collecting metrics, the range is [0, 1]                                        | Yes      |
-| sameSpan   | bool    | Whether to allow to place client-side and server-side annotations for an RPC call in the same span | No       |
-| id128Bit   | bool    | Whether to start traces with 128-bit trace id                                                      | No       |
+| Name          | Type    | Description                                                                                        | Required |
+|---------------|---------|----------------------------------------------------------------------------------------------------| -------- |
+| hostPort      | string  | The host:port of the service                                                                       | No       |
+| serverURL     | string  | The zipkin server URL                                                                              | Yes      |
+| sampleRate    | float64 | The sample rate for collecting metrics, the range is [0, 1]                                        | Yes      |
+| disableReport | bool    | Whether to report span model data to zipkin server                                                 | No       |
+| sameSpan      | bool    | Whether to allow to place client-side and server-side annotations for an RPC call in the same span | No       |
+| id128Bit      | bool    | Whether to start traces with 128-bit trace id                                                      | No       |
 
 ### ipfilter.Spec
 

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -22,7 +22,9 @@ import (
 	"time"
 
 	"github.com/megaease/easegress/pkg/util/fasttime"
+
 	zipkingo "github.com/openzipkin/zipkin-go"
+	zipkinreporter "github.com/openzipkin/zipkin-go/reporter"
 	zipkingohttp "github.com/openzipkin/zipkin-go/reporter/http"
 )
 
@@ -36,11 +38,12 @@ type (
 
 	// ZipkinSpec describes Zipkin.
 	ZipkinSpec struct {
-		Hostport   string  `yaml:"hostport" jsonschema:"omitempty"`
-		ServerURL  string  `yaml:"serverURL" jsonschema:"required,format=url"`
-		SampleRate float64 `yaml:"sampleRate" jsonschema:"required,minimum=0,maximum=1"`
-		SameSpan   bool    `yaml:"sameSpan" jsonschema:"omitempty"`
-		ID128Bit   bool    `yaml:"id128Bit" jsonschema:"omitempty"`
+		Hostport      string  `yaml:"hostport" jsonschema:"omitempty"`
+		ServerURL     string  `yaml:"serverURL" jsonschema:"required,format=url"`
+		DisableReport bool    `yaml:"disableReport" jsonschema:"omitempty"`
+		SampleRate    float64 `yaml:"sampleRate" jsonschema:"required,minimum=0,maximum=1"`
+		SameSpan      bool    `yaml:"sameSpan" jsonschema:"omitempty"`
+		ID128Bit      bool    `yaml:"id128Bit" jsonschema:"omitempty"`
 	}
 
 	// Tracer is the tracer.
@@ -90,8 +93,10 @@ func New(spec *Spec) (*Tracer, error) {
 		return nil, err
 	}
 
-	reporter := zipkingohttp.NewReporter(spec.Zipkin.ServerURL)
-
+	var reporter zipkinreporter.Reporter
+	if !spec.Zipkin.DisableReport {
+		reporter = zipkingohttp.NewReporter(spec.Zipkin.ServerURL)
+	}
 	tracer, err := zipkingo.NewTracer(
 		reporter,
 		zipkingo.WithLocalEndpoint(endpoint),

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -94,7 +94,9 @@ func New(spec *Spec) (*Tracer, error) {
 	}
 
 	var reporter zipkinreporter.Reporter
-	if !spec.Zipkin.DisableReport {
+	if spec.Zipkin.DisableReport {
+		reporter = zipkinreporter.NewNoopReporter()
+	} else {
 		reporter = zipkingohttp.NewReporter(spec.Zipkin.ServerURL)
 	}
 	tracer, err := zipkingo.NewTracer(


### PR DESCRIPTION
[Issue735](https://github.com/megaease/easegress/issues/735) enhancement 
Notes: Cannot pass nil parameter to  [NewTracer function](https://github.com/openzipkin/zipkin-go/blob/f91647633b041da6b71741a09c8ff5d7c06364e2/tracer.go#L43)，because internally it will set [t.noop = 1](https://github.com/openzipkin/zipkin-go/blob/f91647633b041da6b71741a09c8ff5d7c06364e2/tracer.go#L60)
and disable all zipkin function including generating TraceId，we just disable report function，so we need to create zipkin ```reporter.NewNoopReporter()``` manually and pass to ```NewTracer``` function