### PR TITLE
fix ingress translation error

### DIFF
--- a/pkg/object/ingresscontroller/translator.go
+++ b/pkg/object/ingresscontroller/translator.go
@@ -86,6 +86,7 @@ func (b *pipelineSpecBuilder) addProxy(endpoints []string) {
 		"kind":     proxy.Kind,
 		"name":     name,
 		"mainPool": pool,
+		"pools":    []*proxy.ServerPoolSpec{pool},
 	},
 	)
 }

--- a/pkg/object/ingresscontroller/translator.go
+++ b/pkg/object/ingresscontroller/translator.go
@@ -85,7 +85,6 @@ func (b *pipelineSpecBuilder) addProxy(endpoints []string) {
 	b.Filters = append(b.Filters, map[string]interface{}{
 		"kind":     proxy.Kind,
 		"name":     name,
-		"mainPool": pool,
 		"pools":    []*proxy.ServerPoolSpec{pool},
 	},
 	)

--- a/pkg/object/ingresscontroller/translator.go
+++ b/pkg/object/ingresscontroller/translator.go
@@ -83,9 +83,9 @@ func (b *pipelineSpecBuilder) addProxy(endpoints []string) {
 
 	b.Flow = append(b.Flow, pipeline.FlowNode{FilterName: name})
 	b.Filters = append(b.Filters, map[string]interface{}{
-		"kind":     proxy.Kind,
-		"name":     name,
-		"pools":    []*proxy.ServerPoolSpec{pool},
+		"kind":  proxy.Kind,
+		"name":  name,
+		"pools": []*proxy.ServerPoolSpec{pool},
 	},
 	)
 }


### PR DESCRIPTION
**Versions**
easegress : v2.1.0
k8s: v1.22.7

Acoording to the cookbook [Kubernetes Ingress Controller](https://github.com/megaease/easegress/blob/main/doc/cookbook/k8s-ingress-controller.md) I created an ingress and an error occurred. Errors in easegress log file are as follows
```log
2022-09-07T18:38:16.841+08:00   ^[[34mINFO^[[0m trafficcontroller/trafficcontroller.go:260      create namespace ingress-controller-example/ingresscontroller
2022-09-07T18:38:16.841+08:00   ^[[34mINFO^[[0m trafficcontroller/trafficcontroller.go:270      create traffic gate ingress-controller-example/ingresscontroller/http-server-ingress-controller
2022-09-07T18:44:03.36+08:00    ^[[31mERROR^[[0m        ingresscontroller/translator.go:233     failed to generate pipeline spec: {"generalErrs":["*pipeline.Spec: filters: {\"jsonschemaErrs\":[\"pools: Invalid type. Expected: array, given: null\"],\"generalErrs\":[\"*proxy.Spec: one and only one mainPool is required\"]}"]}
2022-09-07T18:44:03.361+08:00   ^[[34mINFO^[[0m trafficcontroller/trafficcontroller.go:274      traffic gate ingress-controller-example/ingresscontroller/http-server-ingress-controller nothing change
2022-09-07T18:47:16.774+08:00   ^[[31mERROR^[[0m        ingresscontroller/translator.go:233     failed to generate pipeline spec: {"generalErrs":["*pipeline.Spec: filters: {\"jsonschemaErrs\":[\"pools: Invalid type. Expected: array, given: null\"],\"generalErrs\":[\"*proxy.Spec: one and only one mainPool is required\"]}"]}
```