### PR TITLE
fix(grpcproxy): do not degrade pool on gRPC application-level errors (fixes #1517)

### DIFF
--- a/pkg/filters/proxies/grpcproxy/pool.go
+++ b/pkg/filters/proxies/grpcproxy/pool.go
@@ -373,7 +373,11 @@ func (sp *ServerPool) biTransport(ctx *serverPoolContext, proxyAsClientStream gr
 				// subsequent calls to stall waiting on pool.borrow(). Only return
 				// resultServerError for transport-level failures (non-gRPC errors)
 				// where the connection itself is broken.
-				if _, isGRPCStatus := status.FromError(s2cErr); isGRPCStatus {
+				if st, isGRPCStatus := status.FromError(s2cErr); isGRPCStatus {
+					// Preserve the backend's gRPC status so the caller receives the
+					// correct code (e.g. NOT_FOUND, INVALID_ARGUMENT). The connection
+					// itself is healthy so we still return nil to avoid pool degradation.
+					ctx.resp.SetStatus(st)
 					return nil
 				}
 				return serverPoolError{status.Convert(s2cErr), resultServerError}

--- a/pkg/filters/proxies/grpcproxy/pool.go
+++ b/pkg/filters/proxies/grpcproxy/pool.go
@@ -366,6 +366,16 @@ func (sp *ServerPool) biTransport(ctx *serverPoolContext, proxyAsClientStream gr
 			ctx.resp.SetTrailer(grpcprot.NewTrailer(proxyAsClientStream.Trailer()))
 			// c2sErr will contain RPC error from client code. If not io.EOF return the RPC error as server stream error.
 			if s2cErr != io.EOF {
+				// A well-formed gRPC status error means the backend communicated an
+				// application-level result (e.g. NOT_FOUND, INVALID_ARGUMENT) over a
+				// healthy connection. Marking the pool entry as resultServerError in
+				// that case degrades a perfectly usable backend connection and causes
+				// subsequent calls to stall waiting on pool.borrow(). Only return
+				// resultServerError for transport-level failures (non-gRPC errors)
+				// where the connection itself is broken.
+				if _, isGRPCStatus := status.FromError(s2cErr); isGRPCStatus {
+					return nil
+				}
 				return serverPoolError{status.Convert(s2cErr), resultServerError}
 			}
 			return nil

--- a/pkg/filters/proxies/grpcproxy/pool_test.go
+++ b/pkg/filters/proxies/grpcproxy/pool_test.go
@@ -253,10 +253,10 @@ type biTransportClientStream struct {
 	recvErr error
 }
 
-func (m *biTransportClientStream) Header() (metadata.MD, error) { return metadata.New(nil), nil }
-func (m *biTransportClientStream) Trailer() metadata.MD         { return metadata.New(nil) }
-func (m *biTransportClientStream) CloseSend() error             { return nil }
-func (m *biTransportClientStream) Context() context.Context     { return context.Background() }
+func (m *biTransportClientStream) Header() (metadata.MD, error)  { return metadata.New(nil), nil }
+func (m *biTransportClientStream) Trailer() metadata.MD          { return metadata.New(nil) }
+func (m *biTransportClientStream) CloseSend() error              { return nil }
+func (m *biTransportClientStream) Context() context.Context      { return context.Background() }
 func (m *biTransportClientStream) SendMsg(msg interface{}) error { return nil }
 func (m *biTransportClientStream) RecvMsg(msg interface{}) error { return m.recvErr }
 
@@ -268,11 +268,11 @@ type biTransportServerStream struct {
 	done <-chan struct{}
 }
 
-func (m *biTransportServerStream) Context() context.Context      { return context.Background() }
-func (m *biTransportServerStream) SetHeader(md metadata.MD) error { return nil }
+func (m *biTransportServerStream) Context() context.Context        { return context.Background() }
+func (m *biTransportServerStream) SetHeader(md metadata.MD) error  { return nil }
 func (m *biTransportServerStream) SendHeader(md metadata.MD) error { return nil }
-func (m *biTransportServerStream) SetTrailer(md metadata.MD)      {}
-func (m *biTransportServerStream) SendMsg(msg interface{}) error  { return nil }
+func (m *biTransportServerStream) SetTrailer(md metadata.MD)       {}
+func (m *biTransportServerStream) SendMsg(msg interface{}) error   { return nil }
 func (m *biTransportServerStream) RecvMsg(msg interface{}) error {
 	<-m.done
 	return io.EOF

--- a/pkg/filters/proxies/grpcproxy/pool_test.go
+++ b/pkg/filters/proxies/grpcproxy/pool_test.go
@@ -287,29 +287,34 @@ func TestBiTransportDoesNotDegradePoolOnGRPCAppError(t *testing.T) {
 	sp := &ServerPool{}
 
 	cases := []struct {
-		name    string
-		err     error
-		wantNil bool
+		name     string
+		err      error
+		wantNil  bool
+		wantCode codes.Code // non-OK: assert spCtx.resp carries this status; OK means skip (e.g. io.EOF)
 	}{
 		{
-			name:    "NOT_FOUND is an application error — pool must not degrade",
-			err:     status.Error(codes.NotFound, "resource not found"),
-			wantNil: true,
+			name:     "NOT_FOUND is an application error — pool must not degrade",
+			err:      status.Error(codes.NotFound, "resource not found"),
+			wantNil:  true,
+			wantCode: codes.NotFound,
 		},
 		{
-			name:    "INVALID_ARGUMENT is an application error — pool must not degrade",
-			err:     status.Error(codes.InvalidArgument, "bad request"),
-			wantNil: true,
+			name:     "INVALID_ARGUMENT is an application error — pool must not degrade",
+			err:      status.Error(codes.InvalidArgument, "bad request"),
+			wantNil:  true,
+			wantCode: codes.InvalidArgument,
 		},
 		{
-			name:    "INTERNAL is a server-side gRPC error — pool must not degrade",
-			err:     status.Error(codes.Internal, "internal error"),
-			wantNil: true,
+			name:     "INTERNAL is a server-side gRPC error — pool must not degrade",
+			err:      status.Error(codes.Internal, "internal error"),
+			wantNil:  true,
+			wantCode: codes.Internal,
 		},
 		{
 			name:    "io.EOF is the happy-path completion — pool must not degrade",
 			err:     io.EOF,
 			wantNil: true,
+			// wantCode left as codes.OK — no status assertion for the normal success path
 		},
 		{
 			name:    "plain transport error — pool should degrade",
@@ -337,6 +342,12 @@ func TestBiTransportDoesNotDegradePoolOnGRPCAppError(t *testing.T) {
 			if tc.wantNil {
 				assert.Nil(t, result,
 					"biTransport should return nil for %q so the backend pool is not degraded", tc.name)
+				// For gRPC status errors the backend response code must be preserved
+				// so the caller gets NOT_FOUND/INVALID_ARGUMENT/etc., not a silent OK.
+				if tc.wantCode != codes.OK {
+					assert.Equal(t, tc.wantCode, spCtx.resp.GetStatus().Code(),
+						"backend gRPC status must be propagated to the response for %q", tc.name)
+				}
 			} else {
 				assert.NotNil(t, result,
 					"biTransport should return an error for transport failures like %q", tc.name)

--- a/pkg/filters/proxies/grpcproxy/pool_test.go
+++ b/pkg/filters/proxies/grpcproxy/pool_test.go
@@ -19,6 +19,7 @@ package grpcproxy
 
 import (
 	"context"
+	"io"
 	"math/rand"
 	"sync"
 	"testing"
@@ -28,7 +29,9 @@ import (
 	"github.com/megaease/easegress/v2/pkg/filters/proxies"
 	"github.com/megaease/easegress/v2/pkg/util/objectpool"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
@@ -240,4 +243,107 @@ name: grpcforwardproxy
 
 	request.Header().Set("targetAddress", "192.168.1.1")
 	at.Equal("", proxy.mainPool.getTarget(proxy.mainPool.LoadBalancer().ChooseServer(request).URL))
+}
+
+// biTransportClientStream is a minimal grpc.ClientStream that returns a
+// predetermined error from RecvMsg and blocks the caller until the provided
+// done channel is closed.
+type biTransportClientStream struct {
+	grpc.ClientStream
+	recvErr error
+}
+
+func (m *biTransportClientStream) Header() (metadata.MD, error) { return metadata.New(nil), nil }
+func (m *biTransportClientStream) Trailer() metadata.MD         { return metadata.New(nil) }
+func (m *biTransportClientStream) CloseSend() error             { return nil }
+func (m *biTransportClientStream) Context() context.Context     { return context.Background() }
+func (m *biTransportClientStream) SendMsg(msg interface{}) error { return nil }
+func (m *biTransportClientStream) RecvMsg(msg interface{}) error { return m.recvErr }
+
+// biTransportServerStream is a minimal grpc.ServerStream whose RecvMsg blocks
+// until the done channel is closed, simulating a client that has not finished
+// sending. This prevents the c2sErrChan from racing with s2cErrChan in tests.
+type biTransportServerStream struct {
+	grpc.ServerStream
+	done <-chan struct{}
+}
+
+func (m *biTransportServerStream) Context() context.Context      { return context.Background() }
+func (m *biTransportServerStream) SetHeader(md metadata.MD) error { return nil }
+func (m *biTransportServerStream) SendHeader(md metadata.MD) error { return nil }
+func (m *biTransportServerStream) SetTrailer(md metadata.MD)      {}
+func (m *biTransportServerStream) SendMsg(msg interface{}) error  { return nil }
+func (m *biTransportServerStream) RecvMsg(msg interface{}) error {
+	<-m.done
+	return io.EOF
+}
+
+// TestBiTransportDoesNotDegradePoolOnGRPCAppError verifies that biTransport
+// returns nil (no pool degradation) when the backend responds with a valid
+// gRPC application-level status (e.g. NOT_FOUND, codes.Code 5). Previously,
+// any non-EOF error from the backend would call svr.close(resultServerError),
+// degrading the pool and causing subsequent calls to stall on pool.borrow().
+func TestBiTransportDoesNotDegradePoolOnGRPCAppError(t *testing.T) {
+	sp := &ServerPool{}
+
+	cases := []struct {
+		name    string
+		err     error
+		wantNil bool
+	}{
+		{
+			name:    "NOT_FOUND is an application error — pool must not degrade",
+			err:     status.Error(codes.NotFound, "resource not found"),
+			wantNil: true,
+		},
+		{
+			name:    "INVALID_ARGUMENT is an application error — pool must not degrade",
+			err:     status.Error(codes.InvalidArgument, "bad request"),
+			wantNil: true,
+		},
+		{
+			name:    "INTERNAL is a server-side gRPC error — pool must not degrade",
+			err:     status.Error(codes.Internal, "internal error"),
+			wantNil: true,
+		},
+		{
+			name:    "io.EOF is the happy-path completion — pool must not degrade",
+			err:     io.EOF,
+			wantNil: true,
+		},
+		{
+			name:    "plain transport error — pool should degrade",
+			err:     io.ErrUnexpectedEOF,
+			wantNil: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			done := make(chan struct{})
+			defer close(done)
+
+			clientStream := &biTransportClientStream{recvErr: tc.err}
+			serverStream := &biTransportServerStream{done: done}
+
+			spCtx := &serverPoolContext{
+				stdr: serverStream,
+				stdw: serverStream,
+				resp: grpcprot.NewResponse(),
+			}
+
+			result := sp.biTransport(spCtx, clientStream)
+
+			if tc.wantNil {
+				assert.Nil(t, result,
+					"biTransport should return nil for %q so the backend pool is not degraded", tc.name)
+			} else {
+				assert.NotNil(t, result,
+					"biTransport should return an error for transport failures like %q", tc.name)
+				spe, ok := result.(serverPoolError)
+				assert.True(t, ok)
+				assert.Equal(t, resultServerError, spe.result)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Problem

Fixes #1517.

`biTransportProxy()` in `pkg/filters/proxies/grpcproxy/pool.go` treats every non-`io.EOF` error from the backend stream as a transport failure and calls `svr.close(resultServerError)`, degrading the backend connection pool.

This fires incorrectly for **valid gRPC status errors** (e.g. `NOT_FOUND`, `INVALID_ARGUMENT`, `INTERNAL`) that the backend returned over a perfectly healthy connection. The result:

1. Call A → backend returns `NOT_FOUND` → pool entry marked `resultServerError` → pool exhausted
2. Call B → `pool.borrow()` with no `BorrowTimeout` → **blocks indefinitely**
3. Outer 30-second deadline fires → `context.Canceled` → caller gets a generic service error

## Root Cause

```go
// Before (buggy)
if s2cErr != io.EOF {
    return serverPoolError{status.Convert(s2cErr), resultServerError}  // fires for NOT_FOUND too
}
```

`grpc.ClientStream.RecvMsg()` returns a `*status.Status`-wrapped error for application-level responses. `status.FromError()` returns `ok=true` for these — they indicate the backend sent a valid gRPC response, not that the connection is broken.

## Fix

```go
// After
if s2cErr != io.EOF {
    // A valid gRPC status error means the backend communicated an
    // application-level result over a healthy connection.
    // Only degrade the pool for genuine transport failures.
    if _, isGRPCStatus := status.FromError(s2cErr); isGRPCStatus {
        return nil
    }
    return serverPoolError{status.Convert(s2cErr), resultServerError}
}
```

## Changes

- **`pkg/filters/proxies/grpcproxy/pool.go`** — one `status.FromError()` guard in `biTransport()`
- **`pkg/filters/proxies/grpcproxy/pool_test.go`** — `TestBiTransportDoesNotDegradePoolOnGRPCAppError` covering:
  - `NOT_FOUND` → returns `nil` (no pool degradation)
  - `INVALID_ARGUMENT` → returns `nil`
  - `INTERNAL` → returns `nil`
  - `io.EOF` → returns `nil` (existing happy path)
  - plain transport error (`io.ErrUnexpectedEOF`) → returns `serverPoolError{resultServerError}` (unchanged)

## Testing

```
=== RUN   TestBiTransportDoesNotDegradePoolOnGRPCAppError
    --- PASS: .../NOT_FOUND_is_an_application_error (0.00s)
    --- PASS: .../INVALID_ARGUMENT_is_an_application_error (0.00s)
    --- PASS: .../INTERNAL_is_a_server-side_gRPC_error (0.00s)
    --- PASS: .../io.EOF_is_the_happy-path_completion (0.00s)
    --- PASS: .../plain_transport_error (0.00s)
PASS — full grpcproxy suite: 0 regressions
```