### PR TITLE
meshcontroller: improve service instance search performance in Master

### DIFF
--- a/pkg/object/meshcontroller/master/master.go
+++ b/pkg/object/meshcontroller/master/master.go
@@ -143,7 +143,7 @@ func (m *Master) checkServiceInstances() {
 		serviceName string
 		instanceID  string
 	}
-	statusMap := make(map[instanceKey]*spec.ServiceInstanceStatus)
+	statusMap := make(map[instanceKey]*spec.ServiceInstanceStatus, len(statuses))
 	for _, s := range statuses {
 		statusMap[instanceKey{s.ServiceName, s.InstanceID}] = s
 	}


### PR DESCRIPTION
Replaced the O(N*M) nested loop in checkServiceInstances with an O(N+M) map-based lookup. This significantly improves performance when dealing with a large number of service instances.

The map uses a composite key consisting of ServiceName and InstanceID to uniquely identify each instance status.