### PR TITLE
Define constant for status 499

### DIFF
--- a/pkg/filters/proxies/httpproxy/pool.go
+++ b/pkg/filters/proxies/httpproxy/pool.go
@@ -42,6 +42,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+// statusClientClosedRequest is the status code for Client Closed Request.
+const statusClientClosedRequest = 499
+
 var httpMethods = map[string]struct{}{
 	http.MethodGet:     {},
 	http.MethodHead:    {},
@@ -458,8 +461,7 @@ func (sp *ServerPool) doHandle(stdctx stdcontext.Context, spCtx *serverPoolConte
 		}
 
 		// NOTE: return 499 if client is Disconnected.
-		// TODO: define a constant for 499
-		return serverPoolError{499, resultClientError}
+		return serverPoolError{statusClientClosedRequest, resultClientError}
 	}
 
 	spCtx.stdResp = resp


### PR DESCRIPTION
Defined `statusClientClosedRequest` constant in `pkg/filters/proxies/httpproxy/pool.go` and replaced the hardcoded 499 usage with it.