### PR TITLE
fix wasm bug

### DIFF
--- a/pkg/api/wasm.go
+++ b/pkg/api/wasm.go
@@ -48,7 +48,7 @@ func (s *Server) isFilterExist(pipeline, filter, kind string) bool {
 	}
 
 	for i := range filters {
-		f, _ := filters[i].(map[interface{}]interface{})
+		f, _ := filters[i].(map[string]interface{})
 		if f == nil {
 			continue
 		}

--- a/pkg/filters/wasmhost/hostfunc.go
+++ b/pkg/filters/wasmhost/hostfunc.go
@@ -52,12 +52,12 @@ func (vm *WasmVM) readDataFromWasm(addr int32) []byte {
 }
 
 func (vm *WasmVM) writeDataToWasm(data []byte) int32 {
-	mem := vm.inst.GetExport(vm.store, wasmMemory).Memory().UnsafeData(vm.store)
-
-	vaddr, e := vm.fnAlloc.Call(vm.store, len(data)+4)
+	vaddr, e := vm.fnAlloc.Call(vm.store, int32(len(data)+4))
 	if e != nil {
 		panic(e)
 	}
+
+	mem := vm.inst.GetExport(vm.store, wasmMemory).Memory().UnsafeData(vm.store)
 	addr := vaddr.(int32)
 
 	binary.LittleEndian.PutUint32(mem[addr:], uint32(len(data)))
@@ -76,12 +76,12 @@ func (vm *WasmVM) readStringFromWasm(addr int32) string {
 
 // a string is serialized as 4 byte length + content + trailing zero
 func (vm *WasmVM) writeStringToWasm(s string) int32 {
-	mem := vm.inst.GetExport(vm.store, wasmMemory).Memory().UnsafeData(vm.store)
-
-	vaddr, e := vm.fnAlloc.Call(vm.store, len(s)+4+1)
+	vaddr, e := vm.fnAlloc.Call(vm.store, int32(len(s)+4+1))
 	if e != nil {
 		panic(e)
 	}
+
+	mem := vm.inst.GetExport(vm.store, wasmMemory).Memory().UnsafeData(vm.store)
 	addr := vaddr.(int32)
 
 	binary.LittleEndian.PutUint32(mem[addr:], uint32(len(s)+1))
@@ -97,11 +97,12 @@ func (vm *WasmVM) writeStringArrayToWasm(strs []string) int32 {
 		size += len(s) + 4 + 1
 	}
 
-	mem := vm.inst.GetExport(vm.store, wasmMemory).Memory().UnsafeData(vm.store)
 	vaddr, e := vm.fnAlloc.Call(vm.store, int32(size))
 	if e != nil {
 		panic(e)
 	}
+
+	mem := vm.inst.GetExport(vm.store, wasmMemory).Memory().UnsafeData(vm.store)
 	addr := vaddr.(int32)
 	pos := int(addr)
 

--- a/pkg/filters/wasmhost/wasmhost.go
+++ b/pkg/filters/wasmhost/wasmhost.go
@@ -362,6 +362,12 @@ func (wh *WasmHost) Handle(ctx *context.Context) (result string) {
 		}
 	}()
 
+	resp, _ := ctx.GetOutputResponse().(*httpprot.Response)
+	if resp == nil {
+		resp, _ = httpprot.NewResponse(nil)
+	}
+	ctx.SetOutputResponse(resp)
+
 	r := vm.Run() // execute wasm code
 	n, ok := r.(int32)
 	if !ok || n < 0 || n > maxWasmResult {


### PR DESCRIPTION
1. filter type is map[string]interface{} not map[interface{}]interface{}
2. init response object
3. call alloc function before reading wasm memory, because wasm memory maybe changes when calling alloc function.