### PR TITLE
rename `name` label to be more precise.

### DIFF
--- a/pkg/filters/proxy/pool.go
+++ b/pkg/filters/proxy/pool.go
@@ -612,14 +612,14 @@ type (
 // newMetrics create the ProxyMetrics.
 func (sp *ServerPool) newMetrics(name string) *metrics {
 	commonLabels := prometheus.Labels{
-		"name":         name,
+		"proxyName":    name,
 		"kind":         Kind,
 		"clusterName":  sp.proxy.super.Options().ClusterName,
 		"clusterRole":  sp.proxy.super.Options().ClusterRole,
 		"instanceName": sp.proxy.super.Options().Name,
 	}
 	proxyLabels := []string{"clusterName", "clusterRole", "instanceName",
-		"name", "kind", "loadBalancePolicy", "filterPolicy"}
+		"proxyName", "kind", "loadBalancePolicy", "filterPolicy"}
 	return &metrics{
 		TotalConnections: prometheushelper.NewCounter("proxy_total_connections",
 			"the total count of proxy connections",

--- a/pkg/object/httpserver/metrics_test.go
+++ b/pkg/object/httpserver/metrics_test.go
@@ -24,10 +24,10 @@ import (
 
 func newMockMetrics() *metrics {
 	commonLabels := prometheus.Labels{
-		"name": "name",
-		"kind": Kind,
+		"httpserverName": "name",
+		"kind":           Kind,
 	}
-	mockLabels := []string{"name", "kind", "routerKind", "backend"}
+	mockLabels := []string{"httpserverName", "kind", "routerKind", "backend"}
 	return &metrics{
 		Health: prometheushelper.NewGauge("mock_httpserver_health",
 			"show the status for the http server: 1 for ready, 0 for down",

--- a/pkg/object/httpserver/metrics_test.go
+++ b/pkg/object/httpserver/metrics_test.go
@@ -24,10 +24,10 @@ import (
 
 func newMockMetrics() *metrics {
 	commonLabels := prometheus.Labels{
-		"httpserverName": "name",
+		"httpServerName": "name",
 		"kind":           Kind,
 	}
-	mockLabels := []string{"httpserverName", "kind", "routerKind", "backend"}
+	mockLabels := []string{"httpServerName", "kind", "routerKind", "backend"}
 	return &metrics{
 		Health: prometheushelper.NewGauge("mock_httpserver_health",
 			"show the status for the http server: 1 for ready, 0 for down",

--- a/pkg/object/httpserver/runtime.go
+++ b/pkg/object/httpserver/runtime.go
@@ -441,14 +441,14 @@ type (
 // newMetrics create the HttpServerMetrics.
 func (r *runtime) newMetrics(name string) *metrics {
 	commonLabels := prometheus.Labels{
-		"name":         name,
-		"kind":         Kind,
-		"clusterName":  r.superSpec.Super().Options().ClusterName,
-		"clusterRole":  r.superSpec.Super().Options().ClusterRole,
-		"instanceName": r.superSpec.Super().Options().Name,
+		"httpserverName": name,
+		"kind":           Kind,
+		"clusterName":    r.superSpec.Super().Options().ClusterName,
+		"clusterRole":    r.superSpec.Super().Options().ClusterRole,
+		"instanceName":   r.superSpec.Super().Options().Name,
 	}
 	httpserverLabels := []string{"clusterName", "clusterRole",
-		"instanceName", "name", "kind", "routerKind", "backend"}
+		"instanceName", "httpserverName", "kind", "routerKind", "backend"}
 	return &metrics{
 		Health: prometheushelper.NewGauge(
 			"httpserver_health",

--- a/pkg/object/httpserver/runtime.go
+++ b/pkg/object/httpserver/runtime.go
@@ -441,14 +441,14 @@ type (
 // newMetrics create the HttpServerMetrics.
 func (r *runtime) newMetrics(name string) *metrics {
 	commonLabels := prometheus.Labels{
-		"httpserverName": name,
+		"httpServerName": name,
 		"kind":           Kind,
 		"clusterName":    r.superSpec.Super().Options().ClusterName,
 		"clusterRole":    r.superSpec.Super().Options().ClusterRole,
 		"instanceName":   r.superSpec.Super().Options().Name,
 	}
 	httpserverLabels := []string{"clusterName", "clusterRole",
-		"instanceName", "httpserverName", "kind", "routerKind", "backend"}
+		"instanceName", "httpServerName", "kind", "routerKind", "backend"}
 	return &metrics{
 		Health: prometheushelper.NewGauge(
 			"httpserver_health",


### PR DESCRIPTION
rename `name` label to `httpserverName` or `proxyName`, to be more precise.