### PR TITLE
[codex] Harden Helm admin API defaults

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ on:
       - main
     paths:
       - "**/*.go"
+      - "helm-charts/**"
       - "go.mod"
       - "go.sum"
       - ".github/workflows/test.yml"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,77 @@
+# EASEGRESS KNOWLEDGE BASE
+
+## Reply Format (Required)
+
+- Every first reply must begin with: "I have followed the instructions in AGENTS.md."
+- Immediately follow with a concise, natural-English refinement of the user's query to aid English learning.
+
+## Overview
+
+Easegress is a Go-based traffic orchestration system. Main binaries:
+
+- `cmd/server`: `easegress-server`
+- `cmd/client`: `egctl`
+- `cmd/builder`: `egbuilder`
+
+Core runtime flow:
+
+- `pkg/registry` blank-imports built-ins
+- filters register through `pkg/filters`
+- objects register through `pkg/supervisor`
+- traffic gates dispatch to pipelines, which run filter chains
+
+## Key Paths
+
+- `pkg/filters/`: built-in filters
+- `pkg/object/`: controllers, traffic gates, pipelines
+- `pkg/supervisor/`: object lifecycle and categories
+- `pkg/api/`: admin API
+- `pkg/option/`: startup flags, env vars, YAML config
+- `build/test/`: integration test harness
+- `docs/` and `example/`: user-facing docs and sample configs
+
+## Working Rules
+
+- New built-in filters, objects, and routers must both self-register and be added to `pkg/registry/registry.go`, or they will not be included in the server binary.
+- Prefer `cmd/client/commandv2/` for CLI work; `cmd/client/command/` is deprecated.
+- Use the module path `github.com/megaease/easegress/v2` consistently in source changes.
+- Keep the Apache 2.0 license header on new Go files.
+- If `--config-file` is used, other CLI flags are ignored.
+- Update docs/examples when changing user-visible config, CLI, filter kinds, object kinds, or API behavior.
+
+## Commands
+
+```bash
+make build
+make fmt
+make vet
+make test
+make integration_test
+make wasm
+```
+
+Useful variants:
+
+```bash
+make test TEST_FLAGS="-race -coverprofile=coverage.txt -covermode=atomic"
+EASEGRESS_TEST_SKIP_DOCKER=true make test
+go run ./cmd/server --help
+go run ./cmd/client --help
+go run ./cmd/builder --help
+```
+
+## CI Notes
+
+- `test.yml`: unit tests, integration tests, wasm build
+- `code.analysis.yml`: `gofmt`, `revive`, misspell
+- `golangci.lint.yml`: `golangci-lint`
+- `license.yml`: license headers
+- `release.yml`: test matrix + GoReleaser on tags
+
+## Pre-PR Checklist
+
+- `make fmt`, `make vet`, and `make test` pass
+- Run `make integration_test` for cluster, supervisor, lifecycle, or traffic changes
+- Run `make wasm` for `wasmhost` changes
+- Keep `go.mod` and `go.sum` tidy unless dependency changes are intentional
+- Update docs/examples for user-visible behavior changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,11 +10,13 @@ Welcome to the Easegress contributing guide. Are you looking for help or a way t
 
 ## Getting help
 
-If you have not already, please check the [README.md](./README.md#getting-started) and the Easegress [documentation](./doc/README.md#easegress-documentation). If you don’t find an answer to your problem, you can ask your question at [Slack](./README.md#community) or in other community channels.
+If you have not already, please check the [README.md](./README.md#getting-started) and the Easegress [documentation](./doc/README.md#easegress-documentation).
+If you do not find an answer to your problem, open a GitHub issue or use the public community channel listed in [README.md](./README.md#community).
 
 ## Feature requests
 
-Do you want to suggest an idea for the project? Use this *Feature request* [issue template](https://github.com/megaease/easegress/issues/new?template=feature_request.md) to describe your idea.
+Do you want to suggest an idea for the project?
+Use this *Feature request* [issue template](https://github.com/easegress-io/easegress/issues/new?template=feature_request.md) to describe your idea.
 
 ## Reporting general issues
 
@@ -29,14 +31,16 @@ There are many scenarios when you could open an issue, including:
 - Test improvement
 - Any questions on project
 
-Please describe clearly and explicitly your issue. Try to add as many details as you can. You can follow the instructions in the issue ticket to ensure that the issue contains enough background: https://github.com/megaease/easegress/issues/new/choose
+Please describe clearly and explicitly your issue.
+Try to add as many details as you can.
+You can follow the instructions in the issue ticket to ensure that the issue contains enough background: https://github.com/easegress-io/easegress/issues/new/choose
 
 ## Contributing
 
 All contributions to Easegress are welcome! It does not necessary need to be coding; you can also contribute without coding by
 
 - Reporting a bug
-- Helping other members of the community at Slack channel
+- Helping other members of the community in public discussion channels
 - Fixing a typo in the code
 - Fixing a typo in the documentation
 - Providing your feedback on the proposed features and designs
@@ -53,7 +57,8 @@ Contributing code, like bug fixes or new features are equally encouraged! Easegr
 - New unit test or improvement of existing test
 
 
-If you’re unsure, whether your code contribution will be beneficial, open a ticket or ask in Slack. You can check the [Developer Guide](./docs/06.Development-for-Easegress/6.1.Developer-Guide.md) to understand the high level architecture and Filter and Object extensions of Easegress.
+If you are unsure whether your code contribution will be beneficial, open a ticket or ask in the public community channel.
+You can check the [Developer Guide](./docs/06.Development-for-Easegress/6.1.Developer-Guide.md) to understand the high level architecture and Filter and Object extensions of Easegress.
 
 For any code or documentation change, please read the following Pull request guide.
 
@@ -67,7 +72,7 @@ When contributing to Easegress, it’s good idea to follow these steps:
 2. Fork the repository and clone your fork:
    1. `git clone https://github.com/<yourusername>/easegress.git`
 3. Track the upstream remote
-   1. `git remote add upstream https://github.com/megaease/easegress.git`
+   1. `git remote add upstream https://github.com/easegress-io/easegress.git`
 4. Create your branch, for example
    1. `git checkout -b fix/<micro-title>-<issue-number>`
 5. Do your changes and commit them

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ test:
 	go mod tidy
 	git diff --exit-code go.mod go.sum
 	go mod verify
-	go test -v ${TEST_GCFLAGS} ${MKFILE_DIR}pkg/... ${MKFILE_DIR}cmd/... ${TEST_FLAGS}
+	go test -v ${TEST_GCFLAGS} ${MKFILE_DIR}pkg/... ${MKFILE_DIR}cmd/... ${MKFILE_DIR}helm-charts/easegress ${TEST_FLAGS}
 
 integration_test: build
 	{ \

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 [![Docker pulls](https://img.shields.io/docker/pulls/megaease/easegress.svg)](https://hub.docker.com/r/megaease/easegress)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/easegress-io/easegress)](https://github.com/easegress-io/easegress/blob/main/go.mod)
-[![Join Easegress Slack](https://img.shields.io/badge/slack-megaease-brightgreen?logo=slack)](https://cloud-native.slack.com/messages/easegress)
+[![Join Easegress Slack](https://img.shields.io/badge/slack-easegress-brightgreen?logo=slack)](https://cloud-native.slack.com/messages/easegress)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8265/badge)](https://www.bestpractices.dev/projects/8265)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Feasegress-io%2Feasegress.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Feasegress-io%2Feasegress?ref=badge_shield)
 
-<a href="https://megaease.com/easegress">
+<a href="https://github.com/easegress-io/easegress">
     <img src="./docs/imgs/easegress.svg"
         alt="Easegress logo" title="Easegress" height="175" width="175" align="right"/>
 </a>
@@ -216,8 +216,9 @@ For full list, see [Tutorials](docs/02.Tutorials/README.md) and [Cookbook](docs/
 
 ## Community
 
-- [Join Slack Workspace](https://cloud-native.slack.com/messages/easegress) for requirement, issue and development.
-- [MegaEase on Twitter](https://twitter.com/megaease)
+- Open [GitHub issues](https://github.com/easegress-io/easegress/issues/new/choose) for bugs, feature requests, questions, and documentation problems.
+- Join the [Easegress Slack channel](https://cloud-native.slack.com/messages/easegress) for public development discussion.
+- Report security vulnerabilities privately to Yun Long <longdeqidao@gmail.com>.
 
 ### Community Tools
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,14 +1,14 @@
 # Easegress   <!-- omit from toc -->
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/megaease/easegress)](https://goreportcard.com/report/github.com/megaease/easegress)
-[![GitHub Workflow Status (branch)](https://img.shields.io/github/actions/workflow/status/megaease/easegress/test.yml?branch=main)](https://github.com/megaease/easegress/actions/workflows/test.yml)
-[![codecov](https://codecov.io/gh/megaease/easegress/branch/main/graph/badge.svg?token=5Q80B98LPI)](https://codecov.io/gh/megaease/easegress)
+[![Go Report Card](https://goreportcard.com/badge/github.com/easegress-io/easegress)](https://goreportcard.com/report/github.com/easegress-io/easegress)
+[![GitHub Workflow Status (branch)](https://img.shields.io/github/actions/workflow/status/easegress-io/easegress/test.yml?branch=main)](https://github.com/easegress-io/easegress/actions/workflows/test.yml)
+[![codecov](https://codecov.io/gh/easegress-io/easegress/branch/main/graph/badge.svg?token=5Q80B98LPI)](https://codecov.io/gh/easegress-io/easegress)
 [![Docker pulls](https://img.shields.io/docker/pulls/megaease/easegress.svg)](https://hub.docker.com/r/megaease/easegress)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/megaease/easegress)](https://github.com/megaease/easegress/blob/main/go.mod)
-[![Join Easegress Slack](https://img.shields.io/badge/slack-megaease-brightgreen?logo=slack)](https://cloud-native.slack.com/messages/easegress)
+[![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/easegress-io/easegress)](https://github.com/easegress-io/easegress/blob/main/go.mod)
+[![Join Easegress Slack](https://img.shields.io/badge/slack-easegress-brightgreen?logo=slack)](https://cloud-native.slack.com/messages/easegress)
 
-<a href="https://megaease.com/easegress">
+<a href="https://github.com/easegress-io/easegress">
     <img src="./docs/imgs/easegress.svg"
         alt="Easegress logo" title="Easegress" height="175" width="175" align="right"/>
 </a>
@@ -146,8 +146,9 @@
 
 ## 社区
 
-- [加入Slack工作区](https://cloud-native.slack.com/messages/easegress)，提出需求、讨论问题、解决问题。
-- [推特上的 MegaEase](https://twitter.com/megaease)
+- 通过 [GitHub Issues](https://github.com/easegress-io/easegress/issues/new/choose) 提交缺陷、功能需求、问题和文档反馈。
+- 加入 [Easegress Slack 频道](https://cloud-native.slack.com/messages/easegress)，参与公开开发讨论。
+- 安全漏洞请私下发送给维护者 Yun Long <longdeqidao@gmail.com>。
 
 ## 许可证
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,4 +13,6 @@ Supported [Go versions](https://go.dev/dl/):
 
 # Reporting a Vulnerability
 
-If you would like to report a vulnerability in the Easegress or to let us know of a publicly disclosed security vulnerability (e.g. <https://nvd.nist.gov/vuln/detail/CVE-2019-6486> ), please email us <security@megaease.com>.
+Easegress currently accepts private vulnerability reports through the project maintainers.
+Please email Yun Long <longdeqidao@gmail.com> with a clear subject such as `Easegress security report`.
+Do not disclose technical details publicly until a maintainer coordinates the disclosure process with you.

--- a/docs/03.Advanced-Cookbook/3.02.Flash-Sale.md
+++ b/docs/03.Advanced-Cookbook/3.02.Flash-Sale.md
@@ -485,7 +485,9 @@ $ egctl wasm list-data flash-sale-pipeline wasm
 {}
 ```
 
-Well, the above is all technical details. You can freely use the code to customize your business logic. However, it should be aware that **the above is just a demo, and the practical solution is more complicated because it also needs to filter the crawlers and hackers**. If you need a more professional solution, welcome to contact us.
+The above example is only a demo.
+A production flash-sale solution also needs crawler and abuse protection, capacity planning, and business-specific controls.
+Open a [GitHub issue](https://github.com/easegress-io/easegress/issues/new/choose) if you want to discuss Easegress capabilities for this use case.
 
 ## 7. Summary
 

--- a/docs/03.Advanced-Cookbook/3.12.Migrate.md
+++ b/docs/03.Advanced-Cookbook/3.12.Migrate.md
@@ -170,5 +170,7 @@ protocol specific request/response, like
 
 The above is all the general steps to migrate a filter from v1.x to v2.x,
 and you may need more works that are specific to your implementation to
-complete the migration. We think most of the works would be trivial, but
-please feel free to contact us if you need help.
+complete the migration.
+Most of the work should be straightforward, but please open a
+[GitHub issue](https://github.com/easegress-io/easegress/issues/new/choose)
+if you need help.

--- a/helm-charts/easegress/README.md
+++ b/helm-charts/easegress/README.md
@@ -39,12 +39,31 @@ helm install easegress -n easegress ./helm-charts/easegress \
   --set 'cluster.nodeHostnames={hostname-xyz}'
 ```
 
+The Admin API listens on `127.0.0.1:2381` inside the pod and is not exposed by a service by default.
+Use `kubectl port-forward` for local administration:
+
+```shell
+kubectl port-forward -n easegress pod/easegress-0 2381:2381
+```
+
 Add filters and objects to Easegress:
 
 ```shell
-egctl --server {NODE_IP}:31255 create object -f pipeline.yaml
+egctl --server 127.0.0.1:2381 create object -f pipeline.yaml
 ```
-where NODE_IP is the IP address a node running Easegress pod and `pipeline.yaml` Easegress object definition.
+where `pipeline.yaml` is an Easegress object definition.
+
+To expose the Admin API through a NodePort, enable the admin service explicitly and configure authentication:
+
+```shell
+helm install easegress -n easegress ./helm-charts/easegress \
+  --set admin.apiAddr=0.0.0.0:2381 \
+  --set service.admin.enabled=true \
+  --set service.admin.type=NodePort \
+  --set admin.basicAuth.admin=change-me
+```
+
+Set `admin.allowUnsafeNoAuth=true` only when an external control already protects the Admin API.
 
 ## Uninstall
 
@@ -63,7 +82,15 @@ The following table lists the configurable parameters of the Easegress Helm inst
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | service.nodePort | int | `30780` | nodePort for easegress service. |
-| service.adminPort | int | `31255` | nodePort for egctl access. |
+| service.adminPort | int | `31255` | Deprecated fallback for `service.admin.nodePort`. |
+| service.admin.enabled | bool | `false` | create a service for the Admin API. |
+| service.admin.type | string | `ClusterIP` | service type for the Admin API. |
+| service.admin.nodePort | int | `31255` | nodePort for egctl access when `service.admin.type` is `NodePort`. |
+| admin.apiAddr | string | `127.0.0.1:2381` | address the Admin API listens on. |
+| admin.basicAuth | map | `{}` | username to password map for Admin API basic authentication. |
+| admin.allowUnsafeNoAuth | bool | `false` | allow external Admin API services without chart-configured authentication. |
+| serviceAccount.automountServiceAccountToken | bool | `false` | mount the Kubernetes service account token into Easegress pods. |
+| rbac.readSecrets | bool | `false` | grant read/list/watch permissions on Kubernetes Secrets. |
 | cluster.primaryReplicas | int | `1` | number of easegress service that persists cluster data to disk |
 | cluster.volumeType | string | `emptyDir` | `emptyDir`: use pods internal filesystem that is not persisted when pod crashes. Use `emptyDir` only when primaryReplicas is 1. | `persistentVolume`, create as many persistenVolumes and persistentVolumeClaims as there are nodeHostnames.
 | cluster.volumeLocalPath | string | `/opt/easegress` | local path of persistenVolume on nodes |

--- a/helm-charts/easegress/chart_security_test.go
+++ b/helm-charts/easegress/chart_security_test.go
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2026 The Easegress Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package easegress
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func readChartValues(t *testing.T) map[string]interface{} {
+	t.Helper()
+
+	data, err := os.ReadFile("values.yaml")
+	if err != nil {
+		t.Fatalf("read values.yaml: %v", err)
+	}
+
+	values := map[string]interface{}{}
+	if err := yaml.Unmarshal(data, &values); err != nil {
+		t.Fatalf("parse values.yaml: %v", err)
+	}
+	return values
+}
+
+func chartString(t *testing.T, values map[string]interface{}, keys ...string) string {
+	t.Helper()
+
+	value := chartValue(t, values, keys...)
+	got, ok := value.(string)
+	if !ok {
+		t.Fatalf("%s must be a string, got %T", strings.Join(keys, "."), value)
+	}
+	return got
+}
+
+func chartBool(t *testing.T, values map[string]interface{}, keys ...string) bool {
+	t.Helper()
+
+	value := chartValue(t, values, keys...)
+	got, ok := value.(bool)
+	if !ok {
+		t.Fatalf("%s must be a bool, got %T", strings.Join(keys, "."), value)
+	}
+	return got
+}
+
+func chartValue(t *testing.T, values map[string]interface{}, keys ...string) interface{} {
+	t.Helper()
+
+	var value interface{} = values
+	for _, key := range keys {
+		current, ok := value.(map[string]interface{})
+		if !ok {
+			t.Fatalf("%s parent must be a map, got %T", strings.Join(keys, "."), value)
+		}
+		value, ok = current[key]
+		if !ok {
+			t.Fatalf("missing chart value %s", strings.Join(keys, "."))
+		}
+	}
+	return value
+}
+
+func readChartFile(t *testing.T, path string) string {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}
+
+func TestDefaultChartDoesNotExposeAdminNodePort(t *testing.T) {
+	values := readChartValues(t)
+
+	if got := chartString(t, values, "admin", "apiAddr"); got != "127.0.0.1:2381" {
+		t.Fatalf("default admin.apiAddr = %q, want local-only 127.0.0.1:2381", got)
+	}
+	if chartBool(t, values, "service", "admin", "enabled") {
+		t.Fatal("default service.admin.enabled must be false")
+	}
+	if got := chartString(t, values, "service", "admin", "type"); got == "NodePort" || got == "LoadBalancer" {
+		t.Fatalf("default service.admin.type = %q, want non-external service type", got)
+	}
+
+	serviceTemplate := readChartFile(t, "templates/Service.yaml")
+	for _, required := range []string{
+		"{{- if .Values.service.admin.enabled }}",
+		"admin service type NodePort/LoadBalancer requires admin.basicAuth or admin.allowUnsafeNoAuth=true",
+		"nodePort: {{ default .Values.service.adminPort .Values.service.admin.nodePort }}",
+	} {
+		if !strings.Contains(serviceTemplate, required) {
+			t.Fatalf("templates/Service.yaml missing admin-service guard %q", required)
+		}
+	}
+	if strings.Contains(serviceTemplate, "nodePort: {{ .Values.service.adminPort }}") {
+		t.Fatal("templates/Service.yaml must not unconditionally render the admin NodePort")
+	}
+}
+
+func TestDefaultChartDoesNotExposeKubernetesSecrets(t *testing.T) {
+	values := readChartValues(t)
+
+	if chartBool(t, values, "rbac", "readSecrets") {
+		t.Fatal("default rbac.readSecrets must be false")
+	}
+	if chartBool(t, values, "serviceAccount", "automountServiceAccountToken") {
+		t.Fatal("default serviceAccount.automountServiceAccountToken must be false")
+	}
+
+	clusterRole := readChartFile(t, "templates/ClusterRole.yaml")
+	if strings.Contains(clusterRole, `resources: ["services", "endpoints", "secrets"]`) {
+		t.Fatal("ClusterRole must not always grant secrets access")
+	}
+	if !strings.Contains(clusterRole, "{{- if .Values.rbac.readSecrets }}") {
+		t.Fatal("ClusterRole must gate secrets access on rbac.readSecrets")
+	}
+
+	for _, path := range []string{
+		"templates/StatefulSet.yaml",
+		"templates/Deployment.yaml",
+	} {
+		workload := readChartFile(t, path)
+		if !strings.Contains(workload, "automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}") {
+			t.Fatalf("%s must render serviceAccount.automountServiceAccountToken", path)
+		}
+	}
+}

--- a/helm-charts/easegress/templates/ClusterRole.yaml
+++ b/helm-charts/easegress/templates/ClusterRole.yaml
@@ -4,8 +4,13 @@ metadata:
   name: {{ .Release.Name }}
 rules:
   - apiGroups: [""] # "" indicates the core API group
-    resources: ["services", "endpoints", "secrets"]
+    resources: ["services", "endpoints"]
     verbs: ["get", "watch", "list"]
+  {{- if .Values.rbac.readSecrets }}
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "watch", "list"]
+  {{- end }}
   - apiGroups: ["networking.k8s.io"]
     resources: ["ingresses"]
     verbs: ["get", "watch", "list"]

--- a/helm-charts/easegress/templates/ConfigMap.yaml
+++ b/helm-charts/easegress/templates/ConfigMap.yaml
@@ -14,13 +14,19 @@ data:
       {{- range $i, $e := until (.Values.cluster.primaryReplicas | int) }}
       - {{ $releasename }}-{{$i}}: http://{{ $releasename }}-{{$i}}.easegress-hs.{{ $releasenamespace }}:2380
       {{- end }}
-    api-addr: 0.0.0.0:2381
+    api-addr: {{ .Values.admin.apiAddr }}
     data-dir: /opt/easegress/data
     wal-dir: ""
     cpu-profile-file: ""
     memory-profile-file: ""
     log-dir: {{ .Values.log.path }}
     debug: false
+    {{- with .Values.admin.basicAuth }}
+    basic-auth:
+    {{- range $username, $password := . }}
+      {{ $username | quote }}: {{ $password | quote }}
+    {{- end }}
+    {{- end }}
   eg-secondary.yaml: |
     cluster-name: easegress
     cluster-role: secondary
@@ -34,13 +40,19 @@ data:
       {{ else }}
       - http://{{ .Release.Name }}-0.easegress-hs.{{ .Release.Namespace }}:2380
       {{ end }}
-    api-addr: 0.0.0.0:2381
+    api-addr: {{ .Values.admin.apiAddr }}
     data-dir: /opt/easegress/data
     wal-dir: ""
     cpu-profile-file: ""
     memory-profile-file: ""
     log-dir: {{ .Values.log.path }}
     debug: false
+    {{- with .Values.admin.basicAuth }}
+    basic-auth:
+    {{- range $username, $password := . }}
+      {{ $username | quote }}: {{ $password | quote }}
+    {{- end }}
+    {{- end }}
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}

--- a/helm-charts/easegress/templates/Deployment.yaml
+++ b/helm-charts/easegress/templates/Deployment.yaml
@@ -17,6 +17,7 @@ spec:
         app: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ .Release.Name }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       containers:
       - args:
         - -c

--- a/helm-charts/easegress/templates/Service.yaml
+++ b/helm-charts/easegress/templates/Service.yaml
@@ -27,6 +27,13 @@ spec:
 
 {{- end }}
 
+{{- $adminType := default "ClusterIP" .Values.service.admin.type -}}
+{{- $adminExternallyExposed := or (eq $adminType "NodePort") (eq $adminType "LoadBalancer") -}}
+{{- if and .Values.service.admin.enabled $adminExternallyExposed (empty .Values.admin.basicAuth) (not .Values.admin.allowUnsafeNoAuth) -}}
+{{- fail "admin service type NodePort/LoadBalancer requires admin.basicAuth or admin.allowUnsafeNoAuth=true" -}}
+{{- end }}
+
+{{- if .Values.service.admin.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -38,12 +45,16 @@ spec:
     port: 2381
     protocol: TCP
     targetPort: 2381
-    nodePort: {{ .Values.service.adminPort }}
+    {{- if $adminExternallyExposed }}
+    nodePort: {{ default .Values.service.adminPort .Values.service.admin.nodePort }}
+    {{- end }}
   selector:
     app: {{ .Release.Name }}
-  type: NodePort
+  type: {{ $adminType }}
 
 ---
+{{- end }}
+
 kind: Service
 apiVersion: v1
 metadata:

--- a/helm-charts/easegress/templates/StatefulSet.yaml
+++ b/helm-charts/easegress/templates/StatefulSet.yaml
@@ -23,6 +23,7 @@ spec:
         app: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ .Release.Name }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       containers:
       - args:
         - -c

--- a/helm-charts/easegress/values.yaml
+++ b/helm-charts/easegress/values.yaml
@@ -1,8 +1,29 @@
 service:
   # nodePort for easegress service
   nodePort: 30780
-  # nodeport for egctl access
+  # Deprecated. Use service.admin.nodePort.
   adminPort: 31255
+  admin:
+    # disabled by default because the admin API controls the Easegress instance
+    enabled: false
+    type: ClusterIP
+    # nodePort for egctl access when service.admin.type is NodePort
+    nodePort: 31255
+
+admin:
+  # listen on localhost by default; set to 0.0.0.0:2381 only when exposing the admin API intentionally
+  apiAddr: 127.0.0.1:2381
+  # map of username to password for admin API basic authentication
+  basicAuth: {}
+  # set true only if an external admin service is protected outside this chart
+  allowUnsafeNoAuth: false
+
+serviceAccount:
+  automountServiceAccountToken: false
+
+rbac:
+  # enable only for features that must read Kubernetes TLS secrets, such as IngressController
+  readSecrets: false
 
 # image for easegress deployment
 image:


### PR DESCRIPTION
## Summary

- make the Easegress Helm chart keep the Admin API local-only by default
- disable the Admin API service by default and require BasicAuth or an explicit unsafe override for external admin services
- remove default Kubernetes Secret RBAC and disable service account token automount by default
- add chart regression tests and include them in the normal test target

## Root Cause

The chart default exposed the unauthenticated Admin API through a NodePort, bound it to `0.0.0.0:2381`, mounted the pod service account token, and granted the chart service account Secret read permissions. That combination allowed reachable Admin API callers to create objects that could disclose Kubernetes credentials and read Secrets.

## Validation

- `git diff --cached --check`
- `make test TEST_FLAGS="-run TestDefaultChart -count=1"`
- `go run helm.sh/helm/v3/cmd/helm@v3.15.4 template eg ./helm-charts/easegress --namespace eg-audit`
- unauthenticated external Admin NodePort render rejects with the expected chart error
- default render does not include `easegress-public` or default `resources: ["secrets"]`
