### PR TITLE
support routing by query string

### DIFF
--- a/pkg/object/httpserver/mux.go
+++ b/pkg/object/httpserver/mux.go
@@ -331,7 +331,7 @@ func (mp *MuxPath) matchQueries(r *httpprot.Request) bool {
 			return false
 		}
 
-		if q.Regexp != "" && !q.queryRE.MatchString(v) {
+		if q.Regexp != "" && !q.re.MatchString(v) {
 			return false
 		}
 	}
@@ -575,7 +575,7 @@ func (mi *muxInstance) search(req *httpprot.Request) *route {
 
 	// The key of the cache is req.Host + req.Method + req.URL.Path,
 	// and if a path is cached, we are sure it does not contain any
-	// headers.
+	// headers or any queries.
 	r := mi.getRouteFromCache(req)
 	if r != nil {
 		if r.code != 0 {
@@ -628,7 +628,7 @@ func (mi *muxInstance) search(req *httpprot.Request) *route {
 				queryMismatch = true
 				continue
 			}
-			
+
 			if !allowIP(path.ipFilter, ip) {
 				return forbidden
 			}

--- a/pkg/object/httpserver/spec.go
+++ b/pkg/object/httpserver/spec.go
@@ -109,7 +109,7 @@ type (
 		Values []string `json:"values,omitempty" jsonschema:"omitempty,uniqueItems=true"`
 		Regexp string   `json:"regexp,omitempty" jsonschema:"omitempty,format=regexp"`
 
-		queryRE *regexp.Regexp
+		re *regexp.Regexp
 	}
 )
 
@@ -223,7 +223,9 @@ func (p *Path) Validate() error {
 }
 
 func (q *Query) initQueryRoute() {
-	q.queryRE = regexp.MustCompile(q.Regexp)
+	if q.Regexp != "" {
+		q.re = regexp.MustCompile(q.Regexp)
+	}
 }
 
 func (q *Query) Validate() error {

--- a/pkg/object/httpserver/spec.go
+++ b/pkg/object/httpserver/spec.go
@@ -89,6 +89,7 @@ type (
 		Headers           []*Header      `json:"headers" jsonschema:"omitempty"`
 		ClientMaxBodySize int64          `json:"clientMaxBodySize" jsonschema:"omitempty"`
 		MatchAllHeader    bool           `json:"matchAllHeader" jsonschema:"omitempty"`
+		Queries           []*Query       `json:"queries,omitempty" jsonschema:"omitempty"`
 	}
 
 	// Header is the third level entry of router. A header entry is always under a specific path entry, that is to mean
@@ -100,6 +101,15 @@ type (
 		Regexp string   `json:"regexp,omitempty" jsonschema:"omitempty,format=regexp"`
 
 		headerRE *regexp.Regexp
+	}
+
+	// Query is the third level entry
+	Query struct {
+		Key    string   `json:"key" jsonschema:"required"`
+		Values []string `json:"values,omitempty" jsonschema:"omitempty,uniqueItems=true"`
+		Regexp string   `json:"regexp,omitempty" jsonschema:"omitempty,format=regexp"`
+
+		queryRE *regexp.Regexp
 	}
 )
 
@@ -207,6 +217,18 @@ func (h *Header) Validate() error {
 func (p *Path) Validate() error {
 	if (stringtool.IsAllEmpty(p.Path, p.PathPrefix, p.PathRegexp)) && p.RewriteTarget != "" {
 		return fmt.Errorf("rewriteTarget is specified but path is empty")
+	}
+
+	return nil
+}
+
+func (q *Query) initQueryRoute() {
+	q.queryRE = regexp.MustCompile(q.Regexp)
+}
+
+func (q *Query) Validate() error {
+	if len(q.Values) == 0 && q.Regexp == "" {
+		return fmt.Errorf("both of values and regexp are empty for key: %s", q.Key)
 	}
 
 	return nil


### PR DESCRIPTION
This PR is support routing by query string.

You can config as follows:

- using key and values 
- using regexp

Config examples:

```yaml
  - path: /queryParamsMultiKey
    methods: [GET]
    queries:
    - key: "q"
      values: ["v1", "v2"]
    - key: "q2"
      values: ["v3", "v4"]
  - path: /queryParamsRegexpAndValues2
    methods: [GET]
    queries:
    - key: "id"
      values: ["011"]
      regexp: "[0-9]+"
    backend: 123-pipeline
```

Rules behind

- If your request query key have more than one values, then we just use the first value to match.

Test Examples
```go
// query string values and regexp
stdr, _ = http.NewRequest(http.MethodGet, "http://www.megaease.com/queryParamsRegexpAndValues2", http.NoBody)
stdr.URL.RawQuery = "id=011&&id=baz"
req, _ = httpprot.NewRequest(stdr)
assert.Equal(0, mi.search(req).code)

// query string values and regexp
stdr, _ = http.NewRequest(http.MethodGet, "http://www.megaease.com/queryParamsRegexpAndValues2", http.NoBody)
stdr.URL.RawQuery = "id=baz&&id=011"
req, _ = httpprot.NewRequest(stdr)
assert.Equal(400, mi.search(req).code)

// query string values and regexp
stdr, _ = http.NewRequest(http.MethodGet, "http://www.megaease.com/queryParamsRegexpAndValues2", http.NoBody)
stdr.URL.RawQuery = "id=baz"
req, _ = httpprot.NewRequest(stdr)
assert.Equal(400, mi.search(req).code)
```