### PR TITLE
fix wasm apply-data command

### DIFF
--- a/cmd/client/command/wasm.go
+++ b/cmd/client/command/wasm.go
@@ -85,9 +85,9 @@ func wasmApplyDataCmd() *cobra.Command {
 		},
 
 		Run: func(cmd *cobra.Command, args []string) {
-			visitor := buildSpecVisitor(specFile, cmd)
-			visitor.Visit(func(s *spec) error {
-				handleRequest(http.MethodPost, makeURL(objectsURL), []byte(s.doc), cmd)
+			visitor := buildYAMLVisitor(specFile, cmd)
+			visitor.Visit(func(yamlDoc []byte) error {
+				handleRequest(http.MethodPut, makeURL(wasmDataURL, args[0], args[1]), yamlDoc, cmd)
 				return nil
 			})
 			visitor.Close()

--- a/doc/cookbook/flash-sale.md
+++ b/doc/cookbook/flash-sale.md
@@ -18,7 +18,7 @@ A flash sale is a discount or promotion offered by an eCommerce store for a shor
 
 However, significant discounts, limited quantity, and a short period leading to a significant high traffic spike, which often results in slow service, denial of service, or even downtime.
 
-This document illustrates how to leverage the [WasmHost Filter](https://github.com/megaease/easegress/blob/main/doc/cookbook/wasm.md) to protect the backend service in a flash sale. The WebAssembly code is written in [AssemblyScript](https://www.assemblyscript.org/) by using the [Easegress AssemblyScript SDK](https://github.com/megaease/easegress-assemblyscript-sdk).
+This document illustrates how to leverage the [WasmHost Filter](https://github.com/megaease/easegress/blob/main/doc/reference/wasmhost.md) to protect the backend service in a flash sale. The WebAssembly code is written in [AssemblyScript](https://www.assemblyscript.org/) by using the [Easegress AssemblyScript SDK](https://github.com/megaease/easegress-assemblyscript-sdk).
 
 Before we start, we need to introduce why we use a service gateway with WebAssembly.  Firstly, Easegress as a service gateway is more responsible for the control logic. Secondly, the business logic like the flash sale would be a more customized thing and could be changed frequently.  Using Javascript or other high-level languages to write business logic could bring good productivity and lower technical barriers. With WebAssembly technology, the high-level languages code can be compiled to WASM and loaded dynamically at runtime. Furthermore, the WebAssembly code has good enough performance and security. So this combination can provide a perfect solution in terms of security, high performance, and customization extensions.
 

--- a/doc/cookbook/flash-sale.md
+++ b/doc/cookbook/flash-sale.md
@@ -421,8 +421,8 @@ filters:
     kind: WasmHost
     parameters:                                        # +
       startTime: "2021-08-08T00:00:00+00:00"           # +
-      blockRatio: 0.4                                  # +
-      maxPermission: 3                                 # +
+      blockRatio: "0.4"                                # +
+      maxPermission: "3"                               # +
 ```
 
 And then revise the `constructor` of the program to read in these parameters:

--- a/doc/cookbook/flash-sale.md
+++ b/doc/cookbook/flash-sale.md
@@ -18,7 +18,7 @@ A flash sale is a discount or promotion offered by an eCommerce store for a shor
 
 However, significant discounts, limited quantity, and a short period leading to a significant high traffic spike, which often results in slow service, denial of service, or even downtime.
 
-This document illustrates how to leverage the [WasmHost Filter](https://github.com/megaease/easegress/blob/main/doc/wasmhost.md) to protect the backend service in a flash sale. The WebAssembly code is written in [AssemblyScript](https://www.assemblyscript.org/) by using the [Easegress AssemblyScript SDK](https://github.com/megaease/easegress-assemblyscript-sdk).
+This document illustrates how to leverage the [WasmHost Filter](https://github.com/megaease/easegress/blob/main/doc/cookbook/wasm.md) to protect the backend service in a flash sale. The WebAssembly code is written in [AssemblyScript](https://www.assemblyscript.org/) by using the [Easegress AssemblyScript SDK](https://github.com/megaease/easegress-assemblyscript-sdk).
 
 Before we start, we need to introduce why we use a service gateway with WebAssembly.  Firstly, Easegress as a service gateway is more responsible for the control logic. Secondly, the business logic like the flash sale would be a more customized thing and could be changed frequently.  Using Javascript or other high-level languages to write business logic could bring good productivity and lower technical barriers. With WebAssembly technology, the high-level languages code can be compiled to WASM and loaded dynamically at runtime. Furthermore, the WebAssembly code has good enough performance and security. So this combination can provide a perfect solution in terms of security, high performance, and customization extensions.
 

--- a/doc/cookbook/security.md
+++ b/doc/cookbook/security.md
@@ -300,8 +300,8 @@ filters:
 
 1. https://en.wikipedia.org/wiki/JSON_Web_Token
 2. https://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html
-3. https://github.com/megaease/easegress/blob/main/doc/filters.md#signerliteral
+3. https://github.com/megaease/easegress/blob/main/doc/reference/filters.md#signerliteral
 4. https://oauth.net/2/
-5. https://github.com/megaease/easegress/blob/main/doc/filters.md#validatorOAuth2JWT
+5. https://github.com/megaease/easegress/blob/main/doc/reference/filters.md#validatoroauth2jwt
 6. https://en.wikipedia.org/wiki/Basic_access_authentication
 7. https://manpages.debian.org/testing/apache2-utils/htpasswd.1.en.html

--- a/doc/reference/filters.md
+++ b/doc/reference/filters.md
@@ -1524,19 +1524,18 @@ The relationship between `methods` and `url` is `AND`.
 
 ### basicAuth.LDAPSpec
 
-| Name         | Type   | Description                                                                                                                                           | Required |
-|--------------|--------|------------------------------------------------------------------------------------------------------------------------------------------------------|----------|
-| host         | string | The host of the LDAP server      | Yes      |
-| port         | int    | The port of the LDAP server      | Yes      |
-| baseDN       | string | The base dn of the LDAP server, e.g. `ou=users,dc=example,dc=org`                                                    | Yes      |
-| uid          | string | The user attribute used to bind user, e.g. `cn`                                                       | Yes      |
-| useSSL       | bool   | Whether to use SSL               | No       |
-| skipTLS      | bool   | Whether to skip `StartTLS`       | No       |
-| insecure     | bool   | Whether to skip verifying LDAP server's
-	certificate chain and host name                          | No       |
-| serverName   | string | Server name used to verify certificate when `insecure` is `false`                                                    | No       |
-| certBase64   | string | Base64 encoded certificate       | No       |
-| keyBase64    | string | Base64 encoded key               | No       |
+| Name         | Type   | Description                                                             | Required |
+|--------------|--------|-------------------------------------------------------------------------|----------|
+| host         | string | The host of the LDAP server                                             | Yes      |
+| port         | int    | The port of the LDAP server                                             | Yes      |
+| baseDN       | string | The base dn of the LDAP server, e.g. `ou=users,dc=example,dc=org`       | Yes      |
+| uid          | string | The user attribute used to bind user, e.g. `cn`                         | Yes      |
+| useSSL       | bool   | Whether to use SSL                                                      | No       |
+| skipTLS      | bool   | Whether to skip `StartTLS`                                              | No       |
+| insecure     | bool   | Whether to skip verifying LDAP server's certificate chain and host name | No       |
+| serverName   | string | Server name used to verify certificate when `insecure` is `false`       | No       |
+| certBase64   | string | Base64 encoded certificate                                              | No       |
+| keyBase64    | string | Base64 encoded key                                                      | No       |
 
 ### signer.Spec
 
@@ -1553,10 +1552,11 @@ The relationship between `methods` and `url` is `AND`.
 
 ### signer.HeaderHoisting
 
-| Name | Type | Description | Required |
-| allowedPrefix | []string | Allowed prefix for headers | No |
-| disallowedPrefix | []string | Disallowed prefix for headers | No |
-| disallowed | []string | Disallowed headers | No |
+| Name             | Type     | Description                   | Required |
+|------------------|----------|-------------------------------|----------|
+| allowedPrefix    | []string | Allowed prefix for headers    | No       |
+| disallowedPrefix | []string | Disallowed prefix for headers | No       |
+| disallowed       | []string | Disallowed headers            | No       |
 
 ### signer.Literal
 


### PR DESCRIPTION
fixes #938 and some doc issues

Changes in wasm `apply-data` command:
1. use [YAMLVisitor](https://github.com/megaease/easegress/blob/main/cmd/client/command/visitor.go#L126) instead of SpecVisitor
2. use [wasmApplyData](https://github.com/megaease/easegress/blob/main/pkg/api/wasm.go#L159) handler instead of [createObject](https://github.com/megaease/easegress/blob/main/pkg/api/object.go#L51) handler