### PR TITLE
fix goreleaser build error, add egbuilder to release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,7 +6,7 @@ before:
     - go generate ./...
 
 snapshot:
-  name_template: '{{ .Tag }}'
+  name_template: '{{ .Version }}'
 checksum:
   name_template: 'checksums.txt'
 changelog:
@@ -16,6 +16,20 @@ builds:
   - id: client
     main: cmd/client/main.go
     binary: bin/egctl
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    ldflags:
+      - -s -w
+      - -X github.com/megaease/easegress/v2/pkg/version.RELEASE={{ .Tag }}
+      - -X github.com/megaease/easegress/v2/pkg/version.COMMIT={{.Commit}}
+      - -X github.com/megaease/easegress/v2/pkg/version.REPO=megaease/easegress
+  
+  - id: builder
+    main: cmd/builder/main.go
+    binary: bin/egbuilder
     env:
       - CGO_ENABLED=0
     goos:
@@ -66,6 +80,7 @@ dockers:
     ids:
       - client
       - server
+      - builder
 
     dockerfile: build/package/Dockerfile.goreleaser
 

--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -10,7 +10,7 @@ FROM alpine:3.18
 WORKDIR /opt/easegress
 
 COPY build/package/entrypoint.sh /
-COPY build/bin/egctl build/bin/easegress-server /opt/easegress/bin/
+COPY build/bin/egctl build/bin/easegress-server build/bin/egbuilder /opt/easegress/bin/
 
 # If the following apk command takes too much time or failed because of
 # network issues, we can setup a proxy for it.

--- a/build/package/Dockerfile.goreleaser
+++ b/build/package/Dockerfile.goreleaser
@@ -2,7 +2,7 @@ FROM alpine:3.18
 
 WORKDIR /opt/easegress
 
-ADD egctl easegress-server /opt/easegress/bin/
+ADD bin/egctl bin/easegress-server bin/egbuilder /opt/easegress/bin/
 COPY build/package/entrypoint.sh /
 
 RUN apk --no-cache add tini tzdata && \


### PR DESCRIPTION
- Add `egbuilder` to release.
- Update dockerfile to fix gorelease build error