### PR TITLE
Roll rorate log

### DIFF
--- a/doc/reference/controllers.md
+++ b/doc/reference/controllers.md
@@ -6,6 +6,7 @@
     - [TrafficController](#trafficcontroller)
     - [RawConfigTrafficController](#rawconfigtrafficcontroller)
       - [HTTPServer](#httpserver)
+      - [gRPCServer](#grpc-service-proxy)
     - [AccessLogVariable](#accesslogvariable)
       - [Pipeline](#pipeline)
     - [StatusSyncController](#statussynccontroller)
@@ -117,6 +118,41 @@ rules:
 | caCertBase64     | string                             | Define the root certificate authorities that servers use if required to verify a client certificate by the policy in TLS Client Authentication. | No |
 | globalFilter     | string                             | Name of [GlobalFilter](#globalfilter) for all backends                                   | No                   |
 | accessLogFormat | string | Format of access log, default is `[{{Time}}] [{{RemoteAddr}} {{RealIP}} {{Method}} {{URI}} {{Proto}} {{StatusCode}}] [{{Duration}} rx:{{ReqSize}}B tx:{{RespSize}}B] [{{Tags}}]`, variable is delimited by "{{" and "}}", please refer [Access Log Variable](#accesslogvariable) for all built-in variables | No |
+
+#### gRPC Service Proxy
+
+Easegress gRPC servers is a proxy server base on gRPC protocol.
+
+##### Simple Proxy Configuration
+Below is one of the simplest gRPC Proxy Server, and it will listen on port `8080` and handle the requests that includes kv `content-type:application/grpc` in headers by use backend `pipeline-grpc-forward`
+``` yaml
+kind: GRPCServer
+port: 8080
+name: server-grpc
+#路由规则
+rules:
+  - methods:
+      - backend: pipeline-grpc
+        headers:
+          - key: "Content-Type"
+            values: 
+             - "application/grpc"
+xForwardedFor: true
+```
+
+##### Configuration
+The below parameters will help manage connections better
+
+| Name | Type | Description | Required |
+|------|------|-------------|----------|
+| maxConnections | uint32 | The maximum number of connections allowed by gRPC Server , default value 10240, min is 1 | No |
+| minTimeClientSendPing | duration | The minimum amount of time a client should wait before sending a keepalive ping, default value is 5 minutes | No |
+| permitClintSendPingWithoutStream | duration | If true, server allows keepalive pings even when there are no active streams(RPCs). If false, and client sends ping when there are no active streams, server will send GOAWAY and close the connection. default false | No |
+| maxConnectionIdle | duration | A duration for the amount of time after which an idle connection would be closed by sending a GoAway. Idleness duration is defined since the most recent time the number of outstanding RPCs became zero or the connection establishment. default value is infinity | No |
+| maxConnectionAge | duration | A duration for the maximum amount of time a connection may exist before it will be closed by sending a GoAway. A random jitter of ±10% will be added to MaxConnectionAge to prevent connection storms. default value is infinity | No |
+| maxConnectionAgeGrace | duration | An additive period after MaxConnectionAge after which the connection will be forcibly closed. default value is infinity | No |
+| keepaliveTime | duration | After a duration of this time if the server doesn't see any activity it pings the client to see if the transport is still alive. If set below 1s, a minimum value of 1s will be used instead. default value is 2 hours. | No |
+| keepaliveTimeout | duration | After having pinged for keepalive check, the server waits for a duration of Timeout and if no activity is seen even after that the connection is closed. default value is 20 seconds |No |
 
 ### AccessLogVariable
 
@@ -292,44 +328,6 @@ data:
 | filters    | []map[string]interface{}         | Defines filters, please refer [Filters](filters.md) for details of a specific filter kind.     | Yes |
 | resilience | []map[string]interface{}         | Defines resilience policies, please refer [Resilience Policy](#resiliencepolicy) for details of a specific resilience policy.    | No |
 | data       | map[string]interface{}           | Static user data of the pipeline.         | No  |
-
-
-### gRRC Service Proxy
-
-Easegress gRPC servers is a proxy server base on gRPC protocol.
-
-#### Simple Proxy Configuration
-Below is one of the simplest gRPC Proxy Server, and it will listen on port `8080` and handle the requests that includes kv `content-type:application/grpc` in headers by use backend `pipeline-grpc-forward`
-``` yaml
-kind: GRPCServer
-port: 8080
-name: server-grpc
-#路由规则
-rules:
-  - methods:
-      - backend: pipeline-grpc
-        headers:
-          - key: "Content-Type"
-            values: 
-             - "application/grpc"
-xForwardedFor: true
-```
-
-#### Configuration
-The below parameters will help manage connections better
-
-| Name | Type | Description | Required |
-|------|------|-------------|----------|
-| maxConnections | uint32 | The maximum number of connections allowed by gRPC Server , default value 10240, min is 1 | No |
-| minTimeClientSendPing | duration | The minimum amount of time a client should wait before sending a keepalive ping, default value is 5 minutes | No |
-| permitClintSendPingWithoutStream | duration | If true, server allows keepalive pings even when there are no active streams(RPCs). If false, and client sends ping when there are no active streams, server will send GOAWAY and close the connection. default false | No |
-| maxConnectionIdle | duration | A duration for the amount of time after which an idle connection would be closed by sending a GoAway. Idleness duration is defined since the most recent time the number of outstanding RPCs became zero or the connection establishment. default value is infinity | No |
-| maxConnectionAge | duration | A duration for the maximum amount of time a connection may exist before it will be closed by sending a GoAway. A random jitter of ±10% will be added to MaxConnectionAge to prevent connection storms. default value is infinity | No |
-| maxConnectionAgeGrace | duration | An additive period after MaxConnectionAge after which the connection will be forcibly closed. default value is infinity | No |
-| keepaliveTime | duration | After a duration of this time if the server doesn't see any activity it pings the client to see if the transport is still alive. If set below 1s, a minimum value of 1s will be used instead. default value is 2 hours. | No |
-| keepaliveTimeout | duration | After having pinged for keepalive check, the server waits for a duration of Timeout and if no activity is seen even after that the connection is closed. default value is 20 seconds |No |
-
-
 
 ### StatusSyncController
 

--- a/doc/reference/log.md
+++ b/doc/reference/log.md
@@ -1,5 +1,147 @@
 # Log
 
-Now, easgress support rotating log files like `logrotate`.
-If startup `easegress-server` with `--log-dir` param specified, it will use the following configuration to manage the log files.
+- [Default Configuration](#default-configuration)
+- [Basic Log Spec](#basic-log-spec)
+- [Custom Log Configuration](#custom-log-configuration)
 
+Now, easgress support rotating log files like `logrotate`.
+If startup `easegress-server` with `--log-dir={log-path}` param specified and without `-log-config`, it will use the default configuration to manage the log files.
+
+## Default Configuration
+| Name | Type | Description | Required  |
+|------- |--------|-------------|-----|
+| stdLog | [LogSpec](#BasicLogSpec) | The log configruation for `logger.Debugf`,`logger.Infof`,`logger.LazyDebug`,`logger.Warnf` ,`logger.Errorf` | no |
+| accessLog| [LogSpec](#BasicLogSpec) | The log configruation for `logger.HTTPAccess`,`logger.LazyHTTPAccess` | no |
+| dumpLog | [LogSpec](#BasicLogSpec) | The log configruation for dumping some snapshot | no |
+| adminAPLog | [LogSpec](#BasicLogSpec) | The log configuration for `logger.APIAccess` | no |
+| etcdServerLog | [LogSpec](#BasicLogSpec) | The log configuration for embed etcd-server | no |
+| etcdClientLog | [LogSpec](#BasicLogSpec) | The log configuration for embed etcd-client and EtcdServiceRegistry | no |
+| oTel | [LogSpec](#BasicLogSpec) | The log configuration for opentelemetry otel | no |
+
+```
+		StdLog: &Spec{
+			FileName:   "stdout.log",
+			MaxSize:    128,
+			MaxAge:     30,
+			MaxBackups: 60,
+			LocalTime:  true,
+			Compress:   true,
+		},
+		Access: &Spec{
+			FileName:   "filter_http_access.log",
+			MaxSize:    128,
+			MaxAge:     30,
+			MaxBackups: 60,
+			LocalTime:  true,
+			Compress:   true,
+		},
+		Dump: &Spec{
+			FileName:   "filter_http_dump.log",
+			MaxSize:    128,
+			MaxAge:     30,
+			MaxBackups: 60,
+			LocalTime:  true,
+			Compress:   true,
+		},
+		AdminAPI: &Spec{
+			FileName:   "admin-api.log",
+			MaxSize:    128,
+			MaxAge:     30,
+			MaxBackups: 60,
+			LocalTime:  true,
+			Compress:   true,
+		},
+		EtcdServer: &Spec{
+			FileName:   "etcd-server.log",
+			MaxSize:    128,
+			MaxAge:     30,
+			MaxBackups: 60,
+			LocalTime:  true,
+			Compress:   true,
+		},
+		EtcdClient: &Spec{
+			FileName:   "etcd-client.log",
+			MaxSize:    128,
+			MaxAge:     30,
+			MaxBackups: 60,
+			LocalTime:  true,
+			Compress:   true,
+		},
+		OTel: &Spec{
+			FileName:   "otel.log",
+			MaxSize:    128,
+			MaxAge:     30,
+			MaxBackups: 60,
+			LocalTime:  true,
+			Compress:   true,
+		},
+```
+
+## Basic Log Spec
+| Name | Type | Description | Required |
+|-----|-----|----|----|
+| fileName | string | The name of Log File | yes |
+| maxSize | int | The maximum size in megabytes of the log file before it gets rotated. It defaults to 100 megabytes | no |
+| maxAge | int | The maximum number of days to retain old log files based on the timestamp encoded in their filename.  Note that a day is defined as 24 hours and may not exactly correspond to calendar days due to daylight savings, leap seconds, etc. The default is not to remove old log files based on age | no |
+| maxBackups | int | The maximum number of old log files to retain, and backup log files will be retained in the same directory. The default is to retain all old log files (though MaxAge may still cause them to get deleted.) | no |
+| localTime | bool | It determines if the time used for formatting the timestamps in backup files is the computer's local time. The default is to use UTC time | no |
+| compress | bool | It determines if the rotated log files should be compressed using gzip. The default is not to perform compression | no |
+| perm | string | It defines a file's access permissions. default '0o644' |no|
+
+## Custom Log Configuration
+Startup `easegress-server` with `--log-dir={log-path}` and `--log-config={log-config-file-path}` param specified.
+
+Below is an example of the configuration file content
+```
+stdLog:
+   fileName: masa-bigress.log
+   maxSize: 256
+   maxAge: 30
+   maxBackups: 60
+   localtime: true
+   compress: true
+   perm: "0600"
+accessLog:
+   fileName: access.log
+   maxSize: 256
+   maxAge: 30
+   maxBackups: 60
+   localtime: true
+   compress: true
+   perm: "0o640"
+dumpLog:
+   fileName: dump.log
+   maxSize: 256
+   maxAge: 30
+   maxBackups: 60
+   localtime: true
+   compress: true
+adminAPLog:
+   fileName: admin-api.log
+   maxSize: 256
+   maxAge: 30
+   maxBackups: 60
+   localtime: true
+   compress: true
+etcdServerLog:
+   fileName: etcd-server.log
+   maxSize: 256
+   maxAge: 30
+   maxBackups: 60
+   localtime: true
+   compress: true
+etcdClientLog:
+   fileName: etcd-client.log
+   maxSize: 256
+   maxAge: 30
+   maxBackups: 60
+   localtime: true
+   compress: true
+oTel:
+   fileName: otel.log
+   maxSize: 256
+   maxAge: 30
+   maxBackups: 60
+   localtime: true
+   compress: true
+```

--- a/doc/reference/log.md
+++ b/doc/reference/log.md
@@ -1,0 +1,5 @@
+# Log
+
+Now, easgress support rotating log files like `logrotate`.
+If startup `easegress-server` with `--log-dir` param specified, it will use the following configuration to manage the log files.
+

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/ArthurHlt/go-eureka-client v1.1.0
 	github.com/MicahParks/keyfunc v1.9.0
 	github.com/Shopify/sarama v1.38.1
+	github.com/agiledragon/gomonkey/v2 v2.10.1
 	github.com/bytecodealliance/wasmtime-go v1.0.0
 	github.com/eclipse/paho.mqtt.golang v1.4.2
 	github.com/fatih/color v1.15.0
@@ -46,6 +47,7 @@ require (
 	github.com/quic-go/quic-go v0.36.1
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
 	github.com/rs/cors v1.9.0
+	github.com/smartystreets/goconvey v1.6.4
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.16.0
@@ -93,8 +95,10 @@ require (
 	github.com/emicklei/go-restful/v3 v3.10.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/pprof v0.0.0-20230228050547-1710fef4ab10 // indirect
+	github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.2 // indirect
 	github.com/huandu/xstrings v1.3.2 // indirect
+	github.com/jtolds/gls v4.20.0+incompatible // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/onsi/ginkgo/v2 v2.9.5 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
@@ -103,6 +107,7 @@ require (
 	github.com/quic-go/qpack v0.4.0 // indirect
 	github.com/quic-go/qtls-go1-19 v0.3.2 // indirect
 	github.com/quic-go/qtls-go1-20 v0.2.2 // indirect
+	github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d // indirect
 	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/tchap/go-patricia/v2 v2.3.1 // indirect
 	github.com/vultr/govultr/v3 v3.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/OneOfOne/xxhash v1.2.8/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdII
 github.com/Shopify/sarama v1.38.1 h1:lqqPUPQZ7zPqYlWpTh+LQ9bhYNu2xJL6k1SJN4WVe2A=
 github.com/Shopify/sarama v1.38.1/go.mod h1:iwv9a67Ha8VNa+TifujYoWGxWnu2kNVAQdSdZ4X2o5g=
 github.com/Shopify/toxiproxy/v2 v2.5.0 h1:i4LPT+qrSlKNtQf5QliVjdP08GyAH8+BUIc9gT0eahc=
+github.com/agiledragon/gomonkey/v2 v2.10.1 h1:FPJJNykD1957cZlGhr9X0zjr291/lbazoZ/dmc4mS4c=
+github.com/agiledragon/gomonkey/v2 v2.10.1/go.mod h1:ap1AmDzcVOAz1YpeJ3TCzIgstoaWLA6jbbgxfB4w2iY=
 github.com/agnivade/levenshtein v1.1.1 h1:QY8M92nrzkmr798gCo3kmMyqXFzdQVpxLlGPRBij0P8=
 github.com/agnivade/levenshtein v1.1.1/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVbJomOvKkmgYbo=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -396,6 +398,7 @@ github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
@@ -509,6 +512,7 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtblin/go-ldap-client v0.0.0-20170223121919-b73f66626b33 h1:XDpFOMOZq0u0Ar4F0p/wklqQXp/AMV1pTF5T5bDoUfQ=
 github.com/jtblin/go-ldap-client v0.0.0-20170223121919-b73f66626b33/go.mod h1:+0BcLY5d54TVv6irFzHoiFvwAHR6T0g9B+by/UaS9T0=
+github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
@@ -724,8 +728,11 @@ github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrf
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
+github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
+github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.5 h1:jjzc5WVemNEDTLwv9tlmemhC73tI08BNOIGwBOo10Js=
 github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -336,7 +336,7 @@ func (c *cluster) getClient() (*clientv3.Client, error) {
 		DialTimeout:          dialTimeout,
 		DialKeepAliveTime:    dialKeepAliveTime,
 		DialKeepAliveTimeout: dialKeepAliveTimeout,
-		LogConfig:            logger.EtcdClientLoggerConfig(c.opt, logger.EtcdClientFilename),
+		Logger:               logger.DefaultEtcdClientLogger(c.opt),
 		MaxCallSendMsgSize:   c.opt.Cluster.MaxCallSendMsgSize,
 	})
 	if err != nil {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -336,7 +336,7 @@ func (c *cluster) getClient() (*clientv3.Client, error) {
 		DialTimeout:          dialTimeout,
 		DialKeepAliveTime:    dialKeepAliveTime,
 		DialKeepAliveTimeout: dialKeepAliveTimeout,
-		Logger:               logger.DefaultEtcdClientLogger(c.opt),
+		Logger:               logger.DefaultEtcdClientLogger(),
 		MaxCallSendMsgSize:   c.opt.Cluster.MaxCallSendMsgSize,
 	})
 	if err != nil {

--- a/pkg/cluster/config.go
+++ b/pkg/cluster/config.go
@@ -18,12 +18,9 @@
 package cluster
 
 import (
-	"net/url"
-	"path/filepath"
-
 	"go.etcd.io/etcd/server/v3/embed"
+	"net/url"
 
-	"github.com/megaease/easegress/pkg/common"
 	"github.com/megaease/easegress/pkg/logger"
 	"github.com/megaease/easegress/pkg/option"
 )
@@ -95,11 +92,7 @@ func CreateStaticClusterEtcdConfig(opt *option.Options) (*embed.Config, error) {
 	ec.MaxRequestBytes = maxRequestBytes
 	ec.SnapshotCount = snapshotCount
 	ec.Logger = "zap"
-
-	ec.LogOutputs = []string{"stdout"}
-	if opt.AbsLogDir != "" {
-		ec.LogOutputs = []string{common.NormalizeZapLogPath(filepath.Join(opt.AbsLogDir, logFilename))}
-	}
+	ec.ZapLoggerBuilder = embed.NewZapLoggerBuilder(logger.DefaultEtcdServerLogger(opt))
 
 	ec.ClusterState = embed.ClusterStateFlagNew
 	if opt.Cluster.StateFlag == "existing" {

--- a/pkg/cluster/config.go
+++ b/pkg/cluster/config.go
@@ -92,7 +92,7 @@ func CreateStaticClusterEtcdConfig(opt *option.Options) (*embed.Config, error) {
 	ec.MaxRequestBytes = maxRequestBytes
 	ec.SnapshotCount = snapshotCount
 	ec.Logger = "zap"
-	ec.ZapLoggerBuilder = embed.NewZapLoggerBuilder(logger.DefaultEtcdServerLogger(opt))
+	ec.ZapLoggerBuilder = embed.NewZapLoggerBuilder(logger.DefaultEtcdServerLogger())
 
 	ec.ClusterState = embed.ClusterStateFlagNew
 	if opt.Cluster.StateFlag == "existing" {

--- a/pkg/logger/logfile.go
+++ b/pkg/logger/logfile.go
@@ -34,6 +34,7 @@ type (
 	// 1. Reopen the file after receiving SIGHUP, for log rotate.
 	// 2. Reduce execution time of callers by asynchronous log(return after only memory copy).
 	// 3. Batch write logs by cache them with timeout.
+	// 4. Before the process shutdown, try to commit the current contents of the file to stable storage
 	LogFile struct {
 		logger *Logger
 

--- a/pkg/logger/logfile_test.go
+++ b/pkg/logger/logfile_test.go
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2017, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package logger
+
+import (
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestLogFileWrite(t *testing.T) {
+	dir := makeTempDir("TestLogFileWrite", t)
+	path := logFilePath(dir)
+	defer os.RemoveAll(dir)
+
+	file, err := NewLogFile(&Spec{
+		FileName: path,
+	}, 1024)
+	at := assert.New(t)
+	at.NoError(err)
+	b := []byte("TestLogFileWrite")
+	written, err := file.Write(b)
+	at.NoError(err)
+	at.Equal(written, len(b))
+	// wait timer flush
+	time.Sleep(2 * cacheTimeout)
+	existsWithContent(path, b, t)
+}
+
+func TestLogFileClose(t *testing.T) {
+	dir := makeTempDir("TestLogFileClose", t)
+	path := logFilePath(dir)
+	defer os.RemoveAll(dir)
+
+	file, _ := NewLogFile(&Spec{
+		FileName: path,
+	}, 0)
+	at := assert.New(t)
+	b := []byte("TestLogFileClose")
+	file.Write(b)
+
+	file.Close()
+	existsWithContent(path, b, t)
+	_, ok := <-file.eventChan
+
+	at.False(ok)
+}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -102,7 +102,7 @@ type LogsSpec struct {
 	EtcdServer *Spec `json:"etcdServerLog" jsonschema:"omitempty"`
 	// EtcdClient is the file to write logs of etcd client to.
 	EtcdClient *Spec `json:"etcdClientLog" jsonschema:"omitempty"`
-	// OTel is the file to write logs of etcd client to.
+	// OTel is the file to write logs of opentelemetry otel.
 	OTel *Spec `json:"oTel" jsonschema:"omitempty"`
 }
 
@@ -147,7 +147,7 @@ var (
 			Compress:   true,
 		},
 		EtcdServer: &Spec{
-			FileName:   "etcd-server-eg.log",
+			FileName:   "etcd-server.log",
 			MaxSize:    128,
 			MaxAge:     30,
 			MaxBackups: 60,
@@ -187,9 +187,12 @@ func DefaultEtcdServerLogger(opt *option.Options) *zap.Logger {
 	if err != nil {
 		panic(err)
 	}
+
+	opts := []zap.Option{zap.AddCaller()}
+
 	syncer := zapcore.AddSync(gressLF)
 	core := zapcore.NewCore(zapcore.NewConsoleEncoder(encoderConfig), syncer, level)
-	return zap.New(core)
+	return zap.New(core, opts...)
 }
 
 // DefaultEtcdClientLogger generates default etcd client logger.
@@ -224,9 +227,12 @@ func etcdClientLogger(opt *option.Options, spec *Spec) *zap.Logger {
 	if err != nil {
 		panic(err)
 	}
+
+	opts := []zap.Option{zap.AddCaller()}
+
 	syncer := zapcore.AddSync(gressLF)
 	core := zapcore.NewCore(zapcore.NewConsoleEncoder(encoderConfig), syncer, level)
-	return zap.New(core)
+	return zap.New(core, opts...)
 }
 
 func defaultEncoderConfig() zapcore.EncoderConfig {

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -202,7 +202,7 @@ func initEtcdServer(opt *option.Options) {
 
 	syncer := zapcore.AddSync(gressLF)
 	core := zapcore.NewCore(zapcore.NewConsoleEncoder(encoderConfig), syncer, level)
-	etcdClientLogger = zap.New(core, opts...)
+	etcdServerLogger = zap.New(core, opts...)
 }
 
 // DefaultEtcdClientLogger generates default etcd client logger.

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/megaease/easegress/pkg/env"
 	"github.com/megaease/easegress/pkg/option"
+	"github.com/stretchr/testify/assert"
 	"os"
 	"path"
 	"testing"
@@ -52,6 +53,8 @@ stdLog:
 		convey.So(env.InitServerDir(options), convey.ShouldBeNil)
 
 		convey.So(func() { Init(options) }, convey.ShouldNotPanic)
+		// reset the loggers
+		defer InitNop()
 
 		convey.So(defaultLogsConfig.StdLog.MaxSize, convey.ShouldEqual, 1)
 		convey.So(defaultLogsConfig.StdLog.Perm, convey.ShouldEqual, "0600")
@@ -59,8 +62,15 @@ stdLog:
 
 		convey.So(defaultLogger, convey.ShouldNotBeNil)
 		convey.So(etcdClientLogger, convey.ShouldNotBeNil)
+		convey.So(CustomerEtcdClientLogger(options, "test-unit"), convey.ShouldNotBeNil)
 
 		fileCount(path.Join(dir, "logs"), 0, t)
 	})
 
+}
+
+func TestInitMockAndMock(t *testing.T) {
+	at := assert.New(t)
+	at.NotPanics(InitMock)
+	at.NotPanics(InitNop)
 }

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2017, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package logger
+
+import (
+	"github.com/megaease/easegress/pkg/util/codectool"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestUnmarshal(t *testing.T) {
+	y := `
+stdLog:
+  fileName: std.log
+  maxSize: 1
+  maxBackups: 2
+  perm: "0600"
+`
+	codectool.MustUnmarshal([]byte(y), defaultLogsConfig)
+
+	at := assert.New(t)
+	at.Equal("std.log", defaultLogsConfig.StdLog.FileName)
+	at.Equal("0600", defaultLogsConfig.StdLog.Perm)
+	at.Equal(1, defaultLogsConfig.StdLog.MaxSize)
+
+	at.NotNil(defaultLogsConfig.EtcdServer)
+	at.NotNil(defaultLogsConfig.Access)
+	at.NotNil(defaultLogsConfig.Dump)
+	at.NotNil(defaultLogsConfig.AdminAPI)
+	at.NotNil(defaultLogsConfig.OTel)
+	at.NotNil(defaultLogsConfig.EtcdClient)
+}

--- a/pkg/logger/lumberjack.go
+++ b/pkg/logger/lumberjack.go
@@ -91,7 +91,7 @@ type (
 		// using gzip. The default is not to perform compression.
 		Compress bool `json:"compress" jsonschema:"omitempty"`
 
-		// File represents a file's mode and permission bits. default 0644/0o644
+		// Perm represents a file's mode and permission bits. default 0644/0o644
 		Perm string `json:"perm" jsonschema:"omitempty"`
 	}
 )

--- a/pkg/logger/lumberjack.go
+++ b/pkg/logger/lumberjack.go
@@ -1,0 +1,552 @@
+/*
+ * Copyright (c) 2017, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package logger
+
+import (
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"github.com/megaease/easegress/pkg/util/stringtool"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+const (
+	backupTimeFormat = "2006-01-02T15-04-05.000"
+	compressSuffix   = ".gz"
+	defaultMaxSize   = 100
+	defaultFileMode  = os.FileMode(0o644)
+)
+
+// ensure we always implement io.WriteCloser
+var _ io.WriteCloser = (*Logger)(nil)
+
+type (
+	// Logger is base on lumberjack.Logger v2.2.1 with minor modifications.
+	Logger struct {
+		spec       *Spec
+		perm       os.FileMode
+		closeEvent chan struct{}
+
+		size int64
+		file *os.File
+		mu   sync.Mutex
+
+		millCh    chan bool
+		startMill sync.Once
+	}
+
+	Spec struct {
+		// FileName is the file to write logs to.  Backup log files will be retained
+		// in the same directory.  It uses <processname>-lumberjack.log in
+		// os.TempDir() if empty.
+		FileName string `json:"fileName" jsonschema:"required"`
+
+		// MaxSize is the maximum size in megabytes of the log file before it gets
+		// rotated. It defaults to 100 megabytes.
+		MaxSize int `json:"maxSize" jsonschema:"omitempty"`
+
+		// MaxAge is the maximum number of days to retain old log files based on the
+		// timestamp encoded in their filename.  Note that a day is defined as 24
+		// hours and may not exactly correspond to calendar days due to daylight
+		// savings, leap seconds, etc. The default is not to remove old log files
+		// based on age.
+		MaxAge int `json:"maxAge" jsonschema:"omitempty"`
+
+		// MaxBackups is the maximum number of old log files to retain.  The default
+		// is to retain all old log files (though MaxAge may still cause them to get
+		// deleted.)
+		MaxBackups int `json:"maxBackups" jsonschema:"omitempty"`
+
+		// LocalTime determines if the time used for formatting the timestamps in
+		// backup files is the computer's local time.  The default is to use UTC
+		// time.
+		LocalTime bool `json:"localTime" jsonschema:"omitempty"`
+
+		// Compress determines if the rotated log files should be compressed
+		// using gzip. The default is not to perform compression.
+		Compress bool `json:"compress" jsonschema:"omitempty"`
+
+		// File represents a file's mode and permission bits. default 0644/0o644
+		Perm string `json:"perm" jsonschema:"omitempty"`
+	}
+)
+
+var (
+	// currentTime exists so it can be mocked out by tests.
+	currentTime = time.Now
+
+	// os_Stat exists so it can be mocked out by tests.
+	osStat = os.Stat
+
+	// megabyte is the conversion factor between MaxSize and bytes.  It is a
+	// variable so tests can mock it out and not need to write megabytes of data
+	// to disk.
+	megabyte = 1024 * 1024
+)
+
+func newLogger(spec *Spec) *Logger {
+	if err := spec.Validate(); err != nil {
+		panic(err)
+	}
+	perm := defaultFileMode
+	if spec.Perm != "" {
+		parse, _ := strconv.ParseUint(spec.Perm, 8, 32)
+		perm = os.FileMode(parse)
+	}
+
+	logger := &Logger{
+		spec:       spec,
+		perm:       perm,
+		closeEvent: make(chan struct{}),
+	}
+
+	signalChan := make(chan os.Signal, 1)
+	signal.Notify(signalChan, syscall.SIGHUP)
+	go func() {
+		for {
+			select {
+			case <-signalChan:
+				stderrLogger.Infof("notify SIGHUP signal and rotate %s file", logger.filename())
+				err := logger.Rotate()
+				if err != nil {
+					stderrLogger.Warnf("log file rotate fail %s", err)
+				}
+			case <-logger.closeEvent:
+				return
+			}
+		}
+	}()
+	return logger
+}
+
+func (s *Spec) Validate() error {
+	if s.Perm != "" {
+		// Look for octal
+		if s.Perm[0] != '0' || (len(s.Perm) >= 3 && (stringtool.LowerChar(s.Perm[1]) == 'b' || stringtool.LowerChar(s.Perm[1]) == 'x')) {
+			return fmt.Errorf("file mode %s invalid, it must be in octal", s.Perm)
+		}
+	}
+	return nil
+}
+
+// Write implements io.Writer.  If a write would cause the log file to be larger
+// than MaxSize, the file is closed, renamed to include a timestamp of the
+// current time, and a new log file is created using the original log file name.
+// If the length of the write is greater than MaxSize, an error is returned.
+func (l *Logger) Write(p []byte) (n int, err error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	writeLen := int64(len(p))
+	if writeLen > l.max() {
+		return 0, fmt.Errorf(
+			"write length %d exceeds maximum file size %d", writeLen, l.max(),
+		)
+	}
+
+	if l.file == nil {
+		if err = l.openExistingOrNew(len(p)); err != nil {
+			return 0, err
+		}
+	}
+
+	if l.size+writeLen > l.max() {
+		if err := l.rotate(); err != nil {
+			return 0, err
+		}
+	}
+
+	n, err = l.file.Write(p)
+	l.size += int64(n)
+
+	return n, err
+}
+
+// Close implements io.Closer, and closes the current logfile.
+func (l *Logger) Close() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	close(l.closeEvent)
+	return l.close()
+}
+
+// close closes the file if it is open.
+func (l *Logger) close() error {
+	if l.file == nil {
+		return nil
+	}
+	err := l.file.Close()
+	l.file = nil
+	return err
+}
+
+// Rotate causes Logger to close the existing log file and immediately create a
+// new one.  This is a helper function for applications that want to initiate
+// rotations outside of the normal rotation rules, such as in response to
+// SIGHUP.  After rotating, this initiates compression and removal of old log
+// files according to the configuration.
+func (l *Logger) Rotate() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.rotate()
+}
+
+// rotate closes the current file, moves it aside with a timestamp in the name,
+// (if it exists), opens a new file with the original filename, and then runs
+// post-rotation processing and removal.
+func (l *Logger) rotate() error {
+	if err := l.close(); err != nil {
+		return err
+	}
+	if err := l.openNew(); err != nil {
+		return err
+	}
+	l.mill()
+	return nil
+}
+
+// openNew opens a new log file for writing, moving any old log file out of the
+// way.  This methods assumes the file has already been closed.
+func (l *Logger) openNew() error {
+	err := os.MkdirAll(l.dir(), 0755)
+	if err != nil {
+		return fmt.Errorf("can't make directories for new logfile: %s", err)
+	}
+
+	name := l.filename()
+	mode := os.FileMode(l.perm)
+	_, err = osStat(name)
+	if err == nil {
+		// move the existing file
+		newName := backupName(name, l.spec.LocalTime)
+		if err := os.Rename(name, newName); err != nil {
+			return fmt.Errorf("can't rename log file: %s", err)
+		}
+	}
+
+	// we use truncate here because this should only get called when we've moved
+	// the file ourselves. if someone else creates the file in the meantime,
+	// just wipe out the contents.
+	f, err := os.OpenFile(name, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return fmt.Errorf("can't open new logfile: %s", err)
+	}
+	l.file = f
+	l.size = 0
+	return nil
+}
+
+// backupName creates a new filename from the given name, inserting a timestamp
+// between the filename and the extension, using the local time if requested
+// (otherwise UTC).
+func backupName(name string, local bool) string {
+	dir := filepath.Dir(name)
+	filename := filepath.Base(name)
+	ext := filepath.Ext(filename)
+	prefix := filename[:len(filename)-len(ext)]
+	t := currentTime()
+	if !local {
+		t = t.UTC()
+	}
+
+	timestamp := t.Format(backupTimeFormat)
+	return filepath.Join(dir, fmt.Sprintf("%s-%s%s", prefix, timestamp, ext))
+}
+
+// openExistingOrNew opens the logfile if it exists and if the current write
+// would not put it over MaxSize.  If there is no such file or the write would
+// put it over the MaxSize, a new file is created.
+func (l *Logger) openExistingOrNew(writeLen int) error {
+	l.mill()
+
+	filename := l.filename()
+	info, err := osStat(filename)
+	if os.IsNotExist(err) {
+		return l.openNew()
+	}
+	if err != nil {
+		return fmt.Errorf("error getting log file info: %s", err)
+	}
+
+	if info.Size()+int64(writeLen) >= l.max() {
+		return l.rotate()
+	}
+
+	file, err := os.OpenFile(filename, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		// if we fail to open the old log file for some reason, just ignore
+		// it and open a new log file.
+		return l.openNew()
+	}
+	l.file = file
+	l.size = info.Size()
+	return nil
+}
+
+// filename generates the name of the logfile from the current time.
+func (l *Logger) filename() string {
+	if l.spec.FileName != "" {
+		return l.spec.FileName
+	}
+	name := filepath.Base(os.Args[0]) + "-lumberjack.log"
+	return filepath.Join(os.TempDir(), name)
+}
+
+// millRunOnce performs compression and removal of stale log files.
+// Log files are compressed if enabled via configuration and old log
+// files are removed, keeping at most l.MaxBackups files, as long as
+// none of them are older than MaxAge.
+func (l *Logger) millRunOnce() error {
+	if l.spec.MaxBackups == 0 && l.spec.MaxAge == 0 && !l.spec.Compress {
+		return nil
+	}
+
+	files, err := l.oldLogFiles()
+	if err != nil {
+		return err
+	}
+
+	var compress, remove []logInfo
+
+	if l.spec.MaxBackups > 0 && l.spec.MaxBackups < len(files) {
+		preserved := make(map[string]bool)
+		var remaining []logInfo
+		for _, f := range files {
+			// Only count the uncompressed log file or the
+			// compressed log file, not both.
+			fn := f.Name()
+			if strings.HasSuffix(fn, compressSuffix) {
+				fn = fn[:len(fn)-len(compressSuffix)]
+			}
+			preserved[fn] = true
+
+			if len(preserved) > l.spec.MaxBackups {
+				remove = append(remove, f)
+			} else {
+				remaining = append(remaining, f)
+			}
+		}
+		files = remaining
+	}
+	if l.spec.MaxAge > 0 {
+		diff := time.Duration(int64(24*time.Hour) * int64(l.spec.MaxAge))
+		cutoff := currentTime().Add(-1 * diff)
+
+		var remaining []logInfo
+		for _, f := range files {
+			if f.timestamp.Before(cutoff) {
+				remove = append(remove, f)
+			} else {
+				remaining = append(remaining, f)
+			}
+		}
+		files = remaining
+	}
+
+	if l.spec.Compress {
+		for _, f := range files {
+			if !strings.HasSuffix(f.Name(), compressSuffix) {
+				compress = append(compress, f)
+			}
+		}
+	}
+
+	for _, f := range remove {
+		errRemove := os.Remove(filepath.Join(l.dir(), f.Name()))
+		if err == nil && errRemove != nil {
+			err = errRemove
+		}
+	}
+	for _, f := range compress {
+		fn := filepath.Join(l.dir(), f.Name())
+		errCompress := compressLogFile(fn, fn+compressSuffix, l.perm)
+		if err == nil && errCompress != nil {
+			err = errCompress
+		}
+	}
+
+	return err
+}
+
+// millRun runs in a goroutine to manage post-rotation compression and removal
+// of old log files.
+func (l *Logger) millRun() {
+	for range l.millCh {
+		// what am I going to do, log this?
+		_ = l.millRunOnce()
+	}
+}
+
+// mill performs post-rotation compression and removal of stale log files,
+// starting the mill goroutine if necessary.
+func (l *Logger) mill() {
+	l.startMill.Do(func() {
+		l.millCh = make(chan bool, 1)
+		go l.millRun()
+	})
+	select {
+	case l.millCh <- true:
+	default:
+	}
+}
+
+// oldLogFiles returns the list of backup log files stored in the same
+// directory as the current log file, sorted by ModTime
+func (l *Logger) oldLogFiles() ([]logInfo, error) {
+	files, err := ioutil.ReadDir(l.dir())
+	if err != nil {
+		return nil, fmt.Errorf("can't read log file directory: %s", err)
+	}
+	logFiles := []logInfo{}
+
+	prefix, ext := l.prefixAndExt()
+
+	for _, f := range files {
+		if f.IsDir() {
+			continue
+		}
+		if t, err := l.timeFromName(f.Name(), prefix, ext); err == nil {
+			logFiles = append(logFiles, logInfo{t, f})
+			continue
+		}
+		if t, err := l.timeFromName(f.Name(), prefix, ext+compressSuffix); err == nil {
+			logFiles = append(logFiles, logInfo{t, f})
+			continue
+		}
+		// error parsing means that the suffix at the end was not generated
+		// by lumberjack, and therefore it's not a backup file.
+	}
+
+	sort.Sort(byFormatTime(logFiles))
+
+	return logFiles, nil
+}
+
+// timeFromName extracts the formatted time from the filename by stripping off
+// the filename's prefix and extension. This prevents someone's filename from
+// confusing time.parse.
+func (l *Logger) timeFromName(filename, prefix, ext string) (time.Time, error) {
+	if !strings.HasPrefix(filename, prefix) {
+		return time.Time{}, errors.New("mismatched prefix")
+	}
+	if !strings.HasSuffix(filename, ext) {
+		return time.Time{}, errors.New("mismatched extension")
+	}
+	ts := filename[len(prefix) : len(filename)-len(ext)]
+	return time.Parse(backupTimeFormat, ts)
+}
+
+// max returns the maximum size in bytes of log files before rolling.
+func (l *Logger) max() int64 {
+	if l.spec.MaxSize == 0 {
+		return int64(defaultMaxSize * megabyte)
+	}
+	return int64(l.spec.MaxSize) * int64(megabyte)
+}
+
+// dir returns the directory for the current filename.
+func (l *Logger) dir() string {
+	return filepath.Dir(l.filename())
+}
+
+// prefixAndExt returns the filename part and extension part from the Logger's
+// filename.
+func (l *Logger) prefixAndExt() (prefix, ext string) {
+	filename := filepath.Base(l.filename())
+	ext = filepath.Ext(filename)
+	prefix = filename[:len(filename)-len(ext)] + "-"
+	return prefix, ext
+}
+
+// compressLogFile compresses the given log file, removing the
+// uncompressed log file if successful.
+func compressLogFile(src, dst string, perm os.FileMode) (err error) {
+	f, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("failed to open log file: %v", err)
+	}
+	defer f.Close()
+
+	// If this file already exists, we presume it was created by
+	// a previous attempt to compress the log file.
+	gzf, err := os.OpenFile(dst, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, perm)
+	if err != nil {
+		return fmt.Errorf("failed to open compressed log file: %v", err)
+	}
+	defer gzf.Close()
+
+	gz := gzip.NewWriter(gzf)
+
+	defer func() {
+		if err != nil {
+			os.Remove(dst)
+			err = fmt.Errorf("failed to compress log file: %v", err)
+		}
+	}()
+
+	if _, err := io.Copy(gz, f); err != nil {
+		return err
+	}
+	if err := gz.Close(); err != nil {
+		return err
+	}
+	if err := gzf.Close(); err != nil {
+		return err
+	}
+
+	if err := f.Close(); err != nil {
+		return err
+	}
+	if err := os.Remove(src); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// logInfo is a convenience struct to return the filename and its embedded
+// timestamp.
+type logInfo struct {
+	timestamp time.Time
+	os.FileInfo
+}
+
+// byFormatTime sorts by newest time formatted in the name.
+type byFormatTime []logInfo
+
+func (b byFormatTime) Less(i, j int) bool {
+	return b[i].timestamp.After(b[j].timestamp)
+}
+
+func (b byFormatTime) Swap(i, j int) {
+	b[i], b[j] = b[j], b[i]
+}
+
+func (b byFormatTime) Len() int {
+	return len(b)
+}

--- a/pkg/logger/lumberjack_test.go
+++ b/pkg/logger/lumberjack_test.go
@@ -480,9 +480,9 @@ func TestMaxAge(t *testing.T) {
 
 	filename := logFilePath(dir)
 	l := newLogger(&Spec{
-		FileName:   logFilePath(dir),
-		MaxSize:    10,
-		MaxBackups: 1,
+		FileName: logFilePath(dir),
+		MaxSize:  10,
+		MaxAge:   1,
 	})
 	defer l.Close()
 	b := []byte("boo!")

--- a/pkg/logger/lumberjack_test.go
+++ b/pkg/logger/lumberjack_test.go
@@ -864,12 +864,6 @@ func backupFileLocal(dir string) string {
 	return filepath.Join(dir, "foobar-"+fakeTime().Format(backupTimeFormat)+".log")
 }
 
-// logFileLocal returns the log file name in the given directory for the current
-// fake time using the local timezone.
-func logFileLocal(dir string) string {
-	return filepath.Join(dir, fakeTime().Format(backupTimeFormat))
-}
-
 // fileCount checks that the number of files in the directory is exp.
 func fileCount(dir string, exp int, t testing.TB) {
 	files, err := os.ReadDir(dir)

--- a/pkg/logger/lumberjack_test.go
+++ b/pkg/logger/lumberjack_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 )
@@ -39,8 +40,11 @@ import (
 // control the wall clock as much as possible, which means having a wall clock
 // that doesn't change unless we want it to.
 var fakeCurrentTime = time.Now()
+var lock = &sync.Mutex{}
 
 func fakeTime() time.Time {
+	lock.Lock()
+	defer lock.Unlock()
 	return fakeCurrentTime
 }
 
@@ -877,6 +881,8 @@ func fileCount(dir string, exp int, t testing.TB) {
 
 // newFakeTime sets the fake "current time" to two days later.
 func newFakeTime() {
+	lock.Lock()
+	defer lock.Unlock()
 	fakeCurrentTime = fakeCurrentTime.Add(time.Hour * 24 * 2)
 }
 

--- a/pkg/logger/lumberjack_test.go
+++ b/pkg/logger/lumberjack_test.go
@@ -1,0 +1,893 @@
+/*
+ * Copyright (c) 2017, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package logger
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"github.com/megaease/easegress/pkg/util/codectool"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// !!!NOTE!!!
+//
+// Running these tests in parallel will almost certainly cause sporadic (or even
+// regular) failures, because they're all messing with the same global variable
+// that controls the logic's mocked time.Now.  So... don't do that.
+
+// Since all the tests uses the time to determine filenames etc, we need to
+// control the wall clock as much as possible, which means having a wall clock
+// that doesn't change unless we want it to.
+var fakeCurrentTime = time.Now()
+
+func fakeTime() time.Time {
+	return fakeCurrentTime
+}
+
+func TestSpecValidate(t *testing.T) {
+	data := `
+fileName: foo
+maxSize: 5
+maxAge: 10
+maxBackups: 3
+localTime: true
+compress: true
+`
+	spec := &Spec{}
+	codectool.MustUnmarshal([]byte(data), spec)
+	at := assert.New(t)
+	at.NoError(spec.Validate())
+
+	data = `
+fileName: foo
+maxSize: 5
+maxAge: 10
+maxBackups: 3
+localTime: true
+compress: true
+perm: '0600'
+`
+	spec = &Spec{}
+	codectool.MustUnmarshal([]byte(data), spec)
+	at.NoError(spec.Validate())
+
+	data = `
+fileName: foo
+maxSize: 5
+maxAge: 10
+maxBackups: 3
+localTime: true
+compress: true
+perm: '0o600'
+`
+	spec = &Spec{}
+	codectool.MustUnmarshal([]byte(data), spec)
+	at.NoError(spec.Validate())
+
+	data = `
+fileName: foo
+maxSize: 5
+maxAge: 10
+maxBackups: 3
+localTime: true
+compress: true
+perm: '600'
+`
+
+	spec = &Spec{}
+	codectool.MustUnmarshal([]byte(data), spec)
+	at.Error(spec.Validate())
+
+	data = `
+fileName: foo
+maxSize: 5
+maxAge: 10
+maxBackups: 3
+localTime: true
+compress: true
+perm: '0x600'
+`
+	spec = &Spec{}
+	codectool.MustUnmarshal([]byte(data), spec)
+	at.Error(spec.Validate())
+}
+
+func TestNewFile(t *testing.T) {
+	currentTime = fakeTime
+
+	dir := makeTempDir("TestNewFile", t)
+	defer os.RemoveAll(dir)
+	l := newLogger(&Spec{
+		FileName: logFilePath(dir),
+	})
+	defer l.Close()
+	b := []byte("boo!")
+	n, err := l.Write(b)
+
+	at := assert.New(t)
+	at.NoError(err)
+	at.Equal(len(b), n)
+	existsWithContent(logFilePath(dir), b, t)
+	fileCount(dir, 1, t)
+}
+
+func TestOpenExisting(t *testing.T) {
+	currentTime = fakeTime
+	dir := makeTempDir("TestOpenExisting", t)
+	defer os.RemoveAll(dir)
+
+	filename := logFilePath(dir)
+	data := []byte("foo!")
+	err := os.WriteFile(filename, data, 0644)
+	at := assert.New(t)
+	at.NoError(err)
+	existsWithContent(filename, data, t)
+
+	l := newLogger(&Spec{
+		FileName: logFilePath(dir),
+	})
+	defer l.Close()
+	b := []byte("boo!")
+	n, err := l.Write(b)
+	at.NoError(err)
+	at.Equal(len(b), n)
+
+	// make sure the file got appended
+	existsWithContent(filename, append(data, b...), t)
+
+	// make sure no other files were created
+	fileCount(dir, 1, t)
+}
+
+func TestWriteTooLong(t *testing.T) {
+	currentTime = fakeTime
+	megabyte = 1
+	dir := makeTempDir("TestWriteTooLong", t)
+	defer os.RemoveAll(dir)
+	l := newLogger(&Spec{
+		FileName: logFilePath(dir),
+		MaxSize:  5,
+	})
+	defer l.Close()
+	b := []byte("booooooooooooooo!")
+	n, err := l.Write(b)
+
+	at := assert.New(t)
+	at.Error(err)
+	at.Equal(0, n)
+	at.Equal(err.Error(),
+		fmt.Sprintf("write length %d exceeds maximum file size %d", len(b), l.spec.MaxSize))
+	_, err = os.Stat(logFilePath(dir))
+	at.True(os.IsNotExist(err), "File exists, but should not have been created")
+}
+
+func TestMakeLogDir(t *testing.T) {
+	currentTime = fakeTime
+	dir := time.Now().Format("TestMakeLogDir" + backupTimeFormat)
+	dir = filepath.Join(os.TempDir(), dir)
+	defer os.RemoveAll(dir)
+	l := newLogger(&Spec{
+		FileName: logFilePath(dir),
+	})
+	defer l.Close()
+	b := []byte("boo!")
+	n, err := l.Write(b)
+	at := assert.New(t)
+	at.NoError(err)
+	at.Equal(len(b), n)
+	existsWithContent(logFilePath(dir), b, t)
+	fileCount(dir, 1, t)
+}
+
+func TestDefaultFilename(t *testing.T) {
+	currentTime = fakeTime
+	dir := os.TempDir()
+	filename := filepath.Join(dir, filepath.Base(os.Args[0])+"-lumberjack.log")
+	defer os.Remove(filename)
+	l := newLogger(&Spec{})
+	defer l.Close()
+	b := []byte("boo!")
+	n, err := l.Write(b)
+	at := assert.New(t)
+	at.NoError(err)
+	at.Equal(len(b), n)
+	existsWithContent(filename, b, t)
+}
+
+func TestAutoRotate(t *testing.T) {
+	currentTime = fakeTime
+	megabyte = 1
+
+	dir := makeTempDir("TestAutoRotate", t)
+	defer os.RemoveAll(dir)
+
+	filename := logFilePath(dir)
+	l := newLogger(&Spec{
+		FileName: logFilePath(dir),
+		MaxSize:  10,
+	})
+	defer l.Close()
+	b := []byte("boo!")
+	n, err := l.Write(b)
+
+	at := assert.New(t)
+	at.NoError(err)
+	at.Equal(len(b), n)
+
+	existsWithContent(filename, b, t)
+	fileCount(dir, 1, t)
+
+	newFakeTime()
+
+	b2 := []byte("foooooo!")
+	n, err = l.Write(b2)
+	at.NoError(err)
+	at.Equal(len(b2), n)
+
+	// the old logfile should be moved aside and the main logfile should have
+	// only the last write in it.
+	existsWithContent(filename, b2, t)
+
+	// the backup file will use the current fake time and have the old contents.
+	existsWithContent(backupFile(dir), b, t)
+
+	fileCount(dir, 2, t)
+}
+
+func TestFirstWriteRotate(t *testing.T) {
+	currentTime = fakeTime
+	megabyte = 1
+	dir := makeTempDir("TestFirstWriteRotate", t)
+	defer os.RemoveAll(dir)
+
+	filename := logFilePath(dir)
+	l := newLogger(&Spec{
+		FileName: logFilePath(dir),
+		MaxSize:  10,
+	})
+	defer l.Close()
+
+	start := []byte("boooooo!")
+	err := os.WriteFile(filename, start, 0600)
+	at := assert.New(t)
+
+	at.NoError(err)
+
+	newFakeTime()
+
+	// this would make us rotate
+	b := []byte("fooo!")
+	n, err := l.Write(b)
+	at.NoError(err)
+	at.Equal(len(b), n)
+
+	existsWithContent(filename, b, t)
+	existsWithContent(backupFile(dir), start, t)
+
+	fileCount(dir, 2, t)
+}
+
+func TestMaxBackups(t *testing.T) {
+	currentTime = fakeTime
+	megabyte = 1
+	dir := makeTempDir("TestMaxBackups", t)
+	defer os.RemoveAll(dir)
+
+	filename := logFilePath(dir)
+	l := newLogger(&Spec{
+		FileName:   logFilePath(dir),
+		MaxSize:    10,
+		MaxBackups: 1,
+	})
+	defer l.Close()
+	b := []byte("boo!")
+	n, err := l.Write(b)
+	at := assert.New(t)
+	at.NoError(err, t)
+	at.Equal(len(b), n)
+
+	existsWithContent(filename, b, t)
+	fileCount(dir, 1, t)
+
+	newFakeTime()
+
+	// this will put us over the max
+	b2 := []byte("foooooo!")
+	n, err = l.Write(b2)
+	at.NoError(err)
+	at.Equal(len(b2), n)
+
+	// this will use the new fake time
+	secondFilename := backupFile(dir)
+	existsWithContent(secondFilename, b, t)
+
+	// make sure the old file still exists with the same content.
+	existsWithContent(filename, b2, t)
+
+	fileCount(dir, 2, t)
+
+	newFakeTime()
+
+	// this will make us rotate again
+	b3 := []byte("baaaaaar!")
+	n, err = l.Write(b3)
+	at.NoError(err)
+	at.Equal(len(b3), n)
+
+	// this will use the new fake time
+	thirdFilename := backupFile(dir)
+	existsWithContent(thirdFilename, b2, t)
+
+	existsWithContent(filename, b3, t)
+
+	// we need to wait a little bit since the files get deleted on a different
+	// goroutine.
+	<-time.After(time.Millisecond * 10)
+
+	// should only have two files in the dir still
+	fileCount(dir, 2, t)
+
+	// second file name should still exist
+	existsWithContent(thirdFilename, b2, t)
+
+	// should have deleted the first backup
+	notExist(secondFilename, t)
+
+	// now test that we don't delete directories or non-logfile files
+
+	newFakeTime()
+
+	// create a file that is close to but different from the logfile name.
+	// It shouldn't get caught by our deletion filters.
+	notlogfile := logFilePath(dir) + ".foo"
+	err = os.WriteFile(notlogfile, []byte("data"), 0644)
+	at.NoError(err)
+
+	// Make a directory that exactly matches our log file filters... it still
+	// shouldn't get caught by the deletion filter since it's a directory.
+	notlogfiledir := backupFile(dir)
+	err = os.Mkdir(notlogfiledir, 0700)
+	at.NoError(err)
+
+	newFakeTime()
+
+	// this will use the new fake time
+	fourthFilename := backupFile(dir)
+
+	// Create a log file that is/was being compressed - this should
+	// not be counted since both the compressed and the uncompressed
+	// log files still exist.
+	compLogFile := fourthFilename + compressSuffix
+	err = os.WriteFile(compLogFile, []byte("compress"), 0644)
+	at.NoError(err)
+
+	// this will make us rotate again
+	b4 := []byte("baaaaaaz!")
+	n, err = l.Write(b4)
+	at.NoError(err)
+	at.Equal(len(b4), n)
+
+	existsWithContent(fourthFilename, b3, t)
+	existsWithContent(fourthFilename+compressSuffix, []byte("compress"), t)
+
+	// we need to wait a little bit since the files get deleted on a different
+	// goroutine.
+	<-time.After(time.Millisecond * 10)
+
+	// We should have four things in the directory now - the 2 log files, the
+	// not log file, and the directory
+	fileCount(dir, 5, t)
+
+	// third file name should still exist
+	existsWithContent(filename, b4, t)
+
+	existsWithContent(fourthFilename, b3, t)
+
+	// should have deleted the first filename
+	notExist(thirdFilename, t)
+
+	// the not-a-logfile should still exist
+	exists(notlogfile, t)
+
+	// the directory
+	exists(notlogfiledir, t)
+}
+
+func TestCleanupExistingBackups(t *testing.T) {
+	// test that if we start with more backup files than we're supposed to have
+	// in total, that extra ones get cleaned up when we rotate.
+
+	currentTime = fakeTime
+	megabyte = 1
+
+	dir := makeTempDir("TestCleanupExistingBackups", t)
+	defer os.RemoveAll(dir)
+
+	// make 3 backup files
+
+	data := []byte("data")
+	backup := backupFile(dir)
+	err := os.WriteFile(backup, data, 0644)
+
+	at := assert.New(t)
+	at.NoError(err)
+
+	newFakeTime()
+
+	backup = backupFile(dir)
+	err = os.WriteFile(backup+compressSuffix, data, 0644)
+	at.NoError(err)
+
+	newFakeTime()
+
+	backup = backupFile(dir)
+	err = os.WriteFile(backup, data, 0644)
+	at.NoError(err)
+
+	// now create a primary log file with some data
+	filename := logFilePath(dir)
+	err = os.WriteFile(filename, data, 0644)
+	at.NoError(err)
+
+	l := newLogger(&Spec{
+		FileName:   logFilePath(dir),
+		MaxSize:    10,
+		MaxBackups: 1,
+	})
+	defer l.Close()
+
+	newFakeTime()
+
+	b2 := []byte("foooooo!")
+	n, err := l.Write(b2)
+	at.NoError(err)
+	at.Equal(len(b2), n)
+
+	// we need to wait a little bit since the files get deleted on a different
+	// goroutine.
+	<-time.After(time.Millisecond * 10)
+
+	// now we should only have 2 files left - the primary and one backup
+	fileCount(dir, 2, t)
+}
+
+func TestMaxAge(t *testing.T) {
+	currentTime = fakeTime
+	megabyte = 1
+
+	dir := makeTempDir("TestMaxAge", t)
+	defer os.RemoveAll(dir)
+
+	filename := logFilePath(dir)
+	l := newLogger(&Spec{
+		FileName:   logFilePath(dir),
+		MaxSize:    10,
+		MaxBackups: 1,
+	})
+	defer l.Close()
+	b := []byte("boo!")
+	n, err := l.Write(b)
+
+	at := assert.New(t)
+	at.NoError(err)
+	at.Equal(len(b), n)
+
+	existsWithContent(filename, b, t)
+	fileCount(dir, 1, t)
+
+	// two days later
+	newFakeTime()
+
+	b2 := []byte("foooooo!")
+	n, err = l.Write(b2)
+	at.NoError(err)
+	at.Equal(len(b2), n)
+	existsWithContent(backupFile(dir), b, t)
+
+	// we need to wait a little bit since the files get deleted on a different
+	// goroutine.
+	<-time.After(10 * time.Millisecond)
+
+	// We should still have 2 log files, since the most recent backup was just
+	// created.
+	fileCount(dir, 2, t)
+
+	existsWithContent(filename, b2, t)
+
+	// we should have deleted the old file due to being too old
+	existsWithContent(backupFile(dir), b, t)
+
+	// two days later
+	newFakeTime()
+
+	b3 := []byte("baaaaar!")
+	n, err = l.Write(b3)
+	at.NoError(err)
+	at.Equal(len(b3), n)
+	existsWithContent(backupFile(dir), b2, t)
+
+	// we need to wait a little bit since the files get deleted on a different
+	// goroutine.
+	<-time.After(10 * time.Millisecond)
+
+	// We should have 2 log files - the main log file, and the most recent
+	// backup.  The earlier backup is past the cutoff and should be gone.
+	fileCount(dir, 2, t)
+
+	existsWithContent(filename, b3, t)
+
+	// we should have deleted the old file due to being too old
+	existsWithContent(backupFile(dir), b2, t)
+}
+
+func TestOldLogFiles(t *testing.T) {
+	currentTime = fakeTime
+	megabyte = 1
+
+	dir := makeTempDir("TestOldLogFiles", t)
+	defer os.RemoveAll(dir)
+
+	filename := logFilePath(dir)
+	data := []byte("data")
+	err := os.WriteFile(filename, data, 07)
+	at := assert.New(t)
+	at.NoError(err)
+
+	// This gives us a time with the same precision as the time we get from the
+	// timestamp in the name.
+	t1, err := time.Parse(backupTimeFormat, fakeTime().UTC().Format(backupTimeFormat))
+	at.NoError(err)
+
+	backup := backupFile(dir)
+	err = os.WriteFile(backup, data, 07)
+	at.NoError(err)
+
+	newFakeTime()
+
+	t2, err := time.Parse(backupTimeFormat, fakeTime().UTC().Format(backupTimeFormat))
+	at.NoError(err)
+
+	backup2 := backupFile(dir)
+	err = os.WriteFile(backup2, data, 07)
+	at.NoError(err)
+
+	l := newLogger(&Spec{
+		FileName:   logFilePath(dir),
+		MaxSize:    10,
+		MaxBackups: 1,
+	})
+	files, err := l.oldLogFiles()
+	at.NoError(err)
+	at.Equal(2, len(files))
+
+	// should be sorted by newest file first, which would be t2
+	at.Equal(t2, files[0].timestamp)
+	at.Equal(t1, files[1].timestamp)
+}
+
+func TestTimeFromName(t *testing.T) {
+	l := newLogger(&Spec{
+		FileName: "foo.log",
+	})
+
+	prefix, ext := l.prefixAndExt()
+
+	tests := []struct {
+		filename string
+		want     time.Time
+		wantErr  bool
+	}{
+		{"foo-2014-05-04T14-44-33.555.log", time.Date(2014, 5, 4, 14, 44, 33, 555000000, time.UTC), false},
+		{"foo-2014-05-04T14-44-33.555", time.Time{}, true},
+		{"2014-05-04T14-44-33.555.log", time.Time{}, true},
+		{"foo.log", time.Time{}, true},
+	}
+	at := assert.New(t)
+	for _, test := range tests {
+		got, err := l.timeFromName(test.filename, prefix, ext)
+		at.Equal(got, test.want)
+		at.Equal(err != nil, test.wantErr)
+	}
+}
+
+func TestLocalTime(t *testing.T) {
+	currentTime = fakeTime
+	megabyte = 1
+
+	dir := makeTempDir("TestLocalTime", t)
+	defer os.RemoveAll(dir)
+
+	l := newLogger(&Spec{
+		FileName:  logFilePath(dir),
+		MaxSize:   10,
+		LocalTime: true,
+	})
+	defer l.Close()
+	b := []byte("boo!")
+	n, err := l.Write(b)
+
+	at := assert.New(t)
+	at.NoError(err)
+	at.Equal(len(b), n)
+
+	b2 := []byte("fooooooo!")
+	n2, err := l.Write(b2)
+	at.NoError(err)
+	at.Equal(len(b2), n2)
+
+	existsWithContent(logFilePath(dir), b2, t)
+	existsWithContent(backupFileLocal(dir), b, t)
+}
+
+func TestRotate(t *testing.T) {
+	currentTime = fakeTime
+	dir := makeTempDir("TestRotate", t)
+	defer os.RemoveAll(dir)
+
+	filename := logFilePath(dir)
+
+	l := newLogger(&Spec{
+		FileName:   logFilePath(dir),
+		MaxSize:    100,
+		MaxBackups: 1,
+	})
+	defer l.Close()
+	b := []byte("boo!")
+	n, err := l.Write(b)
+
+	at := assert.New(t)
+	at.NoError(err)
+	at.Equal(len(b), n)
+
+	existsWithContent(filename, b, t)
+	fileCount(dir, 1, t)
+
+	newFakeTime()
+
+	err = l.Rotate()
+	at.NoError(err)
+
+	// we need to wait a little bit since the files get deleted on a different
+	// goroutine.
+	<-time.After(10 * time.Millisecond)
+
+	filename2 := backupFile(dir)
+	existsWithContent(filename2, b, t)
+	existsWithContent(filename, []byte{}, t)
+	fileCount(dir, 2, t)
+	newFakeTime()
+
+	err = l.Rotate()
+	at.NoError(err)
+
+	// we need to wait a little bit since the files get deleted on a different
+	// goroutine.
+	<-time.After(10 * time.Millisecond)
+
+	filename3 := backupFile(dir)
+	existsWithContent(filename3, []byte{}, t)
+	existsWithContent(filename, []byte{}, t)
+	fileCount(dir, 2, t)
+
+	b2 := []byte("foooooo!")
+	n, err = l.Write(b2)
+	at.NoError(err)
+	at.Equal(len(b2), n)
+
+	// this will use the new fake time
+	existsWithContent(filename, b2, t)
+}
+
+func TestCompressOnRotate(t *testing.T) {
+	currentTime = fakeTime
+	megabyte = 1
+
+	dir := makeTempDir("TestCompressOnRotate", t)
+	defer os.RemoveAll(dir)
+
+	filename := logFilePath(dir)
+	l := newLogger(&Spec{
+		FileName: filename,
+		MaxSize:  10,
+		Compress: true,
+	})
+	defer l.Close()
+	b := []byte("boo!")
+	n, err := l.Write(b)
+
+	at := assert.New(t)
+	at.NoError(err)
+	at.Equal(len(b), n)
+
+	existsWithContent(filename, b, t)
+	fileCount(dir, 1, t)
+
+	newFakeTime()
+
+	err = l.Rotate()
+	at.NoError(err)
+
+	// the old logfile should be moved aside and the main logfile should have
+	// nothing in it.
+	existsWithContent(filename, []byte{}, t)
+
+	// we need to wait a little bit since the files get compressed on a different
+	// goroutine.
+	<-time.After(300 * time.Millisecond)
+
+	// a compressed version of the log file should now exist and the original
+	// should have been removed.
+	bc := new(bytes.Buffer)
+	gz := gzip.NewWriter(bc)
+	_, err = gz.Write(b)
+	at.NoError(err)
+	err = gz.Close()
+	at.NoError(err)
+	existsWithContent(backupFile(dir)+compressSuffix, bc.Bytes(), t)
+	notExist(backupFile(dir), t)
+
+	fileCount(dir, 2, t)
+}
+
+func TestCompressOnResume(t *testing.T) {
+	currentTime = fakeTime
+	megabyte = 1
+
+	dir := makeTempDir("TestCompressOnResume", t)
+	defer os.RemoveAll(dir)
+
+	filename := logFilePath(dir)
+	l := newLogger(&Spec{
+		FileName: filename,
+		MaxSize:  10,
+		Compress: true,
+	})
+	defer l.Close()
+
+	// Create a backup file and empty "compressed" file.
+	filename2 := backupFile(dir)
+	b := []byte("foo!")
+	at := assert.New(t)
+	err := os.WriteFile(filename2, b, 0644)
+	at.NoError(err)
+	err = os.WriteFile(filename2+compressSuffix, []byte{}, 0644)
+	at.NoError(err)
+
+	newFakeTime()
+
+	b2 := []byte("boo!")
+	n, err := l.Write(b2)
+	at.NoError(err)
+	at.Equal(len(b2), n)
+	existsWithContent(filename, b2, t)
+
+	// we need to wait a little bit since the files get compressed on a different
+	// goroutine.
+	<-time.After(300 * time.Millisecond)
+
+	// The write should have started the compression - a compressed version of
+	// the log file should now exist and the original should have been removed.
+	bc := new(bytes.Buffer)
+	gz := gzip.NewWriter(bc)
+	_, err = gz.Write(b)
+	at.NoError(err)
+	err = gz.Close()
+	at.NoError(err)
+	existsWithContent(filename2+compressSuffix, bc.Bytes(), t)
+	notExist(filename2, t)
+
+	fileCount(dir, 2, t)
+}
+
+func TestJson(t *testing.T) {
+	data := []byte(`
+{
+	"fileName": "foo",
+	"maxSize": 5,
+	"maxAge": 10,
+	"maxBackups": 3,
+	"localTime": true,
+	"compress": true
+}`[1:])
+	spec := &Spec{}
+
+	err := codectool.UnmarshalJSON(data, spec)
+	at := assert.New(t)
+	at.NoError(err)
+	l := newLogger(spec)
+	at.Equal("foo", l.spec.FileName)
+	at.Equal(5, l.spec.MaxSize)
+	at.Equal(10, l.spec.MaxAge)
+	at.Equal(3, l.spec.MaxBackups)
+	at.Equal(true, l.spec.LocalTime)
+	at.Equal(true, l.spec.Compress)
+}
+
+// makeTempDir creates a file with a semi-unique name in the OS temp directory.
+// It should be based on the name of the test, to keep parallel tests from
+// colliding, and must be cleaned up after the test is finished.
+func makeTempDir(name string, t testing.TB) string {
+	dir := time.Now().Format(name + backupTimeFormat)
+	dir = filepath.Join(os.TempDir(), dir)
+	at := assert.New(t)
+	at.NoError(os.Mkdir(dir, 0700))
+	return dir
+}
+
+// existsWithContent checks that the given file exists and has the correct content.
+func existsWithContent(path string, content []byte, t testing.TB) {
+	info, err := os.Stat(path)
+	at := assert.New(t)
+	at.NoError(err)
+	at.Equal(int64(len(content)), info.Size())
+
+	b, err := os.ReadFile(path)
+	at.NoError(err)
+	at.Equal(content, b)
+}
+
+// logFilePath returns the log file name in the given directory for the current fake
+// time.
+func logFilePath(dir string) string {
+	return filepath.Join(dir, "foobar.log")
+}
+
+func backupFile(dir string) string {
+	return filepath.Join(dir, "foobar-"+fakeTime().UTC().Format(backupTimeFormat)+".log")
+}
+
+func backupFileLocal(dir string) string {
+	return filepath.Join(dir, "foobar-"+fakeTime().Format(backupTimeFormat)+".log")
+}
+
+// logFileLocal returns the log file name in the given directory for the current
+// fake time using the local timezone.
+func logFileLocal(dir string) string {
+	return filepath.Join(dir, fakeTime().Format(backupTimeFormat))
+}
+
+// fileCount checks that the number of files in the directory is exp.
+func fileCount(dir string, exp int, t testing.TB) {
+	files, err := os.ReadDir(dir)
+	at := assert.New(t)
+	at.NoError(err)
+	// Make sure no other files were created.
+	at.Equal(exp, len(files))
+}
+
+// newFakeTime sets the fake "current time" to two days later.
+func newFakeTime() {
+	fakeCurrentTime = fakeCurrentTime.Add(time.Hour * 24 * 2)
+}
+
+func notExist(path string, t testing.TB) {
+	_, err := os.Stat(path)
+	at := assert.New(t)
+	at.Truef(os.IsNotExist(err), "expected to get os.IsNotExist, but instead got %v", err)
+}
+
+func exists(path string, t testing.TB) {
+	_, err := os.Stat(path)
+	at := assert.New(t)
+	at.Truef(err == nil, "expected file to exist, but got error from os.Stat: %v", err)
+}

--- a/pkg/object/etcdserviceregistry/etcdserviceregistry.go
+++ b/pkg/object/etcdserviceregistry/etcdserviceregistry.go
@@ -166,7 +166,7 @@ func (e *EtcdServiceRegistry) buildClient() (*clientv3.Client, error) {
 		DialTimeout:          10 * time.Second,
 		DialKeepAliveTime:    1 * time.Minute,
 		DialKeepAliveTimeout: 1 * time.Minute,
-		LogConfig: logger.EtcdClientLoggerConfig(e.superSpec.Super().Options(),
+		Logger: logger.CustomerEtcdClientLogger(e.superSpec.Super().Options(),
 			"object_"+e.superSpec.Name()),
 	})
 	if err != nil {

--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -91,6 +91,7 @@ type Options struct {
 	DataDir   string `yaml:"data-dir"`
 	WALDir    string `yaml:"wal-dir"`
 	LogDir    string `yaml:"log-dir"`
+	LogConfig string `yaml:"log-config"`
 	MemberDir string `yaml:"member-dir"`
 
 	// Profile.
@@ -147,6 +148,7 @@ func New() *Options {
 	opt.flags.StringVar(&opt.CertFile, "cert-file", "", "Flag to set the certificate file for https.")
 	opt.flags.StringVar(&opt.KeyFile, "key-file", "", "Flag to set the private key file for https.")
 	opt.flags.BoolVar(&opt.Debug, "debug", false, "Flag to set lowest log level from INFO downgrade DEBUG.")
+	opt.flags.BoolVar(&opt.DisableAccessLog, "disable-access", false, "Flag to set whether to disable access logs")
 	opt.flags.StringSliceVar(&opt.InitialObjectConfigFiles, "initial-object-config-files", nil, "List of configuration files for initial objects, these objects will be created at startup if not already exist.")
 	opt.flags.StringVar(&opt.ObjectsDumpInterval, "objects-dump-interval", "", "The time interval to dump running objects config, for example: 30m")
 
@@ -154,6 +156,7 @@ func New() *Options {
 	opt.flags.StringVar(&opt.DataDir, "data-dir", "data", "Path to the data directory.")
 	opt.flags.StringVar(&opt.WALDir, "wal-dir", "", "Path to the WAL directory.")
 	opt.flags.StringVar(&opt.LogDir, "log-dir", "", "Path to the log directory.")
+	opt.flags.StringVar(&opt.LogConfig, "log-config", "", "Config file of the log")
 	opt.flags.StringVar(&opt.MemberDir, "member-dir", "member", "Path to the member directory.")
 
 	opt.flags.StringVar(&opt.CPUProfileFile, "cpu-profile-file", "", "Path to the CPU profile file.")

--- a/pkg/option/option_test.go
+++ b/pkg/option/option_test.go
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2017, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package option
+
+import (
+	"github.com/stretchr/testify/assert"
+	"os"
+	"path"
+	"path/filepath"
+
+	"testing"
+)
+
+func TestLogOptions(t *testing.T) {
+	at := assert.New(t)
+	options := New()
+	dir := path.Join(os.TempDir(), "TestLogOptions")
+	options.HomeDir = dir
+	options.LogDir = "logs"
+	defer os.RemoveAll(dir)
+
+	at.NoError(options.prepare())
+	abs, err := filepath.Abs(path.Join(dir, "logs"))
+	at.NoError(err)
+	at.Equal(abs, options.AbsLogDir)
+
+}

--- a/pkg/util/stringtool/stringtool.go
+++ b/pkg/util/stringtool/stringtool.go
@@ -42,6 +42,11 @@ func Cat(strs ...string) string {
 	return builder.String()
 }
 
+// LowerChar return the lowest case of the char
+func LowerChar(c byte) byte {
+	return c | ('x' - 'X')
+}
+
 // StrInSlice returns whether the string is in the slice.
 func StrInSlice(str string, slice []string) bool {
 	for _, s := range slice {

--- a/pkg/util/stringtool/stringtool_test.go
+++ b/pkg/util/stringtool/stringtool_test.go
@@ -103,3 +103,11 @@ func TestStringMatcher(t *testing.T) {
 	assert.True(sm.Match("/hello"))
 	assert.False(sm.Match("/Hello"))
 }
+
+func TestLowerChar(t *testing.T) {
+	at := assert.New(t)
+
+	at.True('a' == LowerChar('A'))
+	at.True('a' == LowerChar('a'))
+	at.True('c' != LowerChar('A'))
+}


### PR DESCRIPTION
Support roll all easegress logs include `stdout.log`,`etcd-client` and so on.

The reasons for not using [lumberjack](https://github.com/natefinch/lumberjack) directly are as follows:
- It does not support actively commits the current contents of the file to stable storage , so it may cause log contents loss in some scenarios, such as when the process exits gracefully. [lumberjack issue](https://github.com/natefinch/lumberjack/pull/178/files)
- Hard-coded definition log file access permissions are 0600, unless the log files are created in advance