### PR TITLE
remove go.mod replace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -283,15 +283,8 @@ require (
 	knative.dev/networking v0.0.0-20230301131055-c692e9e6afe1 // indirect
 	knative.dev/pkg v0.0.0-20230224205330-75da922ef055 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
-	sigs.k8s.io/kustomize/api v0.13.1 // indirect
-	sigs.k8s.io/kustomize/kyaml v0.14.0 // indirect
+	sigs.k8s.io/kustomize/api v0.12.1 // indirect
+	sigs.k8s.io/kustomize/kyaml v0.13.9 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
-)
-
-replace (
-	github.com/buger/jsonparser => github.com/buger/jsonparser v1.1.1
-	github.com/go-openapi/spec => github.com/go-openapi/spec v0.19.3
-	sigs.k8s.io/kustomize/api => sigs.k8s.io/kustomize/api v0.12.1
-	sigs.k8s.io/kustomize/kyaml => sigs.k8s.io/kustomize/kyaml v0.13.9
 )


### PR DESCRIPTION
This pr removes `replace` in `go.mod`. `replace` in `go.mod` is used for local development. 
When use `go get github.com/megaease/easegress/v2` to get `easegress`, golang will not keep the `replace` part. Which will cause bugs during `go build`.