### PR TITLE
fix unexpected EOF when compression is enabled

### DIFF
--- a/pkg/filters/proxy/compression.go
+++ b/pkg/filters/proxy/compression.go
@@ -64,6 +64,7 @@ func (c *compression) compress(req *http.Request, resp *http.Response) bool {
 		return false
 	}
 
+	resp.ContentLength = -1
 	resp.Header.Del(keyContentLength)
 	resp.Header.Set(keyContentEncoding, "gzip")
 	resp.Header.Add(keyVary, keyContentEncoding)

--- a/pkg/filters/proxy/pool.go
+++ b/pkg/filters/proxy/pool.go
@@ -299,7 +299,7 @@ func (sp *ServerPool) handleMirror(spCtx *serverPoolContext) {
 
 	err := spCtx.prepareRequest(svr, spCtx.req.Context(), true)
 	if err != nil {
-		logger.Debugf("%s: failed to prepare request: %v", sp.name, err)
+		logger.Errorf("%s: failed to prepare request: %v", sp.name, err)
 		return
 	}
 
@@ -377,7 +377,7 @@ func (sp *ServerPool) handle(ctx *context.Context, mirror bool) string {
 	// CircuitBreaker is the most outside resiliencer, if the error
 	// is ErrShortCircuited, we are sure the response is nil.
 	if err == resilience.ErrShortCircuited {
-		logger.Debugf("%s: short circuited by circuit break policy", sp.name)
+		logger.Errorf("%s: short circuited by circuit break policy", sp.name)
 		spCtx.AddTag("short circuited")
 		sp.buildFailureResponse(spCtx, http.StatusServiceUnavailable)
 		return resultShortCircuited
@@ -401,7 +401,7 @@ func (sp *ServerPool) doHandle(stdctx stdcontext.Context, spCtx *serverPoolConte
 
 	// if there's no available server.
 	if svr == nil {
-		logger.Debugf("%s: no available server", sp.name)
+		logger.Errorf("%s: no available server", sp.name)
 		return serverPoolError{http.StatusServiceUnavailable, resultInternalError}
 	}
 
@@ -409,13 +409,13 @@ func (sp *ServerPool) doHandle(stdctx stdcontext.Context, spCtx *serverPoolConte
 	statResult := &gohttpstat.Result{}
 	stdctx = gohttpstat.WithHTTPStat(stdctx, statResult)
 	if err := spCtx.prepareRequest(svr, stdctx, false); err != nil {
-		logger.Debugf("%s: failed to prepare request: %v", sp.name, err)
+		logger.Errorf("%s: failed to prepare request: %v", sp.name, err)
 		return serverPoolError{http.StatusInternalServerError, resultInternalError}
 	}
 
 	resp, err := fnSendRequest(spCtx.stdReq, sp.proxy.client)
 	if err != nil {
-		logger.Debugf("%s: failed to send request: %v", sp.name, err)
+		logger.Errorf("%s: failed to send request: %v", sp.name, err)
 
 		statResult.End(fasttime.Now())
 		spCtx.LazyAddTag(func() string {
@@ -481,7 +481,7 @@ func (sp *ServerPool) buildResponse(spCtx *serverPoolContext) (err error) {
 
 	resp, err := httpprot.NewResponse(spCtx.stdResp)
 	if err != nil {
-		logger.Debugf("%s: NewResponse returns an error: %v", sp.name, err)
+		logger.Errorf("%s: NewResponse returns an error: %v", sp.name, err)
 		body.Close()
 		return err
 	}
@@ -491,7 +491,7 @@ func (sp *ServerPool) buildResponse(spCtx *serverPoolContext) (err error) {
 		maxBodySize = sp.proxy.spec.ServerMaxBodySize
 	}
 	if err = resp.FetchPayload(maxBodySize); err != nil {
-		logger.Debugf("%s: failed to fetch response payload: %v", sp.name, err)
+		logger.Errorf("%s: failed to fetch response payload: %v", sp.name, err)
 		body.Close()
 		return err
 	}

--- a/pkg/filters/proxy/wspool.go
+++ b/pkg/filters/proxy/wspool.go
@@ -148,7 +148,7 @@ func (sp *WebSocketServerPool) handle(ctx *context.Context) (result string) {
 
 	// if there's no available server.
 	if svr == nil {
-		logger.Debugf("%s: no available server", sp.name)
+		logger.Errorf("%s: no available server", sp.name)
 		sp.buildFailureResponse(ctx, http.StatusServiceUnavailable)
 		metric.StatusCode = http.StatusServiceUnavailable
 		return resultInternalError
@@ -156,7 +156,7 @@ func (sp *WebSocketServerPool) handle(ctx *context.Context) (result string) {
 
 	stdw, _ := ctx.GetData("HTTP_RESPONSE_WRITER").(http.ResponseWriter)
 	if stdw == nil {
-		logger.Debugf("%s: cannot get response writer from context", sp.name)
+		logger.Errorf("%s: cannot get response writer from context", sp.name)
 		sp.buildFailureResponse(ctx, http.StatusInternalServerError)
 		metric.StatusCode = http.StatusInternalServerError
 		return resultInternalError

--- a/pkg/filters/responseadaptor/responseadaptor.go
+++ b/pkg/filters/responseadaptor/responseadaptor.go
@@ -175,6 +175,7 @@ func (ra *ResponseAdaptor) compress(resp *httpprot.Response) string {
 	zr := readers.NewGZipCompressReader(resp.GetPayload())
 	if resp.IsStream() {
 		resp.SetPayload(zr)
+		resp.ContentLength = -1
 		resp.HTTPHeader().Del(keyContentLength)
 	} else {
 		data, err := io.ReadAll(zr)
@@ -184,6 +185,7 @@ func (ra *ResponseAdaptor) compress(resp *httpprot.Response) string {
 			return resultCompressFailed
 		}
 		resp.SetPayload(data)
+		resp.ContentLength = int64(len(data))
 		resp.HTTPHeader().Set(keyContentLength, strconv.Itoa(len(data)))
 	}
 
@@ -208,6 +210,7 @@ func (ra *ResponseAdaptor) decompress(resp *httpprot.Response) string {
 
 	if resp.IsStream() {
 		resp.SetPayload(zr)
+		resp.ContentLength = -1
 		resp.HTTPHeader().Del(keyContentLength)
 	} else {
 		data, err := io.ReadAll(zr)
@@ -217,6 +220,7 @@ func (ra *ResponseAdaptor) decompress(resp *httpprot.Response) string {
 			return resultDecompressFailed
 		}
 		resp.SetPayload(data)
+		resp.ContentLength = int64(len(data))
 		resp.HTTPHeader().Set(keyContentLength, strconv.Itoa(len(data)))
 	}
 

--- a/pkg/object/httpserver/mux.go
+++ b/pkg/object/httpserver/mux.go
@@ -549,7 +549,7 @@ func (mi *muxInstance) serveHTTP(stdw http.ResponseWriter, stdr *http.Request) {
 	}
 	err := req.FetchPayload(maxBodySize)
 	if err == httpprot.ErrRequestEntityTooLarge {
-		logger.Debugf("%s: %s", mi.superSpec.Name(), err.Error())
+		logger.Debugf("%s: %s, you may need to increase 'clientMaxBodySize' or set it to -1", mi.superSpec.Name(), err.Error())
 		buildFailureResponse(ctx, http.StatusRequestEntityTooLarge)
 		return
 	}

--- a/pkg/object/httpserver/mux.go
+++ b/pkg/object/httpserver/mux.go
@@ -525,14 +525,14 @@ func (mi *muxInstance) serveHTTP(stdw http.ResponseWriter, stdr *http.Request) {
 
 	route := mi.search(req)
 	if route.code != 0 {
-		logger.Debugf("%s: status code of result route for [%s %s]: %d", mi.superSpec.Name(), req.Method(), req.RequestURI, route.code)
+		logger.Errorf("%s: status code of result route for [%s %s]: %d", mi.superSpec.Name(), req.Method(), req.RequestURI, route.code)
 		buildFailureResponse(ctx, route.code)
 		return
 	}
 
 	handler, ok := mi.muxMapper.GetHandler(route.path.backend)
 	if !ok {
-		logger.Debugf("%s: backend(Pipeline) %q for [%s %s] not found", mi.superSpec.Name(), req.Method(), req.RequestURI, route.path.backend)
+		logger.Errorf("%s: backend(Pipeline) %q for [%s %s] not found", mi.superSpec.Name(), req.Method(), req.RequestURI, route.path.backend)
 		buildFailureResponse(ctx, http.StatusServiceUnavailable)
 		return
 	}
@@ -549,12 +549,12 @@ func (mi *muxInstance) serveHTTP(stdw http.ResponseWriter, stdr *http.Request) {
 	}
 	err := req.FetchPayload(maxBodySize)
 	if err == httpprot.ErrRequestEntityTooLarge {
-		logger.Debugf("%s: %s, you may need to increase 'clientMaxBodySize' or set it to -1", mi.superSpec.Name(), err.Error())
+		logger.Errorf("%s: %s, you may need to increase 'clientMaxBodySize' or set it to -1", mi.superSpec.Name(), err.Error())
 		buildFailureResponse(ctx, http.StatusRequestEntityTooLarge)
 		return
 	}
 	if err != nil {
-		logger.Debugf("%s: failed to read request body: %v", mi.superSpec.Name(), err)
+		logger.Errorf("%s: failed to read request body: %v", mi.superSpec.Name(), err)
 		buildFailureResponse(ctx, http.StatusBadRequest)
 		return
 	}

--- a/pkg/protocols/httpprot/response.go
+++ b/pkg/protocols/httpprot/response.go
@@ -46,7 +46,7 @@ type Response struct {
 }
 
 // ErrResponseEntityTooLarge means the request entity is too large.
-var ErrResponseEntityTooLarge = fmt.Errorf("response entity too large")
+var ErrResponseEntityTooLarge = fmt.Errorf("response entity too large, you may need to increase 'serverMaxBodySize' or set it to -1")
 
 var _ protocols.Response = (*Response)(nil)
 


### PR DESCRIPTION
when compression is enabled in a `Proxy`, it may fail with `io.UnexpectedEOF` and return HTTP 500 to the client.