### PR TITLE
rewrite integration test with egctl commands

### DIFF
--- a/build/test/test.sh
+++ b/build/test/test.sh
@@ -27,6 +27,7 @@ SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 pushd $SCRIPTPATH"/../../example" > /dev/null
 EXAMPLEDIR="$SCRIPTPATH"/../../example
 PRIMARYDIR=$EXAMPLEDIR"/primary-single"
+EGCTL=$PRIMARYDIR"/bin/egctl"
 
 # target file related define.
 server="primary-single/bin/easegress-server"
@@ -74,7 +75,7 @@ else
 fi
 
 # run go test
-go test -v $SCRIPTPATH
+env EGCTL=$EGCTL go test -v $SCRIPTPATH
 
 popd > /dev/null
 exit 0


### PR DESCRIPTION
Rewrite integration test by using `egctl` command directly. Add more test for `egctl` commands.