### PR TITLE
add pipeline name in serializeStats tag

### DIFF
--- a/pkg/object/pipeline/pipeline.go
+++ b/pkg/object/pipeline/pipeline.go
@@ -174,14 +174,15 @@ func (s *Spec) Validate() (err error) {
 	return nil
 }
 
-func serializeStats(stats []FilterStat) string {
+func (p *Pipeline) serializeStats(stats []FilterStat) string {
 	if len(stats) == 0 {
 		return "pipeline: <empty>"
 	}
 
 	var sb strings.Builder
-	sb.WriteString("pipeline: ")
-
+	sb.WriteString("pipeline(")
+	sb.WriteString(p.superSpec.Name())
+	sb.WriteString("): ")
 	for i := range stats {
 		if i > 0 {
 			sb.WriteString("->")
@@ -331,7 +332,7 @@ func (p *Pipeline) HandleWithBeforeAfter(ctx *context.Context, before, after *Pi
 	}
 
 	ctx.LazyAddTag(func() string {
-		return serializeStats(stats)
+		return p.serializeStats(stats)
 	})
 	return result
 }
@@ -346,7 +347,7 @@ func (p *Pipeline) Handle(ctx *context.Context) string {
 	result, stats, _ := p.doHandle(ctx, p.flow, stats)
 
 	ctx.LazyAddTag(func() string {
-		return serializeStats(stats)
+		return p.serializeStats(stats)
 	})
 	return result
 }

--- a/pkg/object/pipeline/pipeline.go
+++ b/pkg/object/pipeline/pipeline.go
@@ -176,7 +176,7 @@ func (s *Spec) Validate() (err error) {
 
 func (p *Pipeline) serializeStats(stats []FilterStat) string {
 	if len(stats) == 0 {
-		return "pipeline: <empty>"
+		return "pipeline(" + p.superSpec.Name() + "): <empty>"
 	}
 
 	var sb strings.Builder


### PR DESCRIPTION
Currently，the default console log only prints filter name，It is very hard to troubleshoot URI path route problem，especially for following configure example，all filter names are same，so we need to print pipeline name to distinct which backend the request URI is routed.
```yaml
kind: HTTPServer
name: http
port: 8080
rules:
  - paths:
      - pathRegexp: /a
        backend: a
      - pathRegexp: /b
        backend: b
---
name: a
kind: Pipeline
flow:
  - filter: proxy
filters:
  - name: proxy
    kind: Proxy
    pools:
      - servers:
          - url:
---

name: b
kind: Pipeline
flow:
  - filter: proxy
filters:
  - name: proxy
    kind: Proxy
    pools:
      - servers:
          - url:
```