### PR TITLE
Remove egctl auto change protocol

### DIFF
--- a/cmd/client/general/request.go
+++ b/cmd/client/general/request.go
@@ -148,11 +148,10 @@ func HandleReqWithStreamResp(httpMethod string, path string, yamlBody []byte) (i
 
 	if strings.HasPrefix(url, HTTPProtocol) && resp.StatusCode == http.StatusBadRequest {
 		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
 		if err != nil {
-			resp.Body.Close()
 			return nil, fmt.Errorf("read response body failed: %v", err)
 		}
-		resp.Body.Close()
 
 		// https://github.com/golang/go/blob/release-branch.go1.20/src/net/http/server.go#L1878-L1885
 		if strings.Contains(string(body), "Client sent an HTTP request to an HTTPS server") {


### PR DESCRIPTION
For now, `egctl` automatically update `http` protocol to `https` protocol is response status code is 400 and response body contains `HTTPS`. 

This strategy can cause some additional problem. As described in #1161 , if user create/update httpserver with yamls, then `easegress-server` may return status code of 400 and a response body with `https` in it (for example, some message about tls config). In this case, `egctl` will try to update protocol from `http` to `https`. Then will cause error of `http: server gave HTTP response to HTTPS client`.  

So, this pr update this protocol change strategy. https://github.com/golang/go/blob/master/src/net/http/server.go#L1922-L1929 based on golang net/http implementation.

```go
if err := tlsConn.HandshakeContext(ctx); err != nil {
	// If the handshake failed due to the client not speaking
	// TLS, assume they're speaking plaintext HTTP and write a
	// 400 response on the TLS conn's underlying net.Conn.
	if re, ok := err.(tls.RecordHeaderError); ok && re.Conn != nil && tlsRecordHeaderLooksLikeHTTP(re.RecordHeader) {
		io.WriteString(re.Conn, "HTTP/1.0 400 Bad Request\r\n\r\nClient sent an HTTP request to an HTTPS server.\n")
		re.Conn.Close()
		return
	}
	c.server.logf("http: TLS handshake error from %s: %v", c.rwc.RemoteAddr(), err)
	return
}
```