### PR TITLE
Update mqtt proxy to broker

### DIFF
--- a/pkg/object/mqttproxy/cachetopicmgr.go
+++ b/pkg/object/mqttproxy/cachetopicmgr.go
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2017, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mqttproxy
+
+import "sync"
+
+type cachedTopicManager struct {
+	levelCache *topicLevelCache
+	topicMgr   *levelTopicManager
+
+	// topicMapper map[topic]map[clientID]qos
+	// sync.Map with value of sync.Map
+	topicMapper sync.Map
+
+	// clientMapper map[clientID]map[topic]qos
+	// sync.Map with value of sync.Map
+	clientMapper sync.Map
+
+	writeCh chan *topicOp
+	closeCh chan struct{}
+}
+
+var _ TopicManager = (*cachedTopicManager)(nil)
+
+func newCachedTopicManager(cacheSize int) *cachedTopicManager {
+	mgr := &cachedTopicManager{
+		topicMgr:   newLevelTopicManager(),
+		levelCache: newTopicLevelCache(cacheSize),
+		writeCh:    make(chan *topicOp, 10000),
+		closeCh:    make(chan struct{}),
+	}
+	go mgr.update()
+	return mgr
+}
+
+func (mgr *cachedTopicManager) findSubscribers(topic string) (map[string]byte, error) {
+	if value, ok := mgr.topicMapper.Load(topic); ok {
+		res := make(map[string]byte)
+		value.(*sync.Map).Range(func(key any, value any) bool {
+			res[key.(string)] = value.(byte)
+			return true
+		})
+		return res, nil
+	}
+	levels, err := mgr.levelCache.get(topic)
+	if err != nil {
+		return nil, err
+	}
+	mgr.writeCh <- &topicOp{
+		opType: publish,
+		publishOp: &publishOp{
+			topic:  topic,
+			levels: levels,
+		},
+	}
+	return mgr.topicMgr.findSubscribers(levels), nil
+}
+
+func (mgr *cachedTopicManager) subscribe(topics []string, qoss []byte, clientID string) error {
+	allLevels, err := mgr.levelCache.getAll(topics)
+	if err != nil {
+		return err
+	}
+
+	mgr.writeCh <- &topicOp{
+		opType: subscribe,
+		subscribeOp: &subscribeOp{
+			allLevels: allLevels,
+			qoss:      qoss,
+			clientID:  clientID,
+		},
+	}
+	return nil
+}
+
+func (mgr *cachedTopicManager) unsubscribe(topics []string, clientID string) error {
+	allLevels, err := mgr.levelCache.getAll(topics)
+	if err != nil {
+		return err
+	}
+
+	mgr.writeCh <- &topicOp{
+		opType: unsubscribe,
+		unsubscribeOp: &unsubscribeOp{
+			allLevels: allLevels,
+			clientID:  clientID,
+		},
+	}
+	return nil
+}
+
+func (mgr *cachedTopicManager) disconnect(topics []string, clientID string) error {
+	allLevels, err := mgr.levelCache.getAll(topics)
+	if err != nil {
+		return err
+	}
+	mgr.writeCh <- &topicOp{
+		opType: disconnect,
+		disconnectOp: &disconnectOp{
+			allLevels: allLevels,
+			clientID:  clientID,
+		},
+	}
+	return nil
+}
+
+func (mgr *cachedTopicManager) processSubscribe(op *subscribeOp) {
+	mgr.topicMgr.subscribe(op.allLevels, op.qoss, op.clientID)
+	matchTopics := []string{}
+
+	mgr.topicMapper.Range(func(key any, value any) bool {
+		topicLevels, _ := mgr.levelCache.get(key.(string))
+		for i, levels := range op.allLevels {
+			if isTopicMatch(topicLevels, levels) {
+				matchTopics = append(matchTopics, key.(string))
+				value.(*sync.Map).Store(op.clientID, op.qoss[i])
+			}
+		}
+		return true
+	})
+	clientMap, _ := mgr.clientMapper.LoadOrStore(op.clientID, &sync.Map{})
+	for _, topic := range matchTopics {
+		clientMap.(*sync.Map).Store(topic, op.qoss)
+	}
+}
+
+func (mgr *cachedTopicManager) processUnsubscribe(op *unsubscribeOp) {
+	mgr.topicMgr.unsubscribe(op.allLevels, op.clientID)
+	value, ok := mgr.clientMapper.Load(op.clientID)
+	if !ok {
+		return
+	}
+
+	matchTopics := []string{}
+	value.(*sync.Map).Range(func(key any, value any) bool {
+		topicLevels, _ := mgr.levelCache.get(key.(string))
+		for _, levels := range op.allLevels {
+			if isTopicMatch(topicLevels, levels) {
+				matchTopics = append(matchTopics, key.(string))
+			}
+		}
+		return true
+	})
+	for _, topic := range matchTopics {
+		value.(*sync.Map).Delete(topic)
+		topicMap, ok := mgr.topicMapper.Load(topic)
+		if ok {
+			topicMap.(*sync.Map).Delete(op.clientID)
+		}
+	}
+}
+
+func (mgr *cachedTopicManager) processPublish(op *publishOp) {
+	clients := mgr.topicMgr.findSubscribers(op.levels)
+	topicMap, _ := mgr.topicMapper.LoadOrStore(op.topic, &sync.Map{})
+
+	for cid, qos := range clients {
+		topicMap.(*sync.Map).Store(cid, qos)
+		clientMap, _ := mgr.clientMapper.LoadOrStore(cid, &sync.Map{})
+		clientMap.(*sync.Map).Store(op.topic, qos)
+	}
+}
+
+func (mgr *cachedTopicManager) processDisconnect(op *disconnectOp) {
+	mgr.topicMgr.unsubscribe(op.allLevels, op.clientID)
+	value, ok := mgr.clientMapper.Load(op.clientID)
+	if !ok {
+		return
+	}
+	value.(*sync.Map).Range(func(key any, value any) bool {
+		topicMap, ok := mgr.topicMapper.Load(key.(string))
+		if ok {
+			topicMap.(*sync.Map).Delete(op.clientID)
+		}
+		return true
+	})
+	mgr.clientMapper.Delete(op.clientID)
+}
+
+func (mgr *cachedTopicManager) update() {
+	for {
+		select {
+		case op := <-mgr.writeCh:
+			switch op.opType {
+			case subscribe:
+				mgr.processSubscribe(op.subscribeOp)
+			case unsubscribe:
+				mgr.processUnsubscribe(op.unsubscribeOp)
+			case publish:
+				mgr.processPublish(op.publishOp)
+			case disconnect:
+				mgr.processDisconnect(op.disconnectOp)
+			}
+		case <-mgr.closeCh:
+			return
+		}
+	}
+}
+
+func (mgr *cachedTopicManager) close() {
+	close(mgr.closeCh)
+}

--- a/pkg/object/mqttproxy/client.go
+++ b/pkg/object/mqttproxy/client.go
@@ -329,6 +329,7 @@ func pipelineWrapper(fn processFn, packetType PacketType) processFnWithErr {
 
 func processPublish(c *Client, packet packets.ControlPacket) {
 	publish := packet.(*packets.PublishPacket)
+	c.broker.processBrokerModePublish(c.info.cid, publish)
 	switch publish.Qos {
 	case QoS0:
 		// do nothing

--- a/pkg/object/mqttproxy/nocachetopicmgr.go
+++ b/pkg/object/mqttproxy/nocachetopicmgr.go
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2017, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mqttproxy
+
+type noCacheTopicManager struct {
+	topicMgr   *levelTopicManager
+	topicCache *topicLevelCache
+}
+
+var _ TopicManager = (*noCacheTopicManager)(nil)
+
+func newNoCacheTopicManager(cacheSize int) *noCacheTopicManager {
+	return &noCacheTopicManager{
+		topicMgr:   newLevelTopicManager(),
+		topicCache: newTopicLevelCache(cacheSize),
+	}
+}
+
+func (mgr *noCacheTopicManager) findSubscribers(topic string) (map[string]byte, error) {
+	levels, err := mgr.topicCache.get(topic)
+	if err != nil {
+		return nil, err
+	}
+	return mgr.topicMgr.findSubscribers(levels), nil
+}
+
+func (mgr *noCacheTopicManager) subscribe(topics []string, qoss []byte, clientID string) error {
+	allLevels, err := mgr.topicCache.getAll(topics)
+	if err != nil {
+		return err
+	}
+	mgr.topicMgr.subscribe(allLevels, qoss, clientID)
+	return nil
+}
+
+func (mgr *noCacheTopicManager) unsubscribe(topics []string, clientID string) error {
+	allLevels, err := mgr.topicCache.getAll(topics)
+	if err != nil {
+		return err
+	}
+	mgr.topicMgr.unsubscribe(allLevels, clientID)
+	return nil
+}
+
+func (mgr *noCacheTopicManager) disconnect(topics []string, clientID string) error {
+	return mgr.unsubscribe(topics, clientID)
+}
+
+func (mgr *noCacheTopicManager) close() {
+}

--- a/pkg/object/mqttproxy/session.go
+++ b/pkg/object/mqttproxy/session.go
@@ -95,7 +95,7 @@ func (s *Session) encode() (string, error) {
 }
 
 func (s *Session) decode(str string) error {
-	return codectool.Unmarshal([]byte(str), s.info)
+	return codectool.UnmarshalJSON([]byte(str), s.info)
 }
 
 func (s *Session) init(sm *SessionManager, b *Broker, connect *packets.ConnectPacket) error {

--- a/pkg/object/mqttproxy/sessioncache.go
+++ b/pkg/object/mqttproxy/sessioncache.go
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2017, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mqttproxy
+
+import "sync"
+
+// SessionCacheManager is the interface for session cache.
+// SessionCache is used in broker mode only. It stores session info of clients from
+// different easegress instances. It update topic manager when session info of is updated.
+type SessionCacheManager interface {
+	update(clientID string, session *SessionInfo)
+	delete(clientID string)
+	sync(clients map[string]*SessionInfo)
+	getEGName(clientID string) string
+	close()
+}
+
+type sessionCacheManager struct {
+	egName      string
+	topicMgr    TopicManager
+	cache       map[string]*SessionInfo
+	egNameCache sync.Map
+	writeCh     chan *sessionCacheOp
+	doneCh      chan struct{}
+}
+
+var _ SessionCacheManager = (*sessionCacheManager)(nil)
+
+type sessionCacheOpType int
+
+const (
+	sessionCacheOpUpdate sessionCacheOpType = iota
+	sessionCacheOpDelete
+	sessionCacheOpSync
+)
+
+type sessionCacheOp struct {
+	opType   sessionCacheOpType
+	clientID string
+	session  *SessionInfo
+	clients  map[string]*SessionInfo
+}
+
+func newSessionCacheManager(sepc *Spec, topicMgr TopicManager) SessionCacheManager {
+	mgr := &sessionCacheManager{
+		egName:   sepc.Name,
+		topicMgr: topicMgr,
+		cache:    make(map[string]*SessionInfo),
+		writeCh:  make(chan *sessionCacheOp, 10000),
+	}
+	go mgr.run()
+	return mgr
+}
+
+func (c *sessionCacheManager) update(clientID string, session *SessionInfo) {
+	c.writeCh <- &sessionCacheOp{
+		opType:   sessionCacheOpUpdate,
+		clientID: clientID,
+		session:  session,
+	}
+}
+
+func (c *sessionCacheManager) delete(clientID string) {
+	c.writeCh <- &sessionCacheOp{
+		opType:   sessionCacheOpDelete,
+		clientID: clientID,
+		session:  nil,
+	}
+}
+
+func (c *sessionCacheManager) sync(clients map[string]*SessionInfo) {
+	c.writeCh <- &sessionCacheOp{
+		opType:  sessionCacheOpSync,
+		clients: clients,
+	}
+}
+
+func (c *sessionCacheManager) processUpdate(clientID string, session *SessionInfo) {
+	c.egNameCache.Store(clientID, session.EGName)
+	if session.EGName == c.egName {
+		c.cache[clientID] = session
+		return
+	}
+
+	oldSession, ok := c.cache[clientID]
+	c.cache[clientID] = session
+	if !ok {
+		topics := make([]string, 0, len(session.Topics))
+		qoss := make([]byte, 0, len(session.Topics))
+		for t, v := range session.Topics {
+			topics = append(topics, t)
+			qoss = append(qoss, byte(v))
+		}
+		c.topicMgr.subscribe(topics, qoss, clientID)
+		return
+	}
+
+	subTopics := []string{}
+	subQoss := []byte{}
+	for k, v := range session.Topics {
+		if _, ok := oldSession.Topics[k]; !ok {
+			subTopics = append(subTopics, k)
+			subQoss = append(subQoss, byte(v))
+		}
+	}
+	unsubTopics := []string{}
+	unsubQoss := []byte{}
+	for k, v := range oldSession.Topics {
+		if _, ok := session.Topics[k]; !ok {
+			unsubTopics = append(unsubTopics, k)
+			unsubQoss = append(unsubQoss, byte(v))
+		}
+	}
+	c.topicMgr.subscribe(subTopics, subQoss, clientID)
+	c.topicMgr.unsubscribe(unsubTopics, clientID)
+}
+
+func (c *sessionCacheManager) processDelete(clientID string) {
+	c.egNameCache.Delete(clientID)
+	session, ok := c.cache[clientID]
+	if ok {
+		topics := make([]string, 0, len(session.Topics))
+		for t := range session.Topics {
+			topics = append(topics, t)
+		}
+		c.topicMgr.disconnect(topics, clientID)
+		delete(c.cache, clientID)
+	}
+}
+
+func (c *sessionCacheManager) processSync(clients map[string]*SessionInfo) {
+	for k := range c.cache {
+		if _, ok := clients[k]; !ok {
+			c.processDelete(k)
+		}
+	}
+	for k, v := range clients {
+		c.processUpdate(k, v)
+	}
+}
+
+func (c *sessionCacheManager) run() {
+	for {
+		select {
+		case <-c.doneCh:
+			return
+		case op := <-c.writeCh:
+			switch op.opType {
+			case sessionCacheOpUpdate:
+				c.processUpdate(op.clientID, op.session)
+			case sessionCacheOpDelete:
+				c.processDelete(op.clientID)
+			case sessionCacheOpSync:
+				c.processSync(op.clients)
+			}
+		}
+	}
+}
+
+func (c *sessionCacheManager) getEGName(clientID string) string {
+	val, ok := c.egNameCache.Load(clientID)
+	if !ok {
+		return ""
+	}
+	return val.(string)
+}
+
+func (c *sessionCacheManager) close() {
+	close(c.doneCh)
+}

--- a/pkg/object/mqttproxy/spec.go
+++ b/pkg/object/mqttproxy/spec.go
@@ -71,6 +71,7 @@ type (
 		ConnectionLimit      *RateLimit    `json:"connectionLimit" jsonschema:"omitempty"`
 		ClientPublishLimit   *RateLimit    `json:"clientPublishLimit" jsonschema:"omitempty"`
 		Rules                []*Rule       `json:"rules" jsonschema:"omitempty"`
+		BrokerMode           bool          `json:"brokerMode" jsonschema:"omitempty"`
 	}
 
 	// Rule used to route MQTT packets to different pipelines

--- a/pkg/object/mqttproxy/topic.go
+++ b/pkg/object/mqttproxy/topic.go
@@ -17,224 +17,61 @@
 
 package mqttproxy
 
-import (
-	"fmt"
-	"strings"
-	"sync"
+type topicOpType int
 
-	lru "github.com/hashicorp/golang-lru"
+const (
+	subscribe topicOpType = iota
+	unsubscribe
+	publish
+	disconnect
 )
 
-// TopicManager to manage topic subscribe and unsubscribe in MQTT
-type TopicManager struct {
-	sync.RWMutex
-	root     *topicNode
-	levelMgr *topicLevelManager
+type topicOp struct {
+	opType        topicOpType
+	subscribeOp   *subscribeOp
+	unsubscribeOp *unsubscribeOp
+	publishOp     *publishOp
+	disconnectOp  *disconnectOp
 }
 
-type topicLevelManager struct {
-	data *lru.Cache
+type subscribeOp struct {
+	allLevels [][]string
+	qoss      []byte
+	clientID  string
 }
 
-func newTopicManager(cacheSize int) *TopicManager {
-	return &TopicManager{
-		root:     newNode(),
-		levelMgr: newTopicLevelManager(cacheSize),
+type unsubscribeOp struct {
+	allLevels [][]string
+	clientID  string
+}
+
+type publishOp struct {
+	topic  string
+	levels []string
+}
+
+type disconnectOp struct {
+	allLevels [][]string
+	clientID  string
+}
+
+func isTopicMatch(topicLevels []string, subLevels []string) bool {
+	if len(topicLevels) < len(subLevels) {
+		return false
 	}
-}
-
-func newTopicLevelManager(cacheSize int) *topicLevelManager {
-	// here we promise cacheSize greater than 0, so we ignore this error.
-	cache, _ := lru.New(cacheSize)
-	return &topicLevelManager{
-		data: cache,
+	if (len(topicLevels) > len(subLevels)) && (subLevels[len(subLevels)-1] != "#") {
+		return false
 	}
-}
-
-func (mgr *TopicManager) getLevels(topic string) ([]string, error) {
-	return mgr.levelMgr.get(topic)
-}
-
-func (mgr *TopicManager) subscribe(topics []string, qoss []byte, clientID string) error {
-	mgr.Lock()
-	defer mgr.Unlock()
-
-	for i, t := range topics {
-		if err := mgr.insert(t, qoss[i], clientID); err != nil {
-			return err
+	for i, subLevel := range subLevels {
+		if subLevel == "#" {
+			return true
+		}
+		if subLevel == "+" {
+			continue
+		}
+		if subLevel != topicLevels[i] {
+			return false
 		}
 	}
-	return nil
-}
-
-func (mgr *TopicManager) unsubscribe(topics []string, clientID string) error {
-	mgr.Lock()
-	defer mgr.Unlock()
-
-	for _, t := range topics {
-		if err := mgr.remove(t, clientID); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// findSubscribers is used to find all clients that subscribe a certain topic directly or use wildcard.
-// for example, topic "loc/device/event" will find clients that subscribe topic "+/+/+" or "loc/+/event" or "loc/device/event"
-// so, clients subscribe topics that contain or not contain wildcard, and this function will find all subscribed topics that match
-// the given topic.
-func (mgr *TopicManager) findSubscribers(topic string) (map[string]byte, error) {
-	mgr.RLock()
-	defer mgr.RUnlock()
-
-	levels, err := mgr.getLevels(topic)
-	if err != nil {
-		return nil, err
-	}
-	ans := make(map[string]byte)
-
-	currentLevelNodes := []*topicNode{mgr.root}
-	for _, topicLevel := range levels {
-		nextLevelNodes := []*topicNode{}
-		for _, node := range currentLevelNodes {
-			for nodeLevel, nextNode := range node.nodes {
-				if nodeLevel == "#" {
-					nextNode.addClients(ans)
-
-				} else if nodeLevel == "+" || nodeLevel == topicLevel {
-					nextLevelNodes = append(nextLevelNodes, nextNode)
-				}
-			}
-		}
-		currentLevelNodes = nextLevelNodes
-		if len(currentLevelNodes) == 0 {
-			return ans, nil
-		}
-	}
-	for _, n := range currentLevelNodes {
-		n.addClients(ans)
-		// in MQTT version 3.1.1 section 4.7.1.2, topic "sport/tennis/player1/#" would receive msg from "sport/tennis/player1"
-		// which means when we reach end of topic level, we need check one more level for wildcard #
-		if val, ok := n.nodes["#"]; ok {
-			val.addClients(ans)
-		}
-	}
-	return ans, nil
-}
-
-func (mgr *TopicManager) insert(topic string, qos byte, clientID string) error {
-	levels, err := mgr.getLevels(topic)
-	if err != nil {
-		return err
-	}
-	node := mgr.root
-	var nextNode *topicNode
-	var ok bool
-	for _, l := range levels {
-		nextNode, ok = node.nodes[l]
-		if !ok {
-			nextNode = newNode()
-			node.nodes[l] = nextNode
-		}
-		node = nextNode
-	}
-	node.clients[clientID] = qos
-	return nil
-}
-
-func (mgr *TopicManager) remove(topic string, clientID string) error {
-	levels, err := mgr.getLevels(topic)
-	if err != nil {
-		return err
-	}
-	node := mgr.root
-	var nextNode *topicNode
-	var ok bool
-	prevNodes := []*topicNode{}
-	for _, l := range levels {
-		if nextNode, ok = node.nodes[l]; !ok {
-			return nil
-		}
-		prevNodes = append(prevNodes, node)
-		node = nextNode
-	}
-	delete(node.clients, clientID)
-
-	// clear memory
-	for i := len(prevNodes) - 1; i >= 0; i-- {
-		node = prevNodes[i].nodes[levels[i]]
-		if len(node.clients) == 0 && len(node.nodes) == 0 {
-			delete(prevNodes[i].nodes, levels[i])
-		} else {
-			return nil
-		}
-	}
-	return nil
-}
-
-func splitTopic(topic string) ([]string, bool) {
-	levels := make([]string, strings.Count(topic, "/")+1)
-	levelsLoc := 0
-
-	levelStart := 0
-	wildCardFlag := false
-	for i, char := range topic {
-		if char == '/' {
-			level := topic[levelStart:i]
-			if len(level) > 1 && wildCardFlag {
-				return nil, false
-			}
-			levels[levelsLoc] = level
-			levelsLoc++
-			levelStart = i + 1
-			wildCardFlag = false
-
-		} else if char == '+' {
-			wildCardFlag = true
-
-		} else if char == '#' {
-			wildCardFlag = true
-			if i != len(topic)-1 {
-				return nil, false
-			}
-		}
-	}
-
-	level := topic[levelStart:]
-	if len(level) > 1 && wildCardFlag {
-		return nil, false
-	}
-	levels[levelsLoc] = level
-	return levels, true
-}
-
-func (t *topicLevelManager) get(topic string) ([]string, error) {
-	if val, ok := t.data.Get(topic); ok {
-		return val.([]string), nil
-	}
-	levels, valid := splitTopic(topic)
-	if valid {
-		t.data.Add(topic, levels)
-		return levels, nil
-	}
-	return nil, fmt.Errorf("topic %v is invalid", topic)
-}
-
-type topicNode struct {
-	// client with their qos
-	clients map[string]byte
-	nodes   map[string]*topicNode
-}
-
-func newNode() *topicNode {
-	return &topicNode{
-		clients: make(map[string]byte),
-		nodes:   make(map[string]*topicNode),
-	}
-}
-
-func (node *topicNode) addClients(ans map[string]byte) {
-	for client, qos := range node.clients {
-		ans[client] = qos
-	}
+	return true
 }

--- a/pkg/object/mqttproxy/topicmgr.go
+++ b/pkg/object/mqttproxy/topicmgr.go
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2017, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mqttproxy
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	lru "github.com/hashicorp/golang-lru"
+)
+
+type TopicManager interface {
+	subscribe(topics []string, qoss []byte, clientID string) error
+	unsubscribe(topics []string, clientID string) error
+	disconnect(topics []string, clientID string) error
+	findSubscribers(topic string) (map[string]byte, error)
+	close()
+}
+
+func newTopicManager(spec *Spec) TopicManager {
+	if spec.BrokerMode {
+		return newCachedTopicManager(spec.TopicCacheSize)
+	}
+	return newNoCacheTopicManager(spec.TopicCacheSize)
+}
+
+// levelTopicManager to manage topic subscribe and unsubscribe in MQTT
+type levelTopicManager struct {
+	sync.RWMutex
+	root *topicNode
+}
+
+func newLevelTopicManager() *levelTopicManager {
+	return &levelTopicManager{
+		root: newNode(),
+	}
+}
+
+func (mgr *levelTopicManager) subscribe(allLevels [][]string, qoss []byte, clientID string) {
+	mgr.Lock()
+	defer mgr.Unlock()
+
+	for i, l := range allLevels {
+		mgr.insert(l, qoss[i], clientID)
+	}
+}
+
+func (mgr *levelTopicManager) unsubscribe(allLevels [][]string, clientID string) {
+	mgr.Lock()
+	defer mgr.Unlock()
+
+	for _, l := range allLevels {
+		mgr.remove(l, clientID)
+	}
+}
+
+// findSubscribers is used to find all clients that subscribe a certain topic directly or use wildcard.
+// for example, topic "loc/device/event" will find clients that subscribe topic "+/+/+" or "loc/+/event" or "loc/device/event"
+// so, clients subscribe topics that contain or not contain wildcard, and this function will find all subscribed topics that match
+// the given topic.
+func (mgr *levelTopicManager) findSubscribers(levels []string) map[string]byte {
+	mgr.RLock()
+	defer mgr.RUnlock()
+
+	ans := make(map[string]byte)
+
+	currentLevelNodes := []*topicNode{mgr.root}
+	for _, topicLevel := range levels {
+		nextLevelNodes := []*topicNode{}
+		for _, node := range currentLevelNodes {
+			for nodeLevel, nextNode := range node.nodes {
+				if nodeLevel == "#" {
+					nextNode.addClients(ans)
+
+				} else if nodeLevel == "+" || nodeLevel == topicLevel {
+					nextLevelNodes = append(nextLevelNodes, nextNode)
+				}
+			}
+		}
+		currentLevelNodes = nextLevelNodes
+		if len(currentLevelNodes) == 0 {
+			return ans
+		}
+	}
+	for _, n := range currentLevelNodes {
+		n.addClients(ans)
+		// in MQTT version 3.1.1 section 4.7.1.2, topic "sport/tennis/player1/#" would receive msg from "sport/tennis/player1"
+		// which means when we reach end of topic level, we need check one more level for wildcard #
+		if val, ok := n.nodes["#"]; ok {
+			val.addClients(ans)
+		}
+	}
+	return ans
+}
+
+func (mgr *levelTopicManager) insert(levels []string, qos byte, clientID string) {
+	node := mgr.root
+	var nextNode *topicNode
+	var ok bool
+	for _, l := range levels {
+		nextNode, ok = node.nodes[l]
+		if !ok {
+			nextNode = newNode()
+			node.nodes[l] = nextNode
+		}
+		node = nextNode
+	}
+	node.clients[clientID] = qos
+}
+
+func (mgr *levelTopicManager) remove(levels []string, clientID string) {
+	node := mgr.root
+	var nextNode *topicNode
+	var ok bool
+	prevNodes := []*topicNode{}
+	for _, l := range levels {
+		if nextNode, ok = node.nodes[l]; !ok {
+			return
+		}
+		prevNodes = append(prevNodes, node)
+		node = nextNode
+	}
+	delete(node.clients, clientID)
+
+	// clear memory
+	for i := len(prevNodes) - 1; i >= 0; i-- {
+		node = prevNodes[i].nodes[levels[i]]
+		if len(node.clients) == 0 && len(node.nodes) == 0 {
+			delete(prevNodes[i].nodes, levels[i])
+		} else {
+			return
+		}
+	}
+}
+
+type topicNode struct {
+	// client with their qos
+	clients map[string]byte
+	nodes   map[string]*topicNode
+}
+
+func newNode() *topicNode {
+	return &topicNode{
+		clients: make(map[string]byte),
+		nodes:   make(map[string]*topicNode),
+	}
+}
+
+func (node *topicNode) addClients(ans map[string]byte) {
+	for client, qos := range node.clients {
+		ans[client] = qos
+	}
+}
+
+type topicLevelCache struct {
+	data *lru.Cache
+}
+
+func newTopicLevelCache(cacheSize int) *topicLevelCache {
+	// here we promise cacheSize greater than 0, so we ignore this error.
+	cache, _ := lru.New(cacheSize)
+	return &topicLevelCache{
+		data: cache,
+	}
+}
+
+func (t *topicLevelCache) get(topic string) ([]string, error) {
+	if val, ok := t.data.Get(topic); ok {
+		return val.([]string), nil
+	}
+	levels, valid := splitTopic(topic)
+	if valid {
+		t.data.Add(topic, levels)
+		return levels, nil
+	}
+	return nil, fmt.Errorf("topic %v is invalid", topic)
+}
+
+func (t *topicLevelCache) getAll(topics []string) ([][]string, error) {
+	res := make([][]string, len(topics))
+	for i, topic := range topics {
+		levels, err := t.get(topic)
+		if err != nil {
+			return nil, err
+		}
+		res[i] = levels
+	}
+	return res, nil
+}
+
+func splitTopic(topic string) ([]string, bool) {
+	levels := make([]string, strings.Count(topic, "/")+1)
+	levelsLoc := 0
+
+	levelStart := 0
+	wildCardFlag := false
+	for i, char := range topic {
+		if char == '/' {
+			level := topic[levelStart:i]
+			if len(level) > 1 && wildCardFlag {
+				return nil, false
+			}
+			levels[levelsLoc] = level
+			levelsLoc++
+			levelStart = i + 1
+			wildCardFlag = false
+
+		} else if char == '+' {
+			wildCardFlag = true
+
+		} else if char == '#' {
+			wildCardFlag = true
+			if i != len(topic)-1 {
+				return nil, false
+			}
+		}
+	}
+
+	level := topic[levelStart:]
+	if len(level) > 1 && wildCardFlag {
+		return nil, false
+	}
+	levels[levelsLoc] = level
+	return levels, true
+}


### PR DESCRIPTION
this pr is to make `MQTTProxy` support broker mode by set `brokerMode` true in spec. Original `MQTTProxy` only publish messages to backend `Kafka`. Now, `MQTTProxy` not only publish message to Kafka but also send messages to the subscribed clients directly. 

Main changes:
1. `cachedTopicManager`: it contains topic and mqtt client mapping information from all easegress nodes. 
2. `SessionCacheManager`: it contains all session information for all mqtt clients from all easegress nodes and update `cachedTopicManager`. 
3. `broker`: watch etcd changes and update `SessionCacheManager`.