### PR TITLE
Update keyfunc for compatibility and bug fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/ArthurHlt/go-eureka-client v1.1.0
-	github.com/MicahParks/keyfunc v1.0.3
+	github.com/MicahParks/keyfunc v1.5.1
 	github.com/Shopify/sarama v1.36.0
 	github.com/bytecodealliance/wasmtime-go v1.0.0
 	github.com/eclipse/paho.mqtt.golang v1.4.1
@@ -15,7 +15,7 @@ require (
 	github.com/go-zookeeper/zk v1.0.3
 	github.com/goccy/go-json v0.9.6
 	github.com/golang-jwt/jwt v3.2.1+incompatible
-	github.com/golang-jwt/jwt/v4 v4.3.0
+	github.com/golang-jwt/jwt/v4 v4.4.2
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/consul/api v1.15.2
 	github.com/hashicorp/golang-lru v0.5.4

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962 h1:KeNholpO2xKjgaaSyd+DyQRrsQjhbSeS7qe4nEw8aQw=
 github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962/go.mod h1:kC29dT1vFpj7py2OvG1khBdQpo3kInWP+6QipLbdngo=
-github.com/MicahParks/keyfunc v1.0.3 h1:rKakzF/Gd2QjFPCqSG9SshrWs0oRZffc/c4pVjCXDr0=
-github.com/MicahParks/keyfunc v1.0.3/go.mod h1:R8RZa27qn+5cHTfYLJ9/+7aSb5JIdz7cl0XFo0o4muo=
+github.com/MicahParks/keyfunc v1.5.1 h1:RlyyYgKQI/adkIw1yXYtPvTAOb7hBhSX42aH23d8N0Q=
+github.com/MicahParks/keyfunc v1.5.1/go.mod h1:IdnCilugA0O/99dW+/MkvlyrsX8+L8+x95xuVNtM5jw=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
@@ -358,10 +358,9 @@ github.com/goji/httpauth v0.0.0-20160601135302-2da839ab0f4d/go.mod h1:nnjvkQ9ptG
 github.com/golang-jwt/jwt v3.2.1+incompatible h1:73Z+4BJcrTC+KczS6WvTPvRGOp1WmfEP4Q1lOd9Z/+c=
 github.com/golang-jwt/jwt v3.2.1+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
-github.com/golang-jwt/jwt/v4 v4.1.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
-github.com/golang-jwt/jwt/v4 v4.3.0 h1:kHL1vqdqWNfATmA0FNMdmZNMyZI1U6O31X4rlIPoBog=
-github.com/golang-jwt/jwt/v4 v4.3.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
+github.com/golang-jwt/jwt/v4 v4.4.2 h1:rcc4lwaZgFMCZ5jxF9ABolDcIHdBytAFgqFPbSJQAYs=
+github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/pkg/filters/oidcadaptor/oidcadaptor.go
+++ b/pkg/filters/oidcadaptor/oidcadaptor.go
@@ -223,10 +223,8 @@ func (o *OIDCAdaptor) initDiscoveryOIDCConf() {
 		}
 	}
 	jwks, err := keyfunc.Get(oidcConf.JwksUri, keyfunc.Options{
-		Client:            httpCli,
-		JWKUseNoWhitelist: true,
-		RefreshInterval:   interval,
-		ResponseExtractor: keyfunc.ResponseExtractorStatusAny,
+		Client:          httpCli,
+		RefreshInterval: interval,
 	})
 	if err != nil {
 		logger.Errorf("failed to get the JWKS from the given URL error: %s", err)

--- a/pkg/filters/oidcadaptor/oidcadaptor.go
+++ b/pkg/filters/oidcadaptor/oidcadaptor.go
@@ -223,8 +223,10 @@ func (o *OIDCAdaptor) initDiscoveryOIDCConf() {
 		}
 	}
 	jwks, err := keyfunc.Get(oidcConf.JwksUri, keyfunc.Options{
-		Client:          httpCli,
-		RefreshInterval: interval,
+		Client:            httpCli,
+		JWKUseNoWhitelist: true,
+		RefreshInterval:   interval,
+		ResponseExtractor: keyfunc.ResponseExtractorStatusAny,
 	})
 	if err != nil {
 		logger.Errorf("failed to get the JWKS from the given URL error: %s", err)


### PR DESCRIPTION
The purpose of this PR is to update the `github.com/MicahParks/keyfunc` package. The primary reason I'm making this PR is to introduce the changes from these releases:
* [Support non-RFC compliant base64url padding](https://github.com/MicahParks/keyfunc/releases/tag/v1.1.0) (Compatibility update.)
* [Check HTTP status code](https://github.com/MicahParks/keyfunc/releases/tag/v1.4.0) (Confirms the HTTP status code is 200. Bug fix.)
* [JSON Web Keys restricted by "use" parameter](https://github.com/MicahParks/keyfunc/releases/tag/v1.5.1) (Better RFC compliance. Could be viewed as a bug fix.)


If there is any interest in the other features added since `v1.0.3`, please see the release page:
https://github.com/MicahParks/keyfunc/releases

For a quick summary of the new `keyfunc.Options`, see the documentation for its fields:
https://pkg.go.dev/github.com/MicahParks/keyfunc#Options