### PR TITLE
fix http runtime ticker leak

### DIFF
--- a/pkg/object/httpserver/runtime.go
+++ b/pkg/object/httpserver/runtime.go
@@ -389,6 +389,7 @@ func (r *runtime) handleEventReload(e *eventReload) {
 }
 
 func (r *runtime) handleEventClose(e *eventClose) {
+	r.setState(stateClosed)
 	r.closeServer()
 	r.mux.close()
 	close(e.done)


### PR DESCRIPTION
the ticker in func `checkFailed` would leak when new runtime object (delete httpserver and create new one)