### PR TITLE
bug fix: filter type inference is wrong in wasm.go

### DIFF
--- a/pkg/api/wasm.go
+++ b/pkg/api/wasm.go
@@ -48,7 +48,7 @@ func (s *Server) isFilterExist(pipeline, filter, kind string) bool {
 	}
 
 	for i := range filters {
-		f, _ := filters[i].(map[interface{}]interface{})
+		f, _ := filters[i].(map[string]interface{})
 		if f == nil {
 			continue
 		}


### PR DESCRIPTION
filter type is `map[string]interface{}` not `map[interface{}]interface{}`