### PR TITLE
update MQTT client close strategy

### DIFF
--- a/pkg/object/mqttproxy/broker.go
+++ b/pkg/object/mqttproxy/broker.go
@@ -381,8 +381,7 @@ func (b *Broker) handleConn(conn net.Conn) {
 		}
 	}
 	go client.writeLoop()
-	go client.readLoop()
-	<-client.done
+	client.readLoop()
 }
 
 func (b *Broker) setSession(client *Client, connect *packets.ConnectPacket) {

--- a/pkg/object/mqttproxy/broker.go
+++ b/pkg/object/mqttproxy/broker.go
@@ -381,7 +381,8 @@ func (b *Broker) handleConn(conn net.Conn) {
 		}
 	}
 	go client.writeLoop()
-	client.readLoop()
+	go client.readLoop()
+	<-client.done
 }
 
 func (b *Broker) setSession(client *Client, connect *packets.ConnectPacket) {

--- a/pkg/object/mqttproxy/client.go
+++ b/pkg/object/mqttproxy/client.go
@@ -268,7 +268,6 @@ func (c *Client) close() {
 	logger.SpanDebugf(nil, "client %v connection close", c.info.cid)
 	atomic.StoreInt32(&c.statusFlag, Disconnected)
 	close(c.done)
-	c.conn.Close()
 	c.Unlock()
 
 	// pipeline

--- a/pkg/object/mqttproxy/client.go
+++ b/pkg/object/mqttproxy/client.go
@@ -268,6 +268,7 @@ func (c *Client) close() {
 	logger.SpanDebugf(nil, "client %v connection close", c.info.cid)
 	atomic.StoreInt32(&c.statusFlag, Disconnected)
 	close(c.done)
+	c.conn.Close()
 	c.Unlock()
 
 	// pipeline

--- a/pkg/object/mqttproxy/client.go
+++ b/pkg/object/mqttproxy/client.go
@@ -268,6 +268,7 @@ func (c *Client) close() {
 	logger.SpanDebugf(nil, "client %v connection close", c.info.cid)
 	atomic.StoreInt32(&c.statusFlag, Disconnected)
 	close(c.done)
+	c.conn.SetReadDeadline(time.Now().Add(time.Second))
 	c.Unlock()
 
 	// pipeline


### PR DESCRIPTION
Currently, for mqtt clients that only receive packets and not send any packet, `Client.readLoop` will stuck at `packets.ReadPacket`. This is ok in normal case, but when we close client connection by using http endpoints, `readLoop` will not return as expected. 

To solve this problem, we set a deadline for Conn read.