### PR TITLE
upgrade wasmtime-go from v0.33.1 to v1.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/ArthurHlt/go-eureka-client v1.1.0
 	github.com/Shopify/sarama v1.36.0
-	github.com/bytecodealliance/wasmtime-go v0.33.1
+	github.com/bytecodealliance/wasmtime-go v1.0.0
 	github.com/eclipse/paho.mqtt.golang v1.4.1
 	github.com/fatih/color v1.13.0
 	github.com/fsnotify/fsnotify v1.5.4

--- a/go.sum
+++ b/go.sum
@@ -180,8 +180,8 @@ github.com/blendle/zapdriver v1.3.1 h1:C3dydBOWYRiOk+B8X9IVZ5IOe+7cl+tGOexN4QqHf
 github.com/blendle/zapdriver v1.3.1/go.mod h1:mdXfREi6u5MArG4j9fewC+FGnXaBR+T4Ox4J2u4eHCc=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
-github.com/bytecodealliance/wasmtime-go v0.33.1 h1:TFep11LiqCy1B6QUIAtqH3KZTbZcKasm89/AF9sqLnA=
-github.com/bytecodealliance/wasmtime-go v0.33.1/go.mod h1:q320gUxqyI8yB+ZqRuaJOEnGkAnHh6WtJjMaT2CW4wI=
+github.com/bytecodealliance/wasmtime-go v1.0.0 h1:9u9gqaUiaJeN5IoD1L7egD8atOnTGyJcNp8BhkL9cUU=
+github.com/bytecodealliance/wasmtime-go v1.0.0/go.mod h1:jjlqQbWUfVSbehpErw3UoWFndBXRRMvfikYH6KsCwOg=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.3.0 h1:t/LhUZLVitR1Ow2YOnduCsavhwFUklBMoGVYUCqmCqk=
 github.com/census-instrumentation/opencensus-proto v0.3.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/pkg/filters/wasmhost/vm.go
+++ b/pkg/filters/wasmhost/vm.go
@@ -30,12 +30,10 @@ import (
 
 // WasmVM represents a wasm VM
 type WasmVM struct {
-	host  *WasmHost
-	ctx   *context.Context
-	store *wasmtime.Store
-	inst  *wasmtime.Instance
-	//https://github.com/bytecodealliance/wasmtime/pull/3925
-	//ih      *wasmtime.InterruptHandle
+	host    *WasmHost
+	ctx     *context.Context
+	store   *wasmtime.Store
+	inst    *wasmtime.Instance
 	fnRun   *wasmtime.Func
 	fnAlloc *wasmtime.Func
 	fnFree  *wasmtime.Func


### PR DESCRIPTION
upgrade wasmtime-go from v0.33.1 to v1.0.0(https://github.com/megaease/easegress/issues/821)
fix compatibility about interruption logic detailed in https://github.com/bytecodealliance/wasmtime/pull/3925